### PR TITLE
Run uncrustify on the code

### DIFF
--- a/Frameworks/GCDWebServers.h
+++ b/Frameworks/GCDWebServers.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 // GCDWebServer Core

--- a/Frameworks/Tests.m
+++ b/Frameworks/Tests.m
@@ -9,35 +9,38 @@
 @implementation Tests
 
 - (void)testWebServer {
-  GCDWebServer* server = [[GCDWebServer alloc] init];
-  XCTAssertNotNil(server);
+    GCDWebServer *server = [[GCDWebServer alloc] init];
+
+    XCTAssertNotNil(server);
 }
 
 - (void)testDAVServer {
-  GCDWebDAVServer* server = [[GCDWebDAVServer alloc] init];
-  XCTAssertNotNil(server);
+    GCDWebDAVServer *server = [[GCDWebDAVServer alloc] init];
+
+    XCTAssertNotNil(server);
 }
 
 - (void)testWebUploader {
-  GCDWebUploader* server = [[GCDWebUploader alloc] init];
-  XCTAssertNotNil(server);
+    GCDWebUploader *server = [[GCDWebUploader alloc] init];
+
+    XCTAssertNotNil(server);
 }
 
 - (void)testPaths {
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@""), @"");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"/foo/"), @"/foo");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/bar"), @"foo/bar");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo//bar"), @"foo/bar");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/bar//"), @"foo/bar");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/./bar"), @"foo/bar");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/bar/."), @"foo/bar");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/../bar"), @"bar");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"/foo/../bar"), @"/bar");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"/foo/.."), @"/");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"/.."), @"/");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"."), @"");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@".."), @"");
-  XCTAssertEqualObjects(GCDWebServerNormalizePath(@"../.."), @"");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@""), @"");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"/foo/"), @"/foo");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/bar"), @"foo/bar");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo//bar"), @"foo/bar");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/bar//"), @"foo/bar");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/./bar"), @"foo/bar");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/bar/."), @"foo/bar");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"foo/../bar"), @"bar");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"/foo/../bar"), @"/bar");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"/foo/.."), @"/");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"/.."), @"/");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"."), @"");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@".."), @"");
+    XCTAssertEqualObjects(GCDWebServerNormalizePath(@"../.."), @"");
 }
 
 @end

--- a/GCDWebDAVServer/GCDWebDAVServer.h
+++ b/GCDWebDAVServer/GCDWebDAVServer.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServer.h"
@@ -42,32 +42,32 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  This method is called whenever a file has been downloaded.
  */
-- (void)davServer:(GCDWebDAVServer*)server didDownloadFileAtPath:(NSString*)path;
+- (void)davServer:(GCDWebDAVServer *)server didDownloadFileAtPath:(NSString *)path;
 
 /**
  *  This method is called whenever a file has been uploaded.
  */
-- (void)davServer:(GCDWebDAVServer*)server didUploadFileAtPath:(NSString*)path;
+- (void)davServer:(GCDWebDAVServer *)server didUploadFileAtPath:(NSString *)path;
 
 /**
  *  This method is called whenever a file or directory has been moved.
  */
-- (void)davServer:(GCDWebDAVServer*)server didMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+- (void)davServer:(GCDWebDAVServer *)server didMoveItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath;
 
 /**
  *  This method is called whenever a file or directory has been copied.
  */
-- (void)davServer:(GCDWebDAVServer*)server didCopyItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+- (void)davServer:(GCDWebDAVServer *)server didCopyItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath;
 
 /**
  *  This method is called whenever a file or directory has been deleted.
  */
-- (void)davServer:(GCDWebDAVServer*)server didDeleteItemAtPath:(NSString*)path;
+- (void)davServer:(GCDWebDAVServer *)server didDeleteItemAtPath:(NSString *)path;
 
 /**
  *  This method is called whenever a directory has been created.
  */
-- (void)davServer:(GCDWebDAVServer*)server didCreateDirectoryAtPath:(NSString*)path;
+- (void)davServer:(GCDWebDAVServer *)server didCreateDirectoryAtPath:(NSString *)path;
 
 @end
 
@@ -83,19 +83,19 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns the upload directory as specified when the server was initialized.
  */
-@property(nonatomic, readonly) NSString* uploadDirectory;
+@property (nonatomic, readonly) NSString *uploadDirectory;
 
 /**
  *  Sets the delegate for the server.
  */
-@property(nonatomic, weak, nullable) id<GCDWebDAVServerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<GCDWebDAVServerDelegate> delegate;
 
 /**
  *  Sets which files are allowed to be operated on depending on their extension.
  *
  *  The default value is nil i.e. all file extensions are allowed.
  */
-@property(nonatomic, copy) NSArray<NSString*>* allowedFileExtensions;
+@property (nonatomic, copy) NSArray<NSString *> *allowedFileExtensions;
 
 /**
  *  Sets if files and directories whose name start with a period are allowed to
@@ -103,12 +103,12 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The default value is NO.
  */
-@property(nonatomic) BOOL allowHiddenItems;
+@property (nonatomic) BOOL allowHiddenItems;
 
 /**
  *  This method is the designated initializer for the class.
  */
-- (instancetype)initWithUploadDirectory:(NSString*)path;
+- (instancetype)initWithUploadDirectory:(NSString *)path;
 
 @end
 
@@ -125,35 +125,35 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The default implementation returns YES.
  */
-- (BOOL)shouldUploadFileAtPath:(NSString*)path withTemporaryFile:(NSString*)tempPath;
+- (BOOL)shouldUploadFileAtPath:(NSString *)path withTemporaryFile:(NSString *)tempPath;
 
 /**
  *  This method is called to check if a file or directory is allowed to be moved.
  *
  *  The default implementation returns YES.
  */
-- (BOOL)shouldMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+- (BOOL)shouldMoveItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath;
 
 /**
  *  This method is called to check if a file or directory is allowed to be copied.
  *
  *  The default implementation returns YES.
  */
-- (BOOL)shouldCopyItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+- (BOOL)shouldCopyItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath;
 
 /**
  *  This method is called to check if a file or directory is allowed to be deleted.
  *
  *  The default implementation returns YES.
  */
-- (BOOL)shouldDeleteItemAtPath:(NSString*)path;
+- (BOOL)shouldDeleteItemAtPath:(NSString *)path;
 
 /**
  *  This method is called to check if a directory is allowed to be created.
  *
  *  The default implementation returns YES.
  */
-- (BOOL)shouldCreateDirectoryAtPath:(NSString*)path;
+- (BOOL)shouldCreateDirectoryAtPath:(NSString *)path;
 
 @end
 

--- a/GCDWebDAVServer/GCDWebDAVServer.m
+++ b/GCDWebDAVServer/GCDWebDAVServer.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -48,25 +48,25 @@
 #define kXMLParseOptions (XML_PARSE_NONET | XML_PARSE_RECOVER | XML_PARSE_NOBLANKS | XML_PARSE_COMPACT | XML_PARSE_NOWARNING | XML_PARSE_NOERROR)
 
 typedef NS_ENUM(NSInteger, DAVProperties) {
-  kDAVProperty_ResourceType = (1 << 0),
-  kDAVProperty_CreationDate = (1 << 1),
-  kDAVProperty_LastModified = (1 << 2),
-  kDAVProperty_ContentLength = (1 << 3),
-  kDAVAllProperties = kDAVProperty_ResourceType | kDAVProperty_CreationDate | kDAVProperty_LastModified | kDAVProperty_ContentLength
+    kDAVProperty_ResourceType  = (1 << 0),
+    kDAVProperty_CreationDate  = (1 << 1),
+    kDAVProperty_LastModified  = (1 << 2),
+    kDAVProperty_ContentLength = (1 << 3),
+    kDAVAllProperties          = kDAVProperty_ResourceType | kDAVProperty_CreationDate | kDAVProperty_LastModified | kDAVProperty_ContentLength
 };
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface GCDWebDAVServer (Methods)
-- (nullable GCDWebServerResponse*)performOPTIONS:(GCDWebServerRequest*)request;
-- (nullable GCDWebServerResponse*)performGET:(GCDWebServerRequest*)request;
-- (nullable GCDWebServerResponse*)performPUT:(GCDWebServerFileRequest*)request;
-- (nullable GCDWebServerResponse*)performDELETE:(GCDWebServerRequest*)request;
-- (nullable GCDWebServerResponse*)performMKCOL:(GCDWebServerDataRequest*)request;
-- (nullable GCDWebServerResponse*)performCOPY:(GCDWebServerRequest*)request isMove:(BOOL)isMove;
-- (nullable GCDWebServerResponse*)performPROPFIND:(GCDWebServerDataRequest*)request;
-- (nullable GCDWebServerResponse*)performLOCK:(GCDWebServerDataRequest*)request;
-- (nullable GCDWebServerResponse*)performUNLOCK:(GCDWebServerRequest*)request;
+- (nullable GCDWebServerResponse *)performOPTIONS:(GCDWebServerRequest *)request;
+- (nullable GCDWebServerResponse *)performGET:(GCDWebServerRequest *)request;
+- (nullable GCDWebServerResponse *)performPUT:(GCDWebServerFileRequest *)request;
+- (nullable GCDWebServerResponse *)performDELETE:(GCDWebServerRequest *)request;
+- (nullable GCDWebServerResponse *)performMKCOL:(GCDWebServerDataRequest *)request;
+- (nullable GCDWebServerResponse *)performCOPY:(GCDWebServerRequest *)request isMove:(BOOL)isMove;
+- (nullable GCDWebServerResponse *)performPROPFIND:(GCDWebServerDataRequest *)request;
+- (nullable GCDWebServerResponse *)performLOCK:(GCDWebServerDataRequest *)request;
+- (nullable GCDWebServerResponse *)performUNLOCK:(GCDWebServerRequest *)request;
 @end
 
 NS_ASSUME_NONNULL_END
@@ -75,643 +75,720 @@ NS_ASSUME_NONNULL_END
 
 @dynamic delegate;
 
-- (instancetype)initWithUploadDirectory:(NSString*)path {
-  if ((self = [super init])) {
-    _uploadDirectory = [path copy];
-    GCDWebDAVServer* __unsafe_unretained server = self;
+- (instancetype)initWithUploadDirectory:(NSString *)path {
+    if ((self = [super init])) {
+        _uploadDirectory = [path copy];
+        GCDWebDAVServer * __unsafe_unretained server = self;
 
-    // 9.1 PROPFIND method
-    [self addDefaultHandlerForMethod:@"PROPFIND"
-                        requestClass:[GCDWebServerDataRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performPROPFIND:(GCDWebServerDataRequest*)request];
-                        }];
+        // 9.1 PROPFIND method
+        [self addDefaultHandlerForMethod:@"PROPFIND"
+                            requestClass:[GCDWebServerDataRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performPROPFIND:(GCDWebServerDataRequest *)request];
+                            }];
 
-    // 9.3 MKCOL Method
-    [self addDefaultHandlerForMethod:@"MKCOL"
-                        requestClass:[GCDWebServerDataRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performMKCOL:(GCDWebServerDataRequest*)request];
-                        }];
+        // 9.3 MKCOL Method
+        [self addDefaultHandlerForMethod:@"MKCOL"
+                            requestClass:[GCDWebServerDataRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performMKCOL:(GCDWebServerDataRequest *)request];
+                            }];
 
-    // 9.4 GET & HEAD methods
-    [self addDefaultHandlerForMethod:@"GET"
-                        requestClass:[GCDWebServerRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performGET:request];
-                        }];
+        // 9.4 GET & HEAD methods
+        [self addDefaultHandlerForMethod:@"GET"
+                            requestClass:[GCDWebServerRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performGET:request];
+                            }];
 
-    // 9.6 DELETE method
-    [self addDefaultHandlerForMethod:@"DELETE"
-                        requestClass:[GCDWebServerRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performDELETE:request];
-                        }];
+        // 9.6 DELETE method
+        [self addDefaultHandlerForMethod:@"DELETE"
+                            requestClass:[GCDWebServerRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performDELETE:request];
+                            }];
 
-    // 9.7 PUT method
-    [self addDefaultHandlerForMethod:@"PUT"
-                        requestClass:[GCDWebServerFileRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performPUT:(GCDWebServerFileRequest*)request];
-                        }];
+        // 9.7 PUT method
+        [self addDefaultHandlerForMethod:@"PUT"
+                            requestClass:[GCDWebServerFileRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performPUT:(GCDWebServerFileRequest *)request];
+                            }];
 
-    // 9.8 COPY method
-    [self addDefaultHandlerForMethod:@"COPY"
-                        requestClass:[GCDWebServerRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performCOPY:request isMove:NO];
-                        }];
+        // 9.8 COPY method
+        [self addDefaultHandlerForMethod:@"COPY"
+                            requestClass:[GCDWebServerRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performCOPY:request isMove:NO];
+                            }];
 
-    // 9.9 MOVE method
-    [self addDefaultHandlerForMethod:@"MOVE"
-                        requestClass:[GCDWebServerRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performCOPY:request isMove:YES];
-                        }];
+        // 9.9 MOVE method
+        [self addDefaultHandlerForMethod:@"MOVE"
+                            requestClass:[GCDWebServerRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performCOPY:request isMove:YES];
+                            }];
 
-    // 9.10 LOCK method
-    [self addDefaultHandlerForMethod:@"LOCK"
-                        requestClass:[GCDWebServerDataRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performLOCK:(GCDWebServerDataRequest*)request];
-                        }];
+        // 9.10 LOCK method
+        [self addDefaultHandlerForMethod:@"LOCK"
+                            requestClass:[GCDWebServerDataRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performLOCK:(GCDWebServerDataRequest *)request];
+                            }];
 
-    // 9.11 UNLOCK method
-    [self addDefaultHandlerForMethod:@"UNLOCK"
-                        requestClass:[GCDWebServerRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performUNLOCK:request];
-                        }];
+        // 9.11 UNLOCK method
+        [self addDefaultHandlerForMethod:@"UNLOCK"
+                            requestClass:[GCDWebServerRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performUNLOCK:request];
+                            }];
 
-    // 10.1 OPTIONS method / DAV Header
-    [self addDefaultHandlerForMethod:@"OPTIONS"
-                        requestClass:[GCDWebServerRequest class]
-                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                          return [server performOPTIONS:request];
-                        }];
-  }
-  return self;
+        // 10.1 OPTIONS method / DAV Header
+        [self addDefaultHandlerForMethod:@"OPTIONS"
+                            requestClass:[GCDWebServerRequest class]
+                            processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                return [server performOPTIONS:request];
+                            }];
+    }
+
+    return self;
 }
 
 @end
 
 @implementation GCDWebDAVServer (Methods)
 
-- (BOOL)_checkFileExtension:(NSString*)fileName {
-  if (_allowedFileExtensions && ![_allowedFileExtensions containsObject:[[fileName pathExtension] lowercaseString]]) {
-    return NO;
-  }
-  return YES;
-}
-
-static inline BOOL _IsMacFinder(GCDWebServerRequest* request) {
-  NSString* userAgentHeader = [request.headers objectForKey:@"User-Agent"];
-  return ([userAgentHeader hasPrefix:@"WebDAVFS/"] || [userAgentHeader hasPrefix:@"WebDAVLib/"]);  // OS X WebDAV client
-}
-
-- (GCDWebServerResponse*)performOPTIONS:(GCDWebServerRequest*)request {
-  GCDWebServerResponse* response = [GCDWebServerResponse response];
-  if (_IsMacFinder(request)) {
-    [response setValue:@"1, 2" forAdditionalHeader:@"DAV"];  // Classes 1 and 2
-  } else {
-    [response setValue:@"1" forAdditionalHeader:@"DAV"];  // Class 1
-  }
-  return response;
-}
-
-- (GCDWebServerResponse*)performGET:(GCDWebServerRequest*)request {
-  NSString* relativePath = request.path;
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory = NO;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
-  }
-
-  NSString* itemName = [absolutePath lastPathComponent];
-  if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Downlading item name \"%@\" is not allowed", itemName];
-  }
-
-  // Because HEAD requests are mapped to GET ones, we need to handle directories but it's OK to return nothing per http://webdav.org/specs/rfc4918.html#rfc.section.9.4
-  if (isDirectory) {
-    return [GCDWebServerResponse response];
-  }
-
-  if ([self.delegate respondsToSelector:@selector(davServer:didDownloadFileAtPath:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.delegate davServer:self didDownloadFileAtPath:absolutePath];
-    });
-  }
-
-  if ([request hasByteRange]) {
-    return [GCDWebServerFileResponse responseWithFile:absolutePath byteRange:request.byteRange];
-  }
-
-  return [GCDWebServerFileResponse responseWithFile:absolutePath];
-}
-
-- (GCDWebServerResponse*)performPUT:(GCDWebServerFileRequest*)request {
-  if ([request hasByteRange]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Range uploads not supported"];
-  }
-
-  NSString* relativePath = request.path;
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:[absolutePath stringByDeletingLastPathComponent] isDirectory:&isDirectory] || !isDirectory) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Conflict message:@"Missing intermediate collection(s) for \"%@\"", relativePath];
-  }
-
-  BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory];
-  if (existing && isDirectory) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MethodNotAllowed message:@"PUT not allowed on existing collection \"%@\"", relativePath];
-  }
-
-  NSString* fileName = [absolutePath lastPathComponent];
-  if (([fileName hasPrefix:@"."] && !_allowHiddenItems) || ![self _checkFileExtension:fileName]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file name \"%@\" is not allowed", fileName];
-  }
-
-  if (![self shouldUploadFileAtPath:absolutePath withTemporaryFile:request.temporaryPath]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file to \"%@\" is not permitted", relativePath];
-  }
-
-  [[NSFileManager defaultManager] removeItemAtPath:absolutePath error:NULL];
-  NSError* error = nil;
-  if (![[NSFileManager defaultManager] moveItemAtPath:request.temporaryPath toPath:absolutePath error:&error]) {
-    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
-  }
-
-  if ([self.delegate respondsToSelector:@selector(davServer:didUploadFileAtPath:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.delegate davServer:self didUploadFileAtPath:absolutePath];
-    });
-  }
-  return [GCDWebServerResponse responseWithStatusCode:(existing ? kGCDWebServerHTTPStatusCode_NoContent : kGCDWebServerHTTPStatusCode_Created)];
-}
-
-- (GCDWebServerResponse*)performDELETE:(GCDWebServerRequest*)request {
-  NSString* depthHeader = [request.headers objectForKey:@"Depth"];
-  if (depthHeader && ![depthHeader isEqualToString:@"infinity"]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
-  }
-
-  NSString* relativePath = request.path;
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory = NO;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
-  }
-
-  NSString* itemName = [absolutePath lastPathComponent];
-  if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting item name \"%@\" is not allowed", itemName];
-  }
-
-  if (![self shouldDeleteItemAtPath:absolutePath]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not permitted", relativePath];
-  }
-
-  NSError* error = nil;
-  if (![[NSFileManager defaultManager] removeItemAtPath:absolutePath error:&error]) {
-    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed deleting \"%@\"", relativePath];
-  }
-
-  if ([self.delegate respondsToSelector:@selector(davServer:didDeleteItemAtPath:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.delegate davServer:self didDeleteItemAtPath:absolutePath];
-    });
-  }
-  return [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NoContent];
-}
-
-- (GCDWebServerResponse*)performMKCOL:(GCDWebServerDataRequest*)request {
-  if ([request hasBody] && (request.contentLength > 0)) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_UnsupportedMediaType message:@"Unexpected request body for MKCOL method"];
-  }
-
-  NSString* relativePath = request.path;
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:[absolutePath stringByDeletingLastPathComponent] isDirectory:&isDirectory] || !isDirectory) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Conflict message:@"Missing intermediate collection(s) for \"%@\"", relativePath];
-  }
-
-  NSString* directoryName = [absolutePath lastPathComponent];
-  if (!_allowHiddenItems && [directoryName hasPrefix:@"."]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory name \"%@\" is not allowed", directoryName];
-  }
-
-  if (![self shouldCreateDirectoryAtPath:absolutePath]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory \"%@\" is not permitted", relativePath];
-  }
-
-  NSError* error = nil;
-  if (![[NSFileManager defaultManager] createDirectoryAtPath:absolutePath withIntermediateDirectories:NO attributes:nil error:&error]) {
-    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed creating directory \"%@\"", relativePath];
-  }
-#ifdef __GCDWEBSERVER_ENABLE_TESTING__
-  NSString* creationDateHeader = [request.headers objectForKey:@"X-GCDWebServer-CreationDate"];
-  if (creationDateHeader) {
-    NSDate* date = GCDWebServerParseISO8601(creationDateHeader);
-    if (!date || ![[NSFileManager defaultManager] setAttributes:@{NSFileCreationDate : date} ofItemAtPath:absolutePath error:&error]) {
-      return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed setting creation date for directory \"%@\"", relativePath];
+- (BOOL)_checkFileExtension:(NSString *)fileName {
+    if (_allowedFileExtensions && ![_allowedFileExtensions containsObject:[[fileName pathExtension] lowercaseString]]) {
+        return NO;
     }
-  }
+
+    return YES;
+}
+
+static inline BOOL _IsMacFinder(GCDWebServerRequest *request) {
+    NSString *userAgentHeader = [request.headers objectForKey:@"User-Agent"];
+
+    return ([userAgentHeader hasPrefix:@"WebDAVFS/"] || [userAgentHeader hasPrefix:@"WebDAVLib/"]); // OS X WebDAV client
+}
+
+- (GCDWebServerResponse *)performOPTIONS:(GCDWebServerRequest *)request {
+    GCDWebServerResponse *response = [GCDWebServerResponse response];
+
+    if (_IsMacFinder(request)) {
+        [response setValue:@"1, 2" forAdditionalHeader:@"DAV"]; // Classes 1 and 2
+    } else {
+        [response setValue:@"1" forAdditionalHeader:@"DAV"]; // Class 1
+    }
+
+    return response;
+}
+
+- (GCDWebServerResponse *)performGET:(GCDWebServerRequest *)request {
+    NSString *relativePath = request.path;
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory = NO;
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+    }
+
+    NSString *itemName = [absolutePath lastPathComponent];
+
+    if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Downlading item name \"%@\" is not allowed", itemName];
+    }
+
+    // Because HEAD requests are mapped to GET ones, we need to handle directories but it's OK to return nothing per http://webdav.org/specs/rfc4918.html#rfc.section.9.4
+    if (isDirectory) {
+        return [GCDWebServerResponse response];
+    }
+
+    if ([self.delegate respondsToSelector:@selector(davServer:didDownloadFileAtPath:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate davServer:self didDownloadFileAtPath:absolutePath];
+        });
+    }
+
+    if ([request hasByteRange]) {
+        return [GCDWebServerFileResponse responseWithFile:absolutePath byteRange:request.byteRange];
+    }
+
+    return [GCDWebServerFileResponse responseWithFile:absolutePath];
+}
+
+- (GCDWebServerResponse *)performPUT:(GCDWebServerFileRequest *)request {
+    if ([request hasByteRange]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Range uploads not supported"];
+    }
+
+    NSString *relativePath = request.path;
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory;
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:[absolutePath stringByDeletingLastPathComponent] isDirectory:&isDirectory] || !isDirectory) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Conflict message:@"Missing intermediate collection(s) for \"%@\"", relativePath];
+    }
+
+    BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory];
+
+    if (existing && isDirectory) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MethodNotAllowed message:@"PUT not allowed on existing collection \"%@\"", relativePath];
+    }
+
+    NSString *fileName = [absolutePath lastPathComponent];
+
+    if (([fileName hasPrefix:@"."] && !_allowHiddenItems) || ![self _checkFileExtension:fileName]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file name \"%@\" is not allowed", fileName];
+    }
+
+    if (![self shouldUploadFileAtPath:absolutePath withTemporaryFile:request.temporaryPath]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file to \"%@\" is not permitted", relativePath];
+    }
+
+    [[NSFileManager defaultManager] removeItemAtPath:absolutePath error:NULL];
+    NSError *error = nil;
+
+    if (![[NSFileManager defaultManager] moveItemAtPath:request.temporaryPath toPath:absolutePath error:&error]) {
+        return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
+    }
+
+    if ([self.delegate respondsToSelector:@selector(davServer:didUploadFileAtPath:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate davServer:self didUploadFileAtPath:absolutePath];
+        });
+    }
+
+    return [GCDWebServerResponse responseWithStatusCode:(existing ? kGCDWebServerHTTPStatusCode_NoContent : kGCDWebServerHTTPStatusCode_Created)];
+}
+
+- (GCDWebServerResponse *)performDELETE:(GCDWebServerRequest *)request {
+    NSString *depthHeader = [request.headers objectForKey:@"Depth"];
+
+    if (depthHeader && ![depthHeader isEqualToString:@"infinity"]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
+    }
+
+    NSString *relativePath = request.path;
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory = NO;
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+    }
+
+    NSString *itemName = [absolutePath lastPathComponent];
+
+    if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting item name \"%@\" is not allowed", itemName];
+    }
+
+    if (![self shouldDeleteItemAtPath:absolutePath]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not permitted", relativePath];
+    }
+
+    NSError *error = nil;
+
+    if (![[NSFileManager defaultManager] removeItemAtPath:absolutePath error:&error]) {
+        return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed deleting \"%@\"", relativePath];
+    }
+
+    if ([self.delegate respondsToSelector:@selector(davServer:didDeleteItemAtPath:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate davServer:self didDeleteItemAtPath:absolutePath];
+        });
+    }
+
+    return [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NoContent];
+}
+
+- (GCDWebServerResponse *)performMKCOL:(GCDWebServerDataRequest *)request {
+    if ([request hasBody] && (request.contentLength > 0)) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_UnsupportedMediaType message:@"Unexpected request body for MKCOL method"];
+    }
+
+    NSString *relativePath = request.path;
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory;
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:[absolutePath stringByDeletingLastPathComponent] isDirectory:&isDirectory] || !isDirectory) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Conflict message:@"Missing intermediate collection(s) for \"%@\"", relativePath];
+    }
+
+    NSString *directoryName = [absolutePath lastPathComponent];
+
+    if (!_allowHiddenItems && [directoryName hasPrefix:@"."]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory name \"%@\" is not allowed", directoryName];
+    }
+
+    if (![self shouldCreateDirectoryAtPath:absolutePath]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory \"%@\" is not permitted", relativePath];
+    }
+
+    NSError *error = nil;
+
+    if (![[NSFileManager defaultManager] createDirectoryAtPath:absolutePath withIntermediateDirectories:NO attributes:nil error:&error]) {
+        return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed creating directory \"%@\"", relativePath];
+    }
+
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+    NSString *creationDateHeader = [request.headers objectForKey:@"X-GCDWebServer-CreationDate"];
+
+    if (creationDateHeader) {
+        NSDate *date = GCDWebServerParseISO8601(creationDateHeader);
+
+        if (!date || ![[NSFileManager defaultManager] setAttributes:@{ NSFileCreationDate: date } ofItemAtPath:absolutePath error:&error]) {
+            return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed setting creation date for directory \"%@\"", relativePath];
+        }
+    }
+
 #endif
 
-  if ([self.delegate respondsToSelector:@selector(davServer:didCreateDirectoryAtPath:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.delegate davServer:self didCreateDirectoryAtPath:absolutePath];
-    });
-  }
-  return [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_Created];
+    if ([self.delegate respondsToSelector:@selector(davServer:didCreateDirectoryAtPath:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate davServer:self didCreateDirectoryAtPath:absolutePath];
+        });
+    }
+
+    return [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_Created];
 }
 
-- (GCDWebServerResponse*)performCOPY:(GCDWebServerRequest*)request isMove:(BOOL)isMove {
-  if (!isMove) {
-    NSString* depthHeader = [request.headers objectForKey:@"Depth"];  // TODO: Support "Depth: 0"
-    if (depthHeader && ![depthHeader isEqualToString:@"infinity"]) {
-      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
-    }
-  }
+- (GCDWebServerResponse *)performCOPY:(GCDWebServerRequest *)request isMove:(BOOL)isMove {
+    if (!isMove) {
+        NSString *depthHeader = [request.headers objectForKey:@"Depth"]; // TODO: Support "Depth: 0"
 
-  NSString* srcRelativePath = request.path;
-  NSString* srcAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(srcRelativePath)];
-
-  NSString* dstRelativePath = [request.headers objectForKey:@"Destination"];
-  NSRange range = [dstRelativePath rangeOfString:(NSString*)[request.headers objectForKey:@"Host"]];
-  if ((dstRelativePath == nil) || (range.location == NSNotFound)) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Malformed 'Destination' header: %@", dstRelativePath];
-  }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  dstRelativePath = [[dstRelativePath substringFromIndex:(range.location + range.length)] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-#pragma clang diagnostic pop
-  NSString* dstAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(dstRelativePath)];
-  if (!dstAbsolutePath) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", srcRelativePath];
-  }
-
-  BOOL isDirectory;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:[dstAbsolutePath stringByDeletingLastPathComponent] isDirectory:&isDirectory] || !isDirectory) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Conflict message:@"Invalid destination \"%@\"", dstRelativePath];
-  }
-
-  NSString* srcName = [srcAbsolutePath lastPathComponent];
-  if ((!_allowHiddenItems && [srcName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:srcName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"%@ from item name \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", srcName];
-  }
-
-  NSString* dstName = [dstAbsolutePath lastPathComponent];
-  if ((!_allowHiddenItems && [dstName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:dstName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"%@ to item name \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", dstName];
-  }
-
-  NSString* overwriteHeader = [request.headers objectForKey:@"Overwrite"];
-  BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:dstAbsolutePath];
-  if (existing && ((isMove && ![overwriteHeader isEqualToString:@"T"]) || (!isMove && [overwriteHeader isEqualToString:@"F"]))) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_PreconditionFailed message:@"Destination \"%@\" already exists", dstRelativePath];
-  }
-
-  if (isMove) {
-    if (![self shouldMoveItemFromPath:srcAbsolutePath toPath:dstAbsolutePath]) {
-      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Moving \"%@\" to \"%@\" is not permitted", srcRelativePath, dstRelativePath];
-    }
-  } else {
-    if (![self shouldCopyItemFromPath:srcAbsolutePath toPath:dstAbsolutePath]) {
-      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Copying \"%@\" to \"%@\" is not permitted", srcRelativePath, dstRelativePath];
-    }
-  }
-
-  NSError* error = nil;
-  if (isMove) {
-    [[NSFileManager defaultManager] removeItemAtPath:dstAbsolutePath error:NULL];
-    if (![[NSFileManager defaultManager] moveItemAtPath:srcAbsolutePath toPath:dstAbsolutePath error:&error]) {
-      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden underlyingError:error message:@"Failed copying \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
-    }
-  } else {
-    if (![[NSFileManager defaultManager] copyItemAtPath:srcAbsolutePath toPath:dstAbsolutePath error:&error]) {
-      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden underlyingError:error message:@"Failed copying \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
-    }
-  }
-
-  if (isMove) {
-    if ([self.delegate respondsToSelector:@selector(davServer:didMoveItemFromPath:toPath:)]) {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [self.delegate davServer:self didMoveItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
-      });
-    }
-  } else {
-    if ([self.delegate respondsToSelector:@selector(davServer:didCopyItemFromPath:toPath:)]) {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [self.delegate davServer:self didCopyItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
-      });
-    }
-  }
-
-  return [GCDWebServerResponse responseWithStatusCode:(existing ? kGCDWebServerHTTPStatusCode_NoContent : kGCDWebServerHTTPStatusCode_Created)];
-}
-
-static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar* name) {
-  while (child) {
-    if ((child->type == XML_ELEMENT_NODE) && !xmlStrcmp(child->name, name)) {
-      return child;
-    }
-    child = child->next;
-  }
-  return NULL;
-}
-
-- (void)_addPropertyResponseForItem:(NSString*)itemPath resource:(NSString*)resourcePath properties:(DAVProperties)properties xmlString:(NSMutableString*)xmlString {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  CFStringRef escapedPath = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)resourcePath, NULL, CFSTR("<&>?+"), kCFStringEncodingUTF8);
-#pragma clang diagnostic pop
-  if (escapedPath) {
-    NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:itemPath error:NULL];
-    NSString* type = [attributes objectForKey:NSFileType];
-    BOOL isFile = [type isEqualToString:NSFileTypeRegular];
-    BOOL isDirectory = [type isEqualToString:NSFileTypeDirectory];
-    if ((isFile && [self _checkFileExtension:itemPath]) || isDirectory) {
-      [xmlString appendString:@"<D:response>"];
-      [xmlString appendFormat:@"<D:href>%@</D:href>", escapedPath];
-      [xmlString appendString:@"<D:propstat>"];
-      [xmlString appendString:@"<D:prop>"];
-
-      if (properties & kDAVProperty_ResourceType) {
-        if (isDirectory) {
-          [xmlString appendString:@"<D:resourcetype><D:collection/></D:resourcetype>"];
-        } else {
-          [xmlString appendString:@"<D:resourcetype/>"];
+        if (depthHeader && ![depthHeader isEqualToString:@"infinity"]) {
+            return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
         }
-      }
-
-      if ((properties & kDAVProperty_CreationDate) && [attributes objectForKey:NSFileCreationDate]) {
-        [xmlString appendFormat:@"<D:creationdate>%@</D:creationdate>", GCDWebServerFormatISO8601((NSDate*)[attributes fileCreationDate])];
-      }
-
-      if ((properties & kDAVProperty_LastModified) && isFile && [attributes objectForKey:NSFileModificationDate]) {  // Last modification date is not useful for directories as it changes implicitely and 'Last-Modified' header is not provided for directories anyway
-        [xmlString appendFormat:@"<D:getlastmodified>%@</D:getlastmodified>", GCDWebServerFormatRFC822((NSDate*)[attributes fileModificationDate])];
-      }
-
-      if ((properties & kDAVProperty_ContentLength) && !isDirectory && [attributes objectForKey:NSFileSize]) {
-        [xmlString appendFormat:@"<D:getcontentlength>%llu</D:getcontentlength>", [attributes fileSize]];
-      }
-
-      [xmlString appendString:@"</D:prop>"];
-      [xmlString appendString:@"<D:status>HTTP/1.1 200 OK</D:status>"];
-      [xmlString appendString:@"</D:propstat>"];
-      [xmlString appendString:@"</D:response>\n"];
     }
-    CFRelease(escapedPath);
-  } else {
-    [self logError:@"Failed escaping path: %@", itemPath];
-  }
+
+    NSString *srcRelativePath = request.path;
+    NSString *srcAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(srcRelativePath)];
+
+    NSString *dstRelativePath = [request.headers objectForKey:@"Destination"];
+    NSRange range = [dstRelativePath rangeOfString:(NSString *)[request.headers objectForKey:@"Host"]];
+
+    if ((dstRelativePath == nil) || (range.location == NSNotFound)) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Malformed 'Destination' header: %@", dstRelativePath];
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    dstRelativePath = [[dstRelativePath substringFromIndex:(range.location + range.length)] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+#pragma clang diagnostic pop
+    NSString *dstAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(dstRelativePath)];
+
+    if (!dstAbsolutePath) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", srcRelativePath];
+    }
+
+    BOOL isDirectory;
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:[dstAbsolutePath stringByDeletingLastPathComponent] isDirectory:&isDirectory] || !isDirectory) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Conflict message:@"Invalid destination \"%@\"", dstRelativePath];
+    }
+
+    NSString *srcName = [srcAbsolutePath lastPathComponent];
+
+    if ((!_allowHiddenItems && [srcName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:srcName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"%@ from item name \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", srcName];
+    }
+
+    NSString *dstName = [dstAbsolutePath lastPathComponent];
+
+    if ((!_allowHiddenItems && [dstName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:dstName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"%@ to item name \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", dstName];
+    }
+
+    NSString *overwriteHeader = [request.headers objectForKey:@"Overwrite"];
+    BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:dstAbsolutePath];
+
+    if (existing && ((isMove && ![overwriteHeader isEqualToString:@"T"]) || (!isMove && [overwriteHeader isEqualToString:@"F"]))) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_PreconditionFailed message:@"Destination \"%@\" already exists", dstRelativePath];
+    }
+
+    if (isMove) {
+        if (![self shouldMoveItemFromPath:srcAbsolutePath toPath:dstAbsolutePath]) {
+            return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Moving \"%@\" to \"%@\" is not permitted", srcRelativePath, dstRelativePath];
+        }
+    } else {
+        if (![self shouldCopyItemFromPath:srcAbsolutePath toPath:dstAbsolutePath]) {
+            return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Copying \"%@\" to \"%@\" is not permitted", srcRelativePath, dstRelativePath];
+        }
+    }
+
+    NSError *error = nil;
+
+    if (isMove) {
+        [[NSFileManager defaultManager] removeItemAtPath:dstAbsolutePath error:NULL];
+
+        if (![[NSFileManager defaultManager] moveItemAtPath:srcAbsolutePath toPath:dstAbsolutePath error:&error]) {
+            return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden underlyingError:error message:@"Failed copying \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
+        }
+    } else {
+        if (![[NSFileManager defaultManager] copyItemAtPath:srcAbsolutePath toPath:dstAbsolutePath error:&error]) {
+            return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden underlyingError:error message:@"Failed copying \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
+        }
+    }
+
+    if (isMove) {
+        if ([self.delegate respondsToSelector:@selector(davServer:didMoveItemFromPath:toPath:)]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.delegate davServer:self didMoveItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
+            });
+        }
+    } else {
+        if ([self.delegate respondsToSelector:@selector(davServer:didCopyItemFromPath:toPath:)]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.delegate davServer:self didCopyItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
+            });
+        }
+    }
+
+    return [GCDWebServerResponse responseWithStatusCode:(existing ? kGCDWebServerHTTPStatusCode_NoContent : kGCDWebServerHTTPStatusCode_Created)];
 }
 
-- (GCDWebServerResponse*)performPROPFIND:(GCDWebServerDataRequest*)request {
-  NSInteger depth;
-  NSString* depthHeader = [request.headers objectForKey:@"Depth"];
-  if ([depthHeader isEqualToString:@"0"]) {
-    depth = 0;
-  } else if ([depthHeader isEqualToString:@"1"]) {
-    depth = 1;
-  } else {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];  // TODO: Return 403 / propfind-finite-depth for "infinity" depth
-  }
+static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name) {
+    while (child) {
+        if ((child->type == XML_ELEMENT_NODE) && !xmlStrcmp(child->name, name)) {
+            return child;
+        }
 
-  DAVProperties properties = 0;
-  if (request.data.length) {
+        child = child->next;
+    }
+    return NULL;
+}
+
+- (void)_addPropertyResponseForItem:(NSString *)itemPath resource:(NSString *)resourcePath properties:(DAVProperties)properties xmlString:(NSMutableString *)xmlString {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    CFStringRef escapedPath = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)resourcePath, NULL, CFSTR("<&>?+"), kCFStringEncodingUTF8);
+#pragma clang diagnostic pop
+
+    if (escapedPath) {
+        NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:itemPath error:NULL];
+        NSString *type = [attributes objectForKey:NSFileType];
+        BOOL isFile = [type isEqualToString:NSFileTypeRegular];
+        BOOL isDirectory = [type isEqualToString:NSFileTypeDirectory];
+
+        if ((isFile && [self _checkFileExtension:itemPath]) || isDirectory) {
+            [xmlString appendString:@"<D:response>"];
+            [xmlString appendFormat:@"<D:href>%@</D:href>", escapedPath];
+            [xmlString appendString:@"<D:propstat>"];
+            [xmlString appendString:@"<D:prop>"];
+
+            if (properties & kDAVProperty_ResourceType) {
+                if (isDirectory) {
+                    [xmlString appendString:@"<D:resourcetype><D:collection/></D:resourcetype>"];
+                } else {
+                    [xmlString appendString:@"<D:resourcetype/>"];
+                }
+            }
+
+            if ((properties & kDAVProperty_CreationDate) && [attributes objectForKey:NSFileCreationDate]) {
+                [xmlString appendFormat:@"<D:creationdate>%@</D:creationdate>", GCDWebServerFormatISO8601((NSDate *)[attributes fileCreationDate])];
+            }
+
+            if ((properties & kDAVProperty_LastModified) && isFile && [attributes objectForKey:NSFileModificationDate]) { // Last modification date is not useful for directories as it changes implicitely and 'Last-Modified' header is not provided for directories anyway
+                [xmlString appendFormat:@"<D:getlastmodified>%@</D:getlastmodified>", GCDWebServerFormatRFC822((NSDate *)[attributes fileModificationDate])];
+            }
+
+            if ((properties & kDAVProperty_ContentLength) && !isDirectory && [attributes objectForKey:NSFileSize]) {
+                [xmlString appendFormat:@"<D:getcontentlength>%llu</D:getcontentlength>", [attributes fileSize]];
+            }
+
+            [xmlString appendString:@"</D:prop>"];
+            [xmlString appendString:@"<D:status>HTTP/1.1 200 OK</D:status>"];
+            [xmlString appendString:@"</D:propstat>"];
+            [xmlString appendString:@"</D:response>\n"];
+        }
+
+        CFRelease(escapedPath);
+    } else {
+        [self logError:@"Failed escaping path: %@", itemPath];
+    }
+}
+
+- (GCDWebServerResponse *)performPROPFIND:(GCDWebServerDataRequest *)request {
+    NSInteger depth;
+    NSString *depthHeader = [request.headers objectForKey:@"Depth"];
+
+    if ([depthHeader isEqualToString:@"0"]) {
+        depth = 0;
+    } else if ([depthHeader isEqualToString:@"1"]) {
+        depth = 1;
+    } else {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader]; // TODO: Return 403 / propfind-finite-depth for "infinity" depth
+    }
+
+    DAVProperties properties = 0;
+
+    if (request.data.length) {
+        BOOL success = YES;
+        xmlDocPtr document = xmlReadMemory(request.data.bytes, (int)request.data.length, NULL, NULL, kXMLParseOptions);
+
+        if (document) {
+            xmlNodePtr rootNode = _XMLChildWithName(document->children, (const xmlChar *)"propfind");
+            xmlNodePtr allNode = rootNode ? _XMLChildWithName(rootNode->children, (const xmlChar *)"allprop") : NULL;
+            xmlNodePtr propNode = rootNode ? _XMLChildWithName(rootNode->children, (const xmlChar *)"prop") : NULL;
+
+            if (allNode) {
+                properties = kDAVAllProperties;
+            } else if (propNode) {
+                xmlNodePtr node = propNode->children;
+
+                while (node) {
+                    if (!xmlStrcmp(node->name, (const xmlChar *)"resourcetype")) {
+                        properties |= kDAVProperty_ResourceType;
+                    } else if (!xmlStrcmp(node->name, (const xmlChar *)"creationdate")) {
+                        properties |= kDAVProperty_CreationDate;
+                    } else if (!xmlStrcmp(node->name, (const xmlChar *)"getlastmodified")) {
+                        properties |= kDAVProperty_LastModified;
+                    } else if (!xmlStrcmp(node->name, (const xmlChar *)"getcontentlength")) {
+                        properties |= kDAVProperty_ContentLength;
+                    } else {
+                        [self logWarning:@"Unknown DAV property requested \"%s\"", node->name];
+                    }
+
+                    node = node->next;
+                }
+            } else {
+                success = NO;
+            }
+
+            xmlFreeDoc(document);
+        } else {
+            success = NO;
+        }
+
+        if (!success) {
+            NSString *string = [[NSString alloc] initWithData:request.data encoding:NSUTF8StringEncoding];
+            return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Invalid DAV properties:\n%@", string];
+        }
+    } else {
+        properties = kDAVAllProperties;
+    }
+
+    NSString *relativePath = request.path;
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory = NO;
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+    }
+
+    NSString *itemName = [absolutePath lastPathComponent];
+
+    if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Retrieving properties for item name \"%@\" is not allowed", itemName];
+    }
+
+    NSArray *items = nil;
+
+    if (isDirectory) {
+        NSError *error = nil;
+        items = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:absolutePath error:&error] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
+
+        if (items == nil) {
+            return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed listing directory \"%@\"", relativePath];
+        }
+    }
+
+    NSMutableString *xmlString = [NSMutableString stringWithString:@"<?xml version=\"1.0\" encoding=\"utf-8\" ?>"];
+    [xmlString appendString:@"<D:multistatus xmlns:D=\"DAV:\">\n"];
+
+    if (![relativePath hasPrefix:@"/"]) {
+        relativePath = [@"/" stringByAppendingString:relativePath];
+    }
+
+    [self _addPropertyResponseForItem:absolutePath resource:relativePath properties:properties xmlString:xmlString];
+
+    if (depth == 1) {
+        if (![relativePath hasSuffix:@"/"]) {
+            relativePath = [relativePath stringByAppendingString:@"/"];
+        }
+
+        for (NSString *item in items) {
+            if (_allowHiddenItems || ![item hasPrefix:@"."]) {
+                [self _addPropertyResponseForItem:[absolutePath stringByAppendingPathComponent:item] resource:[relativePath stringByAppendingString:item] properties:properties xmlString:xmlString];
+            }
+        }
+    }
+
+    [xmlString appendString:@"</D:multistatus>"];
+
+    GCDWebServerDataResponse *response = [GCDWebServerDataResponse responseWithData:(NSData *)[xmlString dataUsingEncoding:NSUTF8StringEncoding]
+                                                                        contentType:@"application/xml; charset=\"utf-8\""];
+    response.statusCode = kGCDWebServerHTTPStatusCode_MultiStatus;
+    return response;
+}
+
+- (GCDWebServerResponse *)performLOCK:(GCDWebServerDataRequest *)request {
+    if (!_IsMacFinder(request)) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MethodNotAllowed message:@"LOCK method only allowed for Mac Finder"];
+    }
+
+    NSString *relativePath = request.path;
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory = NO;
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+    }
+
+    NSString *depthHeader = [request.headers objectForKey:@"Depth"];
+    NSString *timeoutHeader = [request.headers objectForKey:@"Timeout"];
+    NSString *scope = nil;
+    NSString *type = nil;
+    NSString *owner = nil;
+    NSString *token = nil;
     BOOL success = YES;
     xmlDocPtr document = xmlReadMemory(request.data.bytes, (int)request.data.length, NULL, NULL, kXMLParseOptions);
+
     if (document) {
-      xmlNodePtr rootNode = _XMLChildWithName(document->children, (const xmlChar*)"propfind");
-      xmlNodePtr allNode = rootNode ? _XMLChildWithName(rootNode->children, (const xmlChar*)"allprop") : NULL;
-      xmlNodePtr propNode = rootNode ? _XMLChildWithName(rootNode->children, (const xmlChar*)"prop") : NULL;
-      if (allNode) {
-        properties = kDAVAllProperties;
-      } else if (propNode) {
-        xmlNodePtr node = propNode->children;
-        while (node) {
-          if (!xmlStrcmp(node->name, (const xmlChar*)"resourcetype")) {
-            properties |= kDAVProperty_ResourceType;
-          } else if (!xmlStrcmp(node->name, (const xmlChar*)"creationdate")) {
-            properties |= kDAVProperty_CreationDate;
-          } else if (!xmlStrcmp(node->name, (const xmlChar*)"getlastmodified")) {
-            properties |= kDAVProperty_LastModified;
-          } else if (!xmlStrcmp(node->name, (const xmlChar*)"getcontentlength")) {
-            properties |= kDAVProperty_ContentLength;
-          } else {
-            [self logWarning:@"Unknown DAV property requested \"%s\"", node->name];
-          }
-          node = node->next;
+        xmlNodePtr node = _XMLChildWithName(document->children, (const xmlChar *)"lockinfo");
+
+        if (node) {
+            xmlNodePtr scopeNode = _XMLChildWithName(node->children, (const xmlChar *)"lockscope");
+
+            if (scopeNode && scopeNode->children && scopeNode->children->name) {
+                scope = [NSString stringWithUTF8String:(const char *)scopeNode->children->name];
+            }
+
+            xmlNodePtr typeNode = _XMLChildWithName(node->children, (const xmlChar *)"locktype");
+
+            if (typeNode && typeNode->children && typeNode->children->name) {
+                type = [NSString stringWithUTF8String:(const char *)typeNode->children->name];
+            }
+
+            xmlNodePtr ownerNode = _XMLChildWithName(node->children, (const xmlChar *)"owner");
+
+            if (ownerNode) {
+                ownerNode = _XMLChildWithName(ownerNode->children, (const xmlChar *)"href");
+
+                if (ownerNode && ownerNode->children && ownerNode->children->content) {
+                    owner = [NSString stringWithUTF8String:(const char *)ownerNode->children->content];
+                }
+            }
+        } else {
+            success = NO;
         }
-      } else {
+
+        xmlFreeDoc(document);
+    } else {
         success = NO;
-      }
-      xmlFreeDoc(document);
-    } else {
-      success = NO;
     }
+
     if (!success) {
-      NSString* string = [[NSString alloc] initWithData:request.data encoding:NSUTF8StringEncoding];
-      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Invalid DAV properties:\n%@", string];
+        NSString *string = [[NSString alloc] initWithData:request.data encoding:NSUTF8StringEncoding];
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Invalid DAV properties:\n%@", string];
     }
-  } else {
-    properties = kDAVAllProperties;
-  }
 
-  NSString* relativePath = request.path;
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory = NO;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
-  }
-
-  NSString* itemName = [absolutePath lastPathComponent];
-  if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Retrieving properties for item name \"%@\" is not allowed", itemName];
-  }
-
-  NSArray* items = nil;
-  if (isDirectory) {
-    NSError* error = nil;
-    items = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:absolutePath error:&error] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
-    if (items == nil) {
-      return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed listing directory \"%@\"", relativePath];
+    if (![scope isEqualToString:@"exclusive"] || ![type isEqualToString:@"write"] || ![depthHeader isEqualToString:@"0"]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Locking request \"%@/%@/%@\" for \"%@\" is not allowed", scope, type, depthHeader, relativePath];
     }
-  }
 
-  NSMutableString* xmlString = [NSMutableString stringWithString:@"<?xml version=\"1.0\" encoding=\"utf-8\" ?>"];
-  [xmlString appendString:@"<D:multistatus xmlns:D=\"DAV:\">\n"];
-  if (![relativePath hasPrefix:@"/"]) {
-    relativePath = [@"/" stringByAppendingString:relativePath];
-  }
-  [self _addPropertyResponseForItem:absolutePath resource:relativePath properties:properties xmlString:xmlString];
-  if (depth == 1) {
-    if (![relativePath hasSuffix:@"/"]) {
-      relativePath = [relativePath stringByAppendingString:@"/"];
+    NSString *itemName = [absolutePath lastPathComponent];
+
+    if ((!_allowHiddenItems && [itemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Locking item name \"%@\" is not allowed", itemName];
     }
-    for (NSString* item in items) {
-      if (_allowHiddenItems || ![item hasPrefix:@"."]) {
-        [self _addPropertyResponseForItem:[absolutePath stringByAppendingPathComponent:item] resource:[relativePath stringByAppendingString:item] properties:properties xmlString:xmlString];
-      }
-    }
-  }
-  [xmlString appendString:@"</D:multistatus>"];
-
-  GCDWebServerDataResponse* response = [GCDWebServerDataResponse responseWithData:(NSData*)[xmlString dataUsingEncoding:NSUTF8StringEncoding]
-                                                                      contentType:@"application/xml; charset=\"utf-8\""];
-  response.statusCode = kGCDWebServerHTTPStatusCode_MultiStatus;
-  return response;
-}
-
-- (GCDWebServerResponse*)performLOCK:(GCDWebServerDataRequest*)request {
-  if (!_IsMacFinder(request)) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MethodNotAllowed message:@"LOCK method only allowed for Mac Finder"];
-  }
-
-  NSString* relativePath = request.path;
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory = NO;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
-  }
-
-  NSString* depthHeader = [request.headers objectForKey:@"Depth"];
-  NSString* timeoutHeader = [request.headers objectForKey:@"Timeout"];
-  NSString* scope = nil;
-  NSString* type = nil;
-  NSString* owner = nil;
-  NSString* token = nil;
-  BOOL success = YES;
-  xmlDocPtr document = xmlReadMemory(request.data.bytes, (int)request.data.length, NULL, NULL, kXMLParseOptions);
-  if (document) {
-    xmlNodePtr node = _XMLChildWithName(document->children, (const xmlChar*)"lockinfo");
-    if (node) {
-      xmlNodePtr scopeNode = _XMLChildWithName(node->children, (const xmlChar*)"lockscope");
-      if (scopeNode && scopeNode->children && scopeNode->children->name) {
-        scope = [NSString stringWithUTF8String:(const char*)scopeNode->children->name];
-      }
-      xmlNodePtr typeNode = _XMLChildWithName(node->children, (const xmlChar*)"locktype");
-      if (typeNode && typeNode->children && typeNode->children->name) {
-        type = [NSString stringWithUTF8String:(const char*)typeNode->children->name];
-      }
-      xmlNodePtr ownerNode = _XMLChildWithName(node->children, (const xmlChar*)"owner");
-      if (ownerNode) {
-        ownerNode = _XMLChildWithName(ownerNode->children, (const xmlChar*)"href");
-        if (ownerNode && ownerNode->children && ownerNode->children->content) {
-          owner = [NSString stringWithUTF8String:(const char*)ownerNode->children->content];
-        }
-      }
-    } else {
-      success = NO;
-    }
-    xmlFreeDoc(document);
-  } else {
-    success = NO;
-  }
-  if (!success) {
-    NSString* string = [[NSString alloc] initWithData:request.data encoding:NSUTF8StringEncoding];
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Invalid DAV properties:\n%@", string];
-  }
-
-  if (![scope isEqualToString:@"exclusive"] || ![type isEqualToString:@"write"] || ![depthHeader isEqualToString:@"0"]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Locking request \"%@/%@/%@\" for \"%@\" is not allowed", scope, type, depthHeader, relativePath];
-  }
-
-  NSString* itemName = [absolutePath lastPathComponent];
-  if ((!_allowHiddenItems && [itemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Locking item name \"%@\" is not allowed", itemName];
-  }
 
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
-  NSString* lockTokenHeader = [request.headers objectForKey:@"X-GCDWebServer-LockToken"];
-  if (lockTokenHeader) {
-    token = lockTokenHeader;
-  }
+    NSString *lockTokenHeader = [request.headers objectForKey:@"X-GCDWebServer-LockToken"];
+
+    if (lockTokenHeader) {
+        token = lockTokenHeader;
+    }
+
 #endif
-  if (!token) {
-    CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
-    CFStringRef string = CFUUIDCreateString(kCFAllocatorDefault, uuid);
-    token = [NSString stringWithFormat:@"urn:uuid:%@", (__bridge NSString*)string];
-    CFRelease(string);
-    CFRelease(uuid);
-  }
 
-  NSMutableString* xmlString = [NSMutableString stringWithString:@"<?xml version=\"1.0\" encoding=\"utf-8\" ?>"];
-  [xmlString appendString:@"<D:prop xmlns:D=\"DAV:\">\n"];
-  [xmlString appendString:@"<D:lockdiscovery>\n<D:activelock>\n"];
-  [xmlString appendFormat:@"<D:locktype><D:%@/></D:locktype>\n", type];
-  [xmlString appendFormat:@"<D:lockscope><D:%@/></D:lockscope>\n", scope];
-  [xmlString appendFormat:@"<D:depth>%@</D:depth>\n", depthHeader];
-  if (owner) {
-    [xmlString appendFormat:@"<D:owner><D:href>%@</D:href></D:owner>\n", owner];
-  }
-  if (timeoutHeader) {
-    [xmlString appendFormat:@"<D:timeout>%@</D:timeout>\n", timeoutHeader];
-  }
-  [xmlString appendFormat:@"<D:locktoken><D:href>%@</D:href></D:locktoken>\n", token];
-  NSString* lockroot = [@"http://" stringByAppendingString:[(NSString*)[request.headers objectForKey:@"Host"] stringByAppendingString:[@"/" stringByAppendingString:relativePath]]];
-  [xmlString appendFormat:@"<D:lockroot><D:href>%@</D:href></D:lockroot>\n", lockroot];
-  [xmlString appendString:@"</D:activelock>\n</D:lockdiscovery>\n"];
-  [xmlString appendString:@"</D:prop>"];
+    if (!token) {
+        CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
+        CFStringRef string = CFUUIDCreateString(kCFAllocatorDefault, uuid);
+        token = [NSString stringWithFormat:@"urn:uuid:%@", (__bridge NSString *)string];
+        CFRelease(string);
+        CFRelease(uuid);
+    }
 
-  [self logVerbose:@"WebDAV pretending to lock \"%@\"", relativePath];
-  GCDWebServerDataResponse* response = [GCDWebServerDataResponse responseWithData:(NSData*)[xmlString dataUsingEncoding:NSUTF8StringEncoding]
-                                                                      contentType:@"application/xml; charset=\"utf-8\""];
-  return response;
+    NSMutableString *xmlString = [NSMutableString stringWithString:@"<?xml version=\"1.0\" encoding=\"utf-8\" ?>"];
+    [xmlString appendString:@"<D:prop xmlns:D=\"DAV:\">\n"];
+    [xmlString appendString:@"<D:lockdiscovery>\n<D:activelock>\n"];
+    [xmlString appendFormat:@"<D:locktype><D:%@/></D:locktype>\n", type];
+    [xmlString appendFormat:@"<D:lockscope><D:%@/></D:lockscope>\n", scope];
+    [xmlString appendFormat:@"<D:depth>%@</D:depth>\n", depthHeader];
+
+    if (owner) {
+        [xmlString appendFormat:@"<D:owner><D:href>%@</D:href></D:owner>\n", owner];
+    }
+
+    if (timeoutHeader) {
+        [xmlString appendFormat:@"<D:timeout>%@</D:timeout>\n", timeoutHeader];
+    }
+
+    [xmlString appendFormat:@"<D:locktoken><D:href>%@</D:href></D:locktoken>\n", token];
+    NSString *lockroot = [@"http://" stringByAppendingString:[(NSString *)[request.headers objectForKey:@"Host"] stringByAppendingString:[@"/" stringByAppendingString:relativePath]]];
+    [xmlString appendFormat:@"<D:lockroot><D:href>%@</D:href></D:lockroot>\n", lockroot];
+    [xmlString appendString:@"</D:activelock>\n</D:lockdiscovery>\n"];
+    [xmlString appendString:@"</D:prop>"];
+
+    [self logVerbose:@"WebDAV pretending to lock \"%@\"", relativePath];
+    GCDWebServerDataResponse *response = [GCDWebServerDataResponse responseWithData:(NSData *)[xmlString dataUsingEncoding:NSUTF8StringEncoding]
+                                                                        contentType:@"application/xml; charset=\"utf-8\""];
+    return response;
 }
 
-- (GCDWebServerResponse*)performUNLOCK:(GCDWebServerRequest*)request {
-  if (!_IsMacFinder(request)) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MethodNotAllowed message:@"UNLOCK method only allowed for Mac Finder"];
-  }
+- (GCDWebServerResponse *)performUNLOCK:(GCDWebServerRequest *)request {
+    if (!_IsMacFinder(request)) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MethodNotAllowed message:@"UNLOCK method only allowed for Mac Finder"];
+    }
 
-  NSString* relativePath = request.path;
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory = NO;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
-  }
+    NSString *relativePath = request.path;
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory = NO;
 
-  NSString* tokenHeader = [request.headers objectForKey:@"Lock-Token"];
-  if (!tokenHeader.length) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Missing 'Lock-Token' header"];
-  }
+    if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+    }
 
-  NSString* itemName = [absolutePath lastPathComponent];
-  if ((!_allowHiddenItems && [itemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Unlocking item name \"%@\" is not allowed", itemName];
-  }
+    NSString *tokenHeader = [request.headers objectForKey:@"Lock-Token"];
 
-  [self logVerbose:@"WebDAV pretending to unlock \"%@\"", relativePath];
-  return [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NoContent];
+    if (!tokenHeader.length) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Missing 'Lock-Token' header"];
+    }
+
+    NSString *itemName = [absolutePath lastPathComponent];
+
+    if ((!_allowHiddenItems && [itemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Unlocking item name \"%@\" is not allowed", itemName];
+    }
+
+    [self logVerbose:@"WebDAV pretending to unlock \"%@\"", relativePath];
+    return [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NoContent];
 }
 
 @end
 
 @implementation GCDWebDAVServer (Subclassing)
 
-- (BOOL)shouldUploadFileAtPath:(NSString*)path withTemporaryFile:(NSString*)tempPath {
-  return YES;
+- (BOOL)shouldUploadFileAtPath:(NSString *)path withTemporaryFile:(NSString *)tempPath {
+    return YES;
 }
 
-- (BOOL)shouldMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath {
-  return YES;
+- (BOOL)shouldMoveItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath {
+    return YES;
 }
 
-- (BOOL)shouldCopyItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath {
-  return YES;
+- (BOOL)shouldCopyItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath {
+    return YES;
 }
 
-- (BOOL)shouldDeleteItemAtPath:(NSString*)path {
-  return YES;
+- (BOOL)shouldDeleteItemAtPath:(NSString *)path {
+    return YES;
 }
 
-- (BOOL)shouldCreateDirectoryAtPath:(NSString*)path {
-  return YES;
+- (BOOL)shouldCreateDirectoryAtPath:(NSString *)path {
+    return YES;
 }
 
 @end

--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import <TargetConditionals.h>
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  GCDWebServerRequest instance created with the same basic info.
  *  Otherwise, it simply returns nil.
  */
-typedef GCDWebServerRequest* _Nullable (^GCDWebServerMatchBlock)(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery);
+typedef GCDWebServerRequest * _Nullable (^GCDWebServerMatchBlock)(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery);
 
 /**
  *  The GCDWebServerProcessBlock is called after the HTTP request has been fully
@@ -54,7 +54,7 @@ typedef GCDWebServerRequest* _Nullable (^GCDWebServerMatchBlock)(NSString* reque
  *  recommended to return a GCDWebServerErrorResponse on error so more useful
  *  information can be returned to the client.
  */
-typedef GCDWebServerResponse* _Nullable (^GCDWebServerProcessBlock)(__kindof GCDWebServerRequest* request);
+typedef GCDWebServerResponse * _Nullable (^GCDWebServerProcessBlock)(__kindof GCDWebServerRequest *request);
 
 /**
  *  The GCDWebServerAsynchronousProcessBlock works like the GCDWebServerProcessBlock
@@ -66,22 +66,22 @@ typedef GCDWebServerResponse* _Nullable (^GCDWebServerProcessBlock)(__kindof GCD
  *  It's however recommended to return a GCDWebServerErrorResponse on error so more
  *  useful information can be returned to the client.
  */
-typedef void (^GCDWebServerCompletionBlock)(GCDWebServerResponse* _Nullable response);
-typedef void (^GCDWebServerAsyncProcessBlock)(__kindof GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock);
+typedef void (^GCDWebServerCompletionBlock)(GCDWebServerResponse * _Nullable response);
+typedef void (^GCDWebServerAsyncProcessBlock)(__kindof GCDWebServerRequest *request, GCDWebServerCompletionBlock completionBlock);
 
 /**
  *  The GCDWebServerBuiltInLoggerBlock is used to override the built-in logger at runtime.
  *  The block will be passed the log level and the log message, see setLogLevel for
  *  documentation of the log levels for the built-in logger.
  */
-typedef void (^GCDWebServerBuiltInLoggerBlock)(int level, NSString* _Nonnull message);
+typedef void (^GCDWebServerBuiltInLoggerBlock)(int level, NSString * _Nonnull message);
 
 /**
  *  The port used by the GCDWebServer (NSNumber / NSUInteger).
  *
  *  The default value is 0 i.e. let the OS pick a random port.
  */
-extern NSString* const GCDWebServerOption_Port;
+extern NSString * const GCDWebServerOption_Port;
 
 /**
  *  The Bonjour name used by the GCDWebServer (NSString). If set to an empty string,
@@ -90,21 +90,21 @@ extern NSString* const GCDWebServerOption_Port;
  *
  *  The default value is nil.
  */
-extern NSString* const GCDWebServerOption_BonjourName;
+extern NSString * const GCDWebServerOption_BonjourName;
 
 /**
-*  The Bonjour TXT Data used by the GCDWebServer (NSDictionary<NSString, NSString>).
-*
-*  The default value is nil.
-*/
-extern NSString* const GCDWebServerOption_BonjourTXTData;
+ *  The Bonjour TXT Data used by the GCDWebServer (NSDictionary<NSString, NSString>).
+ *
+ *  The default value is nil.
+ */
+extern NSString * const GCDWebServerOption_BonjourTXTData;
 
 /**
  *  The Bonjour service type used by the GCDWebServer (NSString).
  *
  *  The default value is "_http._tcp", the service type for HTTP web servers.
  */
-extern NSString* const GCDWebServerOption_BonjourType;
+extern NSString * const GCDWebServerOption_BonjourType;
 
 /**
  *  Request a port mapping in the NAT gateway (NSNumber / BOOL).
@@ -116,7 +116,7 @@ extern NSString* const GCDWebServerOption_BonjourType;
  *  @warning The external port set up by the NAT gateway may be different than
  *  the one used by the GCDWebServer.
  */
-extern NSString* const GCDWebServerOption_RequestNATPortMapping;
+extern NSString * const GCDWebServerOption_RequestNATPortMapping;
 
 /**
  *  Only accept HTTP requests coming from localhost i.e. not from the outside
@@ -127,7 +127,7 @@ extern NSString* const GCDWebServerOption_RequestNATPortMapping;
  *  @warning Bonjour and NAT port mapping should be disabled if using this option
  *  since the server will not be reachable from the outside network anyway.
  */
-extern NSString* const GCDWebServerOption_BindToLocalhost;
+extern NSString * const GCDWebServerOption_BindToLocalhost;
 
 /**
  *  The maximum number of incoming HTTP requests that can be queued waiting to
@@ -135,14 +135,14 @@ extern NSString* const GCDWebServerOption_BindToLocalhost;
  *
  *  The default value is 16.
  */
-extern NSString* const GCDWebServerOption_MaxPendingConnections;
+extern NSString * const GCDWebServerOption_MaxPendingConnections;
 
 /**
  *  The value for "Server" HTTP header used by the GCDWebServer (NSString).
  *
  *  The default value is the GCDWebServer class name.
  */
-extern NSString* const GCDWebServerOption_ServerName;
+extern NSString * const GCDWebServerOption_ServerName;
 
 /**
  *  The authentication method used by the GCDWebServer
@@ -150,14 +150,14 @@ extern NSString* const GCDWebServerOption_ServerName;
  *
  *  The default value is nil i.e. authentication is disabled.
  */
-extern NSString* const GCDWebServerOption_AuthenticationMethod;
+extern NSString * const GCDWebServerOption_AuthenticationMethod;
 
 /**
  *  The authentication realm used by the GCDWebServer (NSString).
  *
  *  The default value is the same as the GCDWebServerOption_ServerName option.
  */
-extern NSString* const GCDWebServerOption_AuthenticationRealm;
+extern NSString * const GCDWebServerOption_AuthenticationRealm;
 
 /**
  *  The authentication accounts used by the GCDWebServer
@@ -165,7 +165,7 @@ extern NSString* const GCDWebServerOption_AuthenticationRealm;
  *
  *  The default value is nil i.e. no accounts.
  */
-extern NSString* const GCDWebServerOption_AuthenticationAccounts;
+extern NSString * const GCDWebServerOption_AuthenticationAccounts;
 
 /**
  *  The class used by the GCDWebServer when instantiating GCDWebServerConnection
@@ -173,7 +173,7 @@ extern NSString* const GCDWebServerOption_AuthenticationAccounts;
  *
  *  The default value is the GCDWebServerConnection class.
  */
-extern NSString* const GCDWebServerOption_ConnectionClass;
+extern NSString * const GCDWebServerOption_ConnectionClass;
 
 /**
  *  Allow the GCDWebServer to pretend "HEAD" requests are actually "GET" ones
@@ -181,7 +181,7 @@ extern NSString* const GCDWebServerOption_ConnectionClass;
  *
  *  The default value is YES.
  */
-extern NSString* const GCDWebServerOption_AutomaticallyMapHEADToGET;
+extern NSString * const GCDWebServerOption_AutomaticallyMapHEADToGET;
 
 /**
  *  The interval expressed in seconds used by the GCDWebServer to decide how to
@@ -190,16 +190,16 @@ extern NSString* const GCDWebServerOption_AutomaticallyMapHEADToGET;
  *
  *  The default value is 1.0 second.
  */
-extern NSString* const GCDWebServerOption_ConnectedStateCoalescingInterval;
+extern NSString * const GCDWebServerOption_ConnectedStateCoalescingInterval;
 
 /**
- *  Set the dispatch queue priority on which server connection will be 
+ *  Set the dispatch queue priority on which server connection will be
  *  run (NSNumber / long).
  *
  *
  *  The default value is DISPATCH_QUEUE_PRIORITY_DEFAULT.
  */
-extern NSString* const GCDWebServerOption_DispatchQueuePriority;
+extern NSString * const GCDWebServerOption_DispatchQueuePriority;
 
 #if TARGET_OS_IPHONE
 
@@ -215,7 +215,7 @@ extern NSString* const GCDWebServerOption_DispatchQueuePriority;
  *
  *  @warning The running property will be NO while the GCDWebServer is suspended.
  */
-extern NSString* const GCDWebServerOption_AutomaticallySuspendInBackground;
+extern NSString * const GCDWebServerOption_AutomaticallySuspendInBackground;
 
 #endif
 
@@ -225,12 +225,12 @@ extern NSString* const GCDWebServerOption_AutomaticallySuspendInBackground;
  *  @warning Use of this authentication scheme is not recommended as the
  *  passwords are sent in clear.
  */
-extern NSString* const GCDWebServerAuthenticationMethod_Basic;
+extern NSString * const GCDWebServerAuthenticationMethod_Basic;
 
 /**
  *  HTTP Digest Access Authentication scheme (see https://tools.ietf.org/html/rfc2617).
  */
-extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
+extern NSString * const GCDWebServerAuthenticationMethod_DigestAccess;
 
 @class GCDWebServer;
 
@@ -245,7 +245,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
 /**
  *  This method is called after the server has successfully started.
  */
-- (void)webServerDidStart:(GCDWebServer*)server;
+- (void)webServerDidStart:(GCDWebServer *)server;
 
 /**
  *  This method is called after the Bonjour registration for the server has
@@ -254,7 +254,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  Use the "bonjourServerURL" property to retrieve the Bonjour address of the
  *  server.
  */
-- (void)webServerDidCompleteBonjourRegistration:(GCDWebServer*)server;
+- (void)webServerDidCompleteBonjourRegistration:(GCDWebServer *)server;
 
 /**
  *  This method is called after the NAT port mapping for the server has been
@@ -263,7 +263,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  Use the "publicServerURL" property to retrieve the public address of the
  *  server.
  */
-- (void)webServerDidUpdateNATPortMapping:(GCDWebServer*)server;
+- (void)webServerDidUpdateNATPortMapping:(GCDWebServer *)server;
 
 /**
  *  This method is called when the first GCDWebServerConnection is opened by the
@@ -274,7 +274,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  until before the last HTTP request has been responded to (and the
  *  corresponding last GCDWebServerConnection closed).
  */
-- (void)webServerDidConnect:(GCDWebServer*)server;
+- (void)webServerDidConnect:(GCDWebServer *)server;
 
 /**
  *  This method is called when the last GCDWebServerConnection is closed after
@@ -286,12 +286,12 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  requests). This effectively coalesces the calls to -webServerDidConnect:
  *  and -webServerDidDisconnect:.
  */
-- (void)webServerDidDisconnect:(GCDWebServer*)server;
+- (void)webServerDidDisconnect:(GCDWebServer *)server;
 
 /**
  *  This method is called after the server has stopped.
  */
-- (void)webServerDidStop:(GCDWebServer*)server;
+- (void)webServerDidStop:(GCDWebServer *)server;
 
 @end
 
@@ -311,19 +311,19 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
 /**
  *  Sets the delegate for the server.
  */
-@property(nonatomic, weak, nullable) id<GCDWebServerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<GCDWebServerDelegate> delegate;
 
 /**
  *  Returns YES if the server is currently running.
  */
-@property(nonatomic, readonly, getter=isRunning) BOOL running;
+@property (nonatomic, readonly, getter = isRunning) BOOL running;
 
 /**
  *  Returns the port used by the server.
  *
  *  @warning This property is only valid if the server is running.
  */
-@property(nonatomic, readonly) NSUInteger port;
+@property (nonatomic, readonly) NSUInteger port;
 
 /**
  *  Returns the Bonjour name used by the server.
@@ -331,7 +331,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  @warning This property is only valid if the server is running and Bonjour
  *  registration has successfully completed, which can take up to a few seconds.
  */
-@property(nonatomic, readonly, nullable) NSString* bonjourName;
+@property (nonatomic, readonly, nullable) NSString *bonjourName;
 
 /**
  *  Returns the Bonjour service type used by the server.
@@ -339,7 +339,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  @warning This property is only valid if the server is running and Bonjour
  *  registration has successfully completed, which can take up to a few seconds.
  */
-@property(nonatomic, readonly, nullable) NSString* bonjourType;
+@property (nonatomic, readonly, nullable) NSString *bonjourType;
 
 /**
  *  This method is the designated initializer for the class.
@@ -379,7 +379,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *
  *  Returns NO if the server failed to start and sets "error" argument if not NULL.
  */
-- (BOOL)startWithOptions:(nullable NSDictionary<NSString*, id>*)options error:(NSError** _Nullable)error;
+- (BOOL)startWithOptions:(nullable NSDictionary<NSString *, id> *)options error:(NSError ** _Nullable)error;
 
 /**
  *  Stops the server and prevents it to accepts new HTTP requests.
@@ -399,7 +399,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *
  *  @warning This property is only valid if the server is running.
  */
-@property(nonatomic, readonly, nullable) NSURL* serverURL;
+@property (nonatomic, readonly, nullable) NSURL *serverURL;
 
 /**
  *  Returns the server's Bonjour URL.
@@ -409,7 +409,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  Also be aware this property will not automatically update if the Bonjour hostname
  *  has been dynamically changed after the server started running (this should be rare).
  */
-@property(nonatomic, readonly, nullable) NSURL* bonjourServerURL;
+@property (nonatomic, readonly, nullable) NSURL *bonjourServerURL;
 
 /**
  *  Returns the server's public URL.
@@ -417,7 +417,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  @warning This property is only valid if the server is running and NAT port
  *  mapping is active.
  */
-@property(nonatomic, readonly, nullable) NSURL* publicServerURL;
+@property (nonatomic, readonly, nullable) NSURL *publicServerURL;
 
 /**
  *  Starts the server on port 8080 (OS X & iOS Simulator) or port 80 (iOS)
@@ -434,7 +434,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *
  *  Returns NO if the server failed to start.
  */
-- (BOOL)startWithPort:(NSUInteger)port bonjourName:(nullable NSString*)name;
+- (BOOL)startWithPort:(NSUInteger)port bonjourName:(nullable NSString *)name;
 
 #if !TARGET_OS_IPHONE
 
@@ -447,7 +447,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *
  *  @warning This method must be used from the main thread only.
  */
-- (BOOL)runWithPort:(NSUInteger)port bonjourName:(nullable NSString*)name;
+- (BOOL)runWithPort:(NSUInteger)port bonjourName:(nullable NSString *)name;
 
 /**
  *  Runs the server synchronously using -startWithOptions: until a SIGTERM or
@@ -458,7 +458,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *
  *  @warning This method must be used from the main thread only.
  */
-- (BOOL)runWithOptions:(nullable NSDictionary<NSString*, id>*)options error:(NSError** _Nullable)error;
+- (BOOL)runWithOptions:(nullable NSDictionary<NSString *, id> *)options error:(NSError ** _Nullable)error;
 
 #endif
 
@@ -470,41 +470,41 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  Adds a default handler to the server to handle all incoming HTTP requests
  *  with a given HTTP method and generate responses synchronously.
  */
-- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block;
+- (void)addDefaultHandlerForMethod:(NSString *)method requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block;
 
 /**
  *  Adds a default handler to the server to handle all incoming HTTP requests
  *  with a given HTTP method and generate responses asynchronously.
  */
-- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block;
+- (void)addDefaultHandlerForMethod:(NSString *)method requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block;
 
 /**
  *  Adds a handler to the server to handle incoming HTTP requests with a given
  *  HTTP method and a specific case-insensitive path  and generate responses
  *  synchronously.
  */
-- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block;
+- (void)addHandlerForMethod:(NSString *)method path:(NSString *)path requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block;
 
 /**
  *  Adds a handler to the server to handle incoming HTTP requests with a given
  *  HTTP method and a specific case-insensitive path and generate responses
  *  asynchronously.
  */
-- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block;
+- (void)addHandlerForMethod:(NSString *)method path:(NSString *)path requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block;
 
 /**
  *  Adds a handler to the server to handle incoming HTTP requests with a given
  *  HTTP method and a path matching a case-insensitive regular expression and
  *  generate responses synchronously.
  */
-- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block;
+- (void)addHandlerForMethod:(NSString *)method pathRegex:(NSString *)regex requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block;
 
 /**
  *  Adds a handler to the server to handle incoming HTTP requests with a given
  *  HTTP method and a path matching a case-insensitive regular expression and
  *  generate responses asynchronously.
  */
-- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block;
+- (void)addHandlerForMethod:(NSString *)method pathRegex:(NSString *)regex requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block;
 
 @end
 
@@ -514,13 +514,13 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  Adds a handler to the server to respond to incoming "GET" HTTP requests
  *  with a specific case-insensitive path with in-memory data.
  */
-- (void)addGETHandlerForPath:(NSString*)path staticData:(NSData*)staticData contentType:(nullable NSString*)contentType cacheAge:(NSUInteger)cacheAge;
+- (void)addGETHandlerForPath:(NSString *)path staticData:(NSData *)staticData contentType:(nullable NSString *)contentType cacheAge:(NSUInteger)cacheAge;
 
 /**
  *  Adds a handler to the server to respond to incoming "GET" HTTP requests
  *  with a specific case-insensitive path with a file.
  */
-- (void)addGETHandlerForPath:(NSString*)path filePath:(NSString*)filePath isAttachment:(BOOL)isAttachment cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests;
+- (void)addGETHandlerForPath:(NSString *)path filePath:(NSString *)filePath isAttachment:(BOOL)isAttachment cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests;
 
 /**
  *  Adds a handler to the server to respond to incoming "GET" HTTP requests
@@ -531,7 +531,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  The "indexFilename" argument allows to specify an "index" file name to use
  *  when the request path corresponds to a directory.
  */
-- (void)addGETHandlerForBasePath:(NSString*)basePath directoryPath:(NSString*)directoryPath indexFilename:(nullable NSString*)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests;
+- (void)addGETHandlerForBasePath:(NSString *)basePath directoryPath:(NSString *)directoryPath indexFilename:(nullable NSString *)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests;
 
 @end
 
@@ -598,22 +598,22 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
 /**
  *  Logs a message to the logging facility at the VERBOSE level.
  */
-- (void)logVerbose:(NSString*)format, ... NS_FORMAT_FUNCTION(1, 2);
+- (void)logVerbose:(NSString *)format, ... NS_FORMAT_FUNCTION(1, 2);
 
 /**
  *  Logs a message to the logging facility at the INFO level.
  */
-- (void)logInfo:(NSString*)format, ... NS_FORMAT_FUNCTION(1, 2);
+- (void)logInfo:(NSString *)format, ... NS_FORMAT_FUNCTION(1, 2);
 
 /**
  *  Logs a message to the logging facility at the WARNING level.
  */
-- (void)logWarning:(NSString*)format, ... NS_FORMAT_FUNCTION(1, 2);
+- (void)logWarning:(NSString *)format, ... NS_FORMAT_FUNCTION(1, 2);
 
 /**
  *  Logs a message to the logging facility at the ERROR level.
  */
-- (void)logError:(NSString*)format, ... NS_FORMAT_FUNCTION(1, 2);
+- (void)logError:(NSString *)format, ... NS_FORMAT_FUNCTION(1, 2);
 
 @end
 
@@ -627,7 +627,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *
  *  @warning The current directory must not contain any prior recording files.
  */
-@property(nonatomic, getter=isRecordingEnabled) BOOL recordingEnabled;
+@property (nonatomic, getter = isRecordingEnabled) BOOL recordingEnabled;
 
 /**
  *  Runs tests by playing back pre-recorded HTTP requests in the given directory
@@ -635,7 +635,7 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *
  *  Returns the number of failed tests or -1 if server failed to start.
  */
-- (NSInteger)runTestsWithOptions:(nullable NSDictionary<NSString*, id>*)options inDirectory:(NSString*)path;
+- (NSInteger)runTestsWithOptions:(nullable NSDictionary<NSString *, id> *)options inDirectory:(NSString *)path;
 
 @end
 

--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -43,34 +43,34 @@
 #import "GCDWebServerPrivate.h"
 
 #if TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
-#define kDefaultPort 80
+#define kDefaultPort              80
 #else
-#define kDefaultPort 8080
+#define kDefaultPort              8080
 #endif
 
 #define kBonjourResolutionTimeout 5.0
 
-NSString* const GCDWebServerOption_Port = @"Port";
-NSString* const GCDWebServerOption_BonjourName = @"BonjourName";
-NSString* const GCDWebServerOption_BonjourType = @"BonjourType";
-NSString* const GCDWebServerOption_BonjourTXTData = @"BonjourTXTData";
-NSString* const GCDWebServerOption_RequestNATPortMapping = @"RequestNATPortMapping";
-NSString* const GCDWebServerOption_BindToLocalhost = @"BindToLocalhost";
-NSString* const GCDWebServerOption_MaxPendingConnections = @"MaxPendingConnections";
-NSString* const GCDWebServerOption_ServerName = @"ServerName";
-NSString* const GCDWebServerOption_AuthenticationMethod = @"AuthenticationMethod";
-NSString* const GCDWebServerOption_AuthenticationRealm = @"AuthenticationRealm";
-NSString* const GCDWebServerOption_AuthenticationAccounts = @"AuthenticationAccounts";
-NSString* const GCDWebServerOption_ConnectionClass = @"ConnectionClass";
-NSString* const GCDWebServerOption_AutomaticallyMapHEADToGET = @"AutomaticallyMapHEADToGET";
-NSString* const GCDWebServerOption_ConnectedStateCoalescingInterval = @"ConnectedStateCoalescingInterval";
-NSString* const GCDWebServerOption_DispatchQueuePriority = @"DispatchQueuePriority";
+NSString * const GCDWebServerOption_Port = @"Port";
+NSString * const GCDWebServerOption_BonjourName = @"BonjourName";
+NSString * const GCDWebServerOption_BonjourType = @"BonjourType";
+NSString * const GCDWebServerOption_BonjourTXTData = @"BonjourTXTData";
+NSString * const GCDWebServerOption_RequestNATPortMapping = @"RequestNATPortMapping";
+NSString * const GCDWebServerOption_BindToLocalhost = @"BindToLocalhost";
+NSString * const GCDWebServerOption_MaxPendingConnections = @"MaxPendingConnections";
+NSString * const GCDWebServerOption_ServerName = @"ServerName";
+NSString * const GCDWebServerOption_AuthenticationMethod = @"AuthenticationMethod";
+NSString * const GCDWebServerOption_AuthenticationRealm = @"AuthenticationRealm";
+NSString * const GCDWebServerOption_AuthenticationAccounts = @"AuthenticationAccounts";
+NSString * const GCDWebServerOption_ConnectionClass = @"ConnectionClass";
+NSString * const GCDWebServerOption_AutomaticallyMapHEADToGET = @"AutomaticallyMapHEADToGET";
+NSString * const GCDWebServerOption_ConnectedStateCoalescingInterval = @"ConnectedStateCoalescingInterval";
+NSString * const GCDWebServerOption_DispatchQueuePriority = @"DispatchQueuePriority";
 #if TARGET_OS_IPHONE
-NSString* const GCDWebServerOption_AutomaticallySuspendInBackground = @"AutomaticallySuspendInBackground";
+NSString * const GCDWebServerOption_AutomaticallySuspendInBackground = @"AutomaticallySuspendInBackground";
 #endif
 
-NSString* const GCDWebServerAuthenticationMethod_Basic = @"Basic";
-NSString* const GCDWebServerAuthenticationMethod_DigestAccess = @"DigestAccess";
+NSString * const GCDWebServerAuthenticationMethod_Basic = @"Basic";
+NSString * const GCDWebServerAuthenticationMethod_DigestAccess = @"DigestAccess";
 
 #if defined(__GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__)
 #if DEBUG
@@ -88,32 +88,37 @@ static BOOL _run;
 
 static GCDWebServerBuiltInLoggerBlock _builtInLoggerBlock;
 
-void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* format, ...) {
-  static const char* levelNames[] = {"DEBUG", "VERBOSE", "INFO", "WARNING", "ERROR"};
-  static int enableLogging = -1;
-  if (enableLogging < 0) {
-    enableLogging = (isatty(STDERR_FILENO) ? 1 : 0);
-  }
-  if (_builtInLoggerBlock || enableLogging) {
-    va_list arguments;
-    va_start(arguments, format);
-    NSString* message = [[NSString alloc] initWithFormat:format arguments:arguments];
-    va_end(arguments);
-    if (_builtInLoggerBlock) {
-      _builtInLoggerBlock(level, message);
-    } else {
-      fprintf(stderr, "[%s] %s\n", levelNames[level], [message UTF8String]);
+void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString *format, ...) {
+    static const char *levelNames[] = {
+        "DEBUG", "VERBOSE", "INFO", "WARNING", "ERROR"
+    };
+    static int enableLogging = -1;
+
+    if (enableLogging < 0) {
+        enableLogging = (isatty(STDERR_FILENO) ? 1 : 0);
     }
-  }
+
+    if (_builtInLoggerBlock || enableLogging) {
+        va_list arguments;
+        va_start(arguments, format);
+        NSString *message = [[NSString alloc] initWithFormat:format arguments:arguments];
+        va_end(arguments);
+
+        if (_builtInLoggerBlock) {
+            _builtInLoggerBlock(level, message);
+        } else {
+            fprintf(stderr, "[%s] %s\n", levelNames[level], [message UTF8String]);
+        }
+    }
 }
 
-#endif
+#endif /* ifdef __GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__ */
 
 #if !TARGET_OS_IPHONE
 
 static void _SignalHandler(int signal) {
-  _run = NO;
-  printf("\n");
+    _run = NO;
+    printf("\n");
 }
 
 #endif
@@ -125,10 +130,11 @@ static void _SignalHandler(int signal) {
 // The main queue works with the application’s run loop to interleave the execution of queued tasks with the execution of other event sources attached to the run loop
 // TODO: Ensure all scheduled blocks on the main queue are also executed
 static void _ExecuteMainThreadRunLoopSources(void) {
-  SInt32 result;
-  do {
-    result = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
-  } while (result == kCFRunLoopRunHandledSource);
+    SInt32 result;
+
+    do {
+        result = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
+    } while (result == kCFRunLoopRunHandledSource);
 }
 
 #endif
@@ -136,72 +142,75 @@ static void _ExecuteMainThreadRunLoopSources(void) {
 @implementation GCDWebServerHandler
 
 - (instancetype)initWithMatchBlock:(GCDWebServerMatchBlock _Nonnull)matchBlock asyncProcessBlock:(GCDWebServerAsyncProcessBlock _Nonnull)processBlock {
-  if ((self = [super init])) {
-    _matchBlock = [matchBlock copy];
-    _asyncProcessBlock = [processBlock copy];
-  }
-  return self;
+    if ((self = [super init])) {
+        _matchBlock = [matchBlock copy];
+        _asyncProcessBlock = [processBlock copy];
+    }
+
+    return self;
 }
 
 @end
 
 @implementation GCDWebServer {
-  dispatch_queue_t _syncQueue;
-  dispatch_group_t _sourceGroup;
-  NSMutableArray<GCDWebServerHandler*>* _handlers;
-  NSInteger _activeConnections;  // Accessed through _syncQueue only
-  BOOL _connected;  // Accessed on main thread only
-  CFRunLoopTimerRef _disconnectTimer;  // Accessed on main thread only
+    dispatch_queue_t _syncQueue;
+    dispatch_group_t _sourceGroup;
+    NSMutableArray<GCDWebServerHandler *> *_handlers;
+    NSInteger _activeConnections; // Accessed through _syncQueue only
+    BOOL _connected; // Accessed on main thread only
+    CFRunLoopTimerRef _disconnectTimer; // Accessed on main thread only
 
-  NSDictionary<NSString*, id>* _options;
-  NSMutableDictionary<NSString*, NSString*>* _authenticationBasicAccounts;
-  NSMutableDictionary<NSString*, NSString*>* _authenticationDigestAccounts;
-  Class _connectionClass;
-  CFTimeInterval _disconnectDelay;
-  dispatch_source_t _source4;
-  dispatch_source_t _source6;
-  CFNetServiceRef _registrationService;
-  CFNetServiceRef _resolutionService;
-  DNSServiceRef _dnsService;
-  CFSocketRef _dnsSocket;
-  CFRunLoopSourceRef _dnsSource;
-  NSString* _dnsAddress;
-  NSUInteger _dnsPort;
-  BOOL _bindToLocalhost;
+    NSDictionary<NSString *, id> *_options;
+    NSMutableDictionary<NSString *, NSString *> *_authenticationBasicAccounts;
+    NSMutableDictionary<NSString *, NSString *> *_authenticationDigestAccounts;
+    Class _connectionClass;
+    CFTimeInterval _disconnectDelay;
+    dispatch_source_t _source4;
+    dispatch_source_t _source6;
+    CFNetServiceRef _registrationService;
+    CFNetServiceRef _resolutionService;
+    DNSServiceRef _dnsService;
+    CFSocketRef _dnsSocket;
+    CFRunLoopSourceRef _dnsSource;
+    NSString *_dnsAddress;
+    NSUInteger _dnsPort;
+    BOOL _bindToLocalhost;
+
 #if TARGET_OS_IPHONE
-  BOOL _suspendInBackground;
-  UIBackgroundTaskIdentifier _backgroundTask;
+    BOOL _suspendInBackground;
+    UIBackgroundTaskIdentifier _backgroundTask;
 #endif
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
-  BOOL _recording;
+    BOOL _recording;
 #endif
 }
 
 + (void)initialize {
-  GCDWebServerInitializeFunctions();
+    GCDWebServerInitializeFunctions();
 }
 
 - (instancetype)init {
-  if ((self = [super init])) {
-    _syncQueue = dispatch_queue_create([NSStringFromClass([self class]) UTF8String], DISPATCH_QUEUE_SERIAL);
-    _sourceGroup = dispatch_group_create();
-    _handlers = [[NSMutableArray alloc] init];
+    if ((self = [super init])) {
+        _syncQueue = dispatch_queue_create([NSStringFromClass([self class]) UTF8String], DISPATCH_QUEUE_SERIAL);
+        _sourceGroup = dispatch_group_create();
+        _handlers = [[NSMutableArray alloc] init];
 #if TARGET_OS_IPHONE
-    _backgroundTask = UIBackgroundTaskInvalid;
+        _backgroundTask = UIBackgroundTaskInvalid;
 #endif
-  }
-  return self;
+    }
+
+    return self;
 }
 
 - (void)dealloc {
-  GWS_DCHECK(_connected == NO);
-  GWS_DCHECK(_activeConnections == 0);
-  GWS_DCHECK(_options == nil);  // The server can never be dealloc'ed while running because of the retain-cycle with the dispatch source
-  GWS_DCHECK(_disconnectTimer == NULL);  // The server can never be dealloc'ed while the disconnect timer is pending because of the retain-cycle
+    GWS_DCHECK(_connected == NO);
+    GWS_DCHECK(_activeConnections == 0);
+    GWS_DCHECK(_options == nil); // The server can never be dealloc'ed while running because of the retain-cycle with the dispatch source
+    GWS_DCHECK(_disconnectTimer == NULL); // The server can never be dealloc'ed while the disconnect timer is pending because of the retain-cycle
 
 #if !OS_OBJECT_USE_OBJC_RETAIN_RELEASE
-  dispatch_release(_sourceGroup);
-  dispatch_release(_syncQueue);
+    dispatch_release(_sourceGroup);
+    dispatch_release(_syncQueue);
 #endif
 }
 
@@ -209,889 +218,992 @@ static void _ExecuteMainThreadRunLoopSources(void) {
 
 // Always called on main thread
 - (void)_startBackgroundTask {
-  GWS_DCHECK([NSThread isMainThread]);
-  if (_backgroundTask == UIBackgroundTaskInvalid) {
-    GWS_LOG_DEBUG(@"Did start background task");
-    _backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-      GWS_LOG_WARNING(@"Application is being suspended while %@ is still connected", [self class]);
-      [self _endBackgroundTask];
-    }];
-  } else {
-    GWS_DNOT_REACHED();
-  }
+    GWS_DCHECK([NSThread isMainThread]);
+
+    if (_backgroundTask == UIBackgroundTaskInvalid) {
+        GWS_LOG_DEBUG(@"Did start background task");
+        _backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+                                                                 GWS_LOG_WARNING(@"Application is being suspended while %@ is still connected", [self class]);
+                                                                 [self _endBackgroundTask];
+                                                             }];
+    } else {
+        GWS_DNOT_REACHED();
+    }
 }
 
 #endif
 
 // Always called on main thread
 - (void)_didConnect {
-  GWS_DCHECK([NSThread isMainThread]);
-  GWS_DCHECK(_connected == NO);
-  _connected = YES;
-  GWS_LOG_DEBUG(@"Did connect");
+    GWS_DCHECK([NSThread isMainThread]);
+    GWS_DCHECK(_connected == NO);
+    _connected = YES;
+    GWS_LOG_DEBUG(@"Did connect");
 
 #if TARGET_OS_IPHONE
-  if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground) {
-    [self _startBackgroundTask];
-  }
+
+    if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground) {
+        [self _startBackgroundTask];
+    }
+
 #endif
 
-  if ([_delegate respondsToSelector:@selector(webServerDidConnect:)]) {
-    [_delegate webServerDidConnect:self];
-  }
+    if ([_delegate respondsToSelector:@selector(webServerDidConnect:)]) {
+        [_delegate webServerDidConnect:self];
+    }
 }
 
-- (void)willStartConnection:(GCDWebServerConnection*)connection {
-  dispatch_sync(_syncQueue, ^{
-    GWS_DCHECK(self->_activeConnections >= 0);
-    if (self->_activeConnections == 0) {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if (self->_disconnectTimer) {
-          CFRunLoopTimerInvalidate(self->_disconnectTimer);
-          CFRelease(self->_disconnectTimer);
-          self->_disconnectTimer = NULL;
+- (void)willStartConnection:(GCDWebServerConnection *)connection {
+    dispatch_sync(_syncQueue, ^{
+        GWS_DCHECK(self->_activeConnections >= 0);
+
+        if (self->_activeConnections == 0) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (self->_disconnectTimer) {
+                    CFRunLoopTimerInvalidate(self->_disconnectTimer);
+                    CFRelease(self->_disconnectTimer);
+                    self->_disconnectTimer = NULL;
+                }
+
+                if (self->_connected == NO) {
+                    [self _didConnect];
+                }
+            });
         }
-        if (self->_connected == NO) {
-          [self _didConnect];
-        }
-      });
-    }
-    self->_activeConnections += 1;
-  });
+
+        self->_activeConnections += 1;
+    });
 }
 
 #if TARGET_OS_IPHONE
 
 // Always called on main thread
 - (void)_endBackgroundTask {
-  GWS_DCHECK([NSThread isMainThread]);
-  if (_backgroundTask != UIBackgroundTaskInvalid) {
-    if (_suspendInBackground && ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) && _source4) {
-      [self _stop];
+    GWS_DCHECK([NSThread isMainThread]);
+
+    if (_backgroundTask != UIBackgroundTaskInvalid) {
+        if (_suspendInBackground && ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) && _source4) {
+            [self _stop];
+        }
+
+        [[UIApplication sharedApplication] endBackgroundTask:_backgroundTask];
+        _backgroundTask = UIBackgroundTaskInvalid;
+        GWS_LOG_DEBUG(@"Did end background task");
     }
-    [[UIApplication sharedApplication] endBackgroundTask:_backgroundTask];
-    _backgroundTask = UIBackgroundTaskInvalid;
-    GWS_LOG_DEBUG(@"Did end background task");
-  }
 }
 
 #endif
 
 // Always called on main thread
 - (void)_didDisconnect {
-  GWS_DCHECK([NSThread isMainThread]);
-  GWS_DCHECK(_connected == YES);
-  _connected = NO;
-  GWS_LOG_DEBUG(@"Did disconnect");
+    GWS_DCHECK([NSThread isMainThread]);
+    GWS_DCHECK(_connected == YES);
+    _connected = NO;
+    GWS_LOG_DEBUG(@"Did disconnect");
 
 #if TARGET_OS_IPHONE
-  [self _endBackgroundTask];
+    [self _endBackgroundTask];
 #endif
 
-  if ([_delegate respondsToSelector:@selector(webServerDidDisconnect:)]) {
-    [_delegate webServerDidDisconnect:self];
-  }
-}
-
-- (void)didEndConnection:(GCDWebServerConnection*)connection {
-  dispatch_sync(_syncQueue, ^{
-    GWS_DCHECK(self->_activeConnections > 0);
-    self->_activeConnections -= 1;
-    if (self->_activeConnections == 0) {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if ((self->_disconnectDelay > 0.0) && (self->_source4 != NULL)) {
-          if (self->_disconnectTimer) {
-            CFRunLoopTimerInvalidate(self->_disconnectTimer);
-            CFRelease(self->_disconnectTimer);
-          }
-          self->_disconnectTimer = CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + self->_disconnectDelay, 0.0, 0, 0, ^(CFRunLoopTimerRef timer) {
-            GWS_DCHECK([NSThread isMainThread]);
-            [self _didDisconnect];
-            CFRelease(self->_disconnectTimer);
-            self->_disconnectTimer = NULL;
-          });
-          CFRunLoopAddTimer(CFRunLoopGetMain(), self->_disconnectTimer, kCFRunLoopCommonModes);
-        } else {
-          [self _didDisconnect];
-        }
-      });
+    if ([_delegate respondsToSelector:@selector(webServerDidDisconnect:)]) {
+        [_delegate webServerDidDisconnect:self];
     }
-  });
 }
 
-- (NSString*)bonjourName {
-  CFStringRef name = _resolutionService ? CFNetServiceGetName(_resolutionService) : NULL;
-  return name && CFStringGetLength(name) ? CFBridgingRelease(CFStringCreateCopy(kCFAllocatorDefault, name)) : nil;
+- (void)didEndConnection:(GCDWebServerConnection *)connection {
+    dispatch_sync(_syncQueue, ^{
+        GWS_DCHECK(self->_activeConnections > 0);
+        self->_activeConnections -= 1;
+
+        if (self->_activeConnections == 0) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if ((self->_disconnectDelay > 0.0) && (self->_source4 != NULL)) {
+                    if (self->_disconnectTimer) {
+                        CFRunLoopTimerInvalidate(self->_disconnectTimer);
+                        CFRelease(self->_disconnectTimer);
+                    }
+
+                    self->_disconnectTimer = CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + self->_disconnectDelay, 0.0, 0, 0, ^(CFRunLoopTimerRef timer) {
+                        GWS_DCHECK([NSThread isMainThread]);
+                        [self _didDisconnect];
+                        CFRelease(self->_disconnectTimer);
+                        self->_disconnectTimer = NULL;
+                    });
+                    CFRunLoopAddTimer(CFRunLoopGetMain(), self->_disconnectTimer, kCFRunLoopCommonModes);
+                } else {
+                    [self _didDisconnect];
+                }
+            });
+        }
+    });
 }
 
-- (NSString*)bonjourType {
-  CFStringRef type = _resolutionService ? CFNetServiceGetType(_resolutionService) : NULL;
-  return type && CFStringGetLength(type) ? CFBridgingRelease(CFStringCreateCopy(kCFAllocatorDefault, type)) : nil;
+- (NSString *)bonjourName {
+    CFStringRef name = _resolutionService ? CFNetServiceGetName(_resolutionService) : NULL;
+
+    return name && CFStringGetLength(name) ? CFBridgingRelease(CFStringCreateCopy(kCFAllocatorDefault, name)) : nil;
+}
+
+- (NSString *)bonjourType {
+    CFStringRef type = _resolutionService ? CFNetServiceGetType(_resolutionService) : NULL;
+
+    return type && CFStringGetLength(type) ? CFBridgingRelease(CFStringCreateCopy(kCFAllocatorDefault, type)) : nil;
 }
 
 - (void)addHandlerWithMatchBlock:(GCDWebServerMatchBlock)matchBlock processBlock:(GCDWebServerProcessBlock)processBlock {
-  [self addHandlerWithMatchBlock:matchBlock
-               asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock) {
-                 completionBlock(processBlock(request));
-               }];
+    [self addHandlerWithMatchBlock:matchBlock
+                 asyncProcessBlock:^(GCDWebServerRequest *request, GCDWebServerCompletionBlock completionBlock) {
+                     completionBlock(processBlock(request));
+                 }];
 }
 
 - (void)addHandlerWithMatchBlock:(GCDWebServerMatchBlock)matchBlock asyncProcessBlock:(GCDWebServerAsyncProcessBlock)processBlock {
-  GWS_DCHECK(_options == nil);
-  GCDWebServerHandler* handler = [[GCDWebServerHandler alloc] initWithMatchBlock:matchBlock asyncProcessBlock:processBlock];
-  [_handlers insertObject:handler atIndex:0];
+    GWS_DCHECK(_options == nil);
+    GCDWebServerHandler *handler = [[GCDWebServerHandler alloc] initWithMatchBlock:matchBlock asyncProcessBlock:processBlock];
+    [_handlers insertObject:handler atIndex:0];
 }
 
 - (void)removeAllHandlers {
-  GWS_DCHECK(_options == nil);
-  [_handlers removeAllObjects];
+    GWS_DCHECK(_options == nil);
+    [_handlers removeAllObjects];
 }
 
-static void _NetServiceRegisterCallBack(CFNetServiceRef service, CFStreamError* error, void* info) {
-  GWS_DCHECK([NSThread isMainThread]);
-  @autoreleasepool {
-    if (error->error) {
-      GWS_LOG_ERROR(@"Bonjour registration error %i (domain %i)", (int)error->error, (int)error->domain);
-    } else {
-      GCDWebServer* server = (__bridge GCDWebServer*)info;
-      GWS_LOG_VERBOSE(@"Bonjour registration complete for %@", [server class]);
-      if (!CFNetServiceResolveWithTimeout(server->_resolutionService, kBonjourResolutionTimeout, NULL)) {
-        GWS_LOG_ERROR(@"Failed starting Bonjour resolution");
-        GWS_DNOT_REACHED();
-      }
+static void _NetServiceRegisterCallBack(CFNetServiceRef service, CFStreamError *error, void *info) {
+    GWS_DCHECK([NSThread isMainThread]);
+    @autoreleasepool {
+        if (error->error) {
+            GWS_LOG_ERROR(@"Bonjour registration error %i (domain %i)", (int)error->error, (int)error->domain);
+        } else {
+            GCDWebServer *server = (__bridge GCDWebServer *)info;
+            GWS_LOG_VERBOSE(@"Bonjour registration complete for %@", [server class]);
+
+            if (!CFNetServiceResolveWithTimeout(server->_resolutionService, kBonjourResolutionTimeout, NULL)) {
+                GWS_LOG_ERROR(@"Failed starting Bonjour resolution");
+                GWS_DNOT_REACHED();
+            }
+        }
     }
-  }
 }
 
-static void _NetServiceResolveCallBack(CFNetServiceRef service, CFStreamError* error, void* info) {
-  GWS_DCHECK([NSThread isMainThread]);
-  @autoreleasepool {
-    if (error->error) {
-      if ((error->domain != kCFStreamErrorDomainNetServices) && (error->error != kCFNetServicesErrorTimeout)) {
-        GWS_LOG_ERROR(@"Bonjour resolution error %i (domain %i)", (int)error->error, (int)error->domain);
-      }
-    } else {
-      GCDWebServer* server = (__bridge GCDWebServer*)info;
-      GWS_LOG_INFO(@"%@ now locally reachable at %@", [server class], server.bonjourServerURL);
-      if ([server.delegate respondsToSelector:@selector(webServerDidCompleteBonjourRegistration:)]) {
-        [server.delegate webServerDidCompleteBonjourRegistration:server];
-      }
+static void _NetServiceResolveCallBack(CFNetServiceRef service, CFStreamError *error, void *info) {
+    GWS_DCHECK([NSThread isMainThread]);
+    @autoreleasepool {
+        if (error->error) {
+            if ((error->domain != kCFStreamErrorDomainNetServices) && (error->error != kCFNetServicesErrorTimeout)) {
+                GWS_LOG_ERROR(@"Bonjour resolution error %i (domain %i)", (int)error->error, (int)error->domain);
+            }
+        } else {
+            GCDWebServer *server = (__bridge GCDWebServer *)info;
+            GWS_LOG_INFO(@"%@ now locally reachable at %@", [server class], server.bonjourServerURL);
+
+            if ([server.delegate respondsToSelector:@selector(webServerDidCompleteBonjourRegistration:)]) {
+                [server.delegate webServerDidCompleteBonjourRegistration:server];
+            }
+        }
     }
-  }
 }
 
-static void _DNSServiceCallBack(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t interfaceIndex, DNSServiceErrorType errorCode, uint32_t externalAddress, DNSServiceProtocol protocol, uint16_t internalPort, uint16_t externalPort, uint32_t ttl, void* context) {
-  GWS_DCHECK([NSThread isMainThread]);
-  @autoreleasepool {
-    GCDWebServer* server = (__bridge GCDWebServer*)context;
-    if ((errorCode == kDNSServiceErr_NoError) || (errorCode == kDNSServiceErr_DoubleNAT)) {
-      struct sockaddr_in addr4;
-      bzero(&addr4, sizeof(addr4));
-      addr4.sin_len = sizeof(addr4);
-      addr4.sin_family = AF_INET;
-      addr4.sin_addr.s_addr = externalAddress;  // Already in network byte order
-      server->_dnsAddress = GCDWebServerStringFromSockAddr((const struct sockaddr*)&addr4, NO);
-      server->_dnsPort = ntohs(externalPort);
-      GWS_LOG_INFO(@"%@ now publicly reachable at %@", [server class], server.publicServerURL);
-    } else {
-      GWS_LOG_ERROR(@"DNS service error %i", errorCode);
-      server->_dnsAddress = nil;
-      server->_dnsPort = 0;
+static void _DNSServiceCallBack(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t interfaceIndex, DNSServiceErrorType errorCode, uint32_t externalAddress, DNSServiceProtocol protocol, uint16_t internalPort, uint16_t externalPort, uint32_t ttl, void *context) {
+    GWS_DCHECK([NSThread isMainThread]);
+    @autoreleasepool {
+        GCDWebServer *server = (__bridge GCDWebServer *)context;
+
+        if ((errorCode == kDNSServiceErr_NoError) || (errorCode == kDNSServiceErr_DoubleNAT)) {
+            struct sockaddr_in addr4;
+            bzero(&addr4, sizeof(addr4));
+            addr4.sin_len = sizeof(addr4);
+            addr4.sin_family = AF_INET;
+            addr4.sin_addr.s_addr = externalAddress; // Already in network byte order
+            server->_dnsAddress = GCDWebServerStringFromSockAddr((const struct sockaddr *)&addr4, NO);
+            server->_dnsPort = ntohs(externalPort);
+            GWS_LOG_INFO(@"%@ now publicly reachable at %@", [server class], server.publicServerURL);
+        } else {
+            GWS_LOG_ERROR(@"DNS service error %i", errorCode);
+            server->_dnsAddress = nil;
+            server->_dnsPort = 0;
+        }
+
+        if ([server.delegate respondsToSelector:@selector(webServerDidUpdateNATPortMapping:)]) {
+            [server.delegate webServerDidUpdateNATPortMapping:server];
+        }
     }
-    if ([server.delegate respondsToSelector:@selector(webServerDidUpdateNATPortMapping:)]) {
-      [server.delegate webServerDidUpdateNATPortMapping:server];
+}
+
+static void _SocketCallBack(CFSocketRef s, CFSocketCallBackType type, CFDataRef address, const void *data, void *info) {
+    GWS_DCHECK([NSThread isMainThread]);
+    @autoreleasepool {
+        GCDWebServer *server = (__bridge GCDWebServer *)info;
+        DNSServiceErrorType status = DNSServiceProcessResult(server->_dnsService);
+
+        if (status != kDNSServiceErr_NoError) {
+            GWS_LOG_ERROR(@"DNS service error %i", status);
+        }
     }
-  }
 }
 
-static void _SocketCallBack(CFSocketRef s, CFSocketCallBackType type, CFDataRef address, const void* data, void* info) {
-  GWS_DCHECK([NSThread isMainThread]);
-  @autoreleasepool {
-    GCDWebServer* server = (__bridge GCDWebServer*)info;
-    DNSServiceErrorType status = DNSServiceProcessResult(server->_dnsService);
-    if (status != kDNSServiceErr_NoError) {
-      GWS_LOG_ERROR(@"DNS service error %i", status);
-    }
-  }
+static inline id _GetOption(NSDictionary<NSString *, id> *options, NSString *key, id defaultValue) {
+    id value = [options objectForKey:key];
+
+    return value ? value : defaultValue;
 }
 
-static inline id _GetOption(NSDictionary<NSString*, id>* options, NSString* key, id defaultValue) {
-  id value = [options objectForKey:key];
-  return value ? value : defaultValue;
-}
+static inline NSString * _EncodeBase64(NSString *string) {
+    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
 
-static inline NSString* _EncodeBase64(NSString* string) {
-  NSData* data = [string dataUsingEncoding:NSUTF8StringEncoding];
 #if TARGET_OS_IPHONE || (__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9)
-  return [[NSString alloc] initWithData:[data base64EncodedDataWithOptions:0] encoding:NSASCIIStringEncoding];
-#else
-  if (@available(macOS 10.9, *)) {
     return [[NSString alloc] initWithData:[data base64EncodedDataWithOptions:0] encoding:NSASCIIStringEncoding];
-  }
-  return [data base64Encoding];
+
+#else
+
+    if (@available(macOS 10.9, *)) {
+        return [[NSString alloc] initWithData:[data base64EncodedDataWithOptions:0] encoding:NSASCIIStringEncoding];
+    }
+
+    return [data base64Encoding];
+
 #endif
 }
 
 - (int)_createListeningSocket:(BOOL)useIPv6
-                 localAddress:(const void*)address
+                 localAddress:(const void *)address
                        length:(socklen_t)length
         maxPendingConnections:(NSUInteger)maxPendingConnections
-                        error:(NSError**)error {
-  int listeningSocket = socket(useIPv6 ? PF_INET6 : PF_INET, SOCK_STREAM, IPPROTO_TCP);
-  if (listeningSocket > 0) {
-    int yes = 1;
-    setsockopt(listeningSocket, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+                        error:(NSError **)error {
+    int listeningSocket = socket(useIPv6 ? PF_INET6 : PF_INET, SOCK_STREAM, IPPROTO_TCP);
 
-    if (bind(listeningSocket, address, length) == 0) {
-      if (listen(listeningSocket, (int)maxPendingConnections) == 0) {
-        GWS_LOG_DEBUG(@"Did open %s listening socket %i", useIPv6 ? "IPv6" : "IPv4", listeningSocket);
-        return listeningSocket;
-      } else {
-        if (error) {
-          *error = GCDWebServerMakePosixError(errno);
+    if (listeningSocket > 0) {
+        int yes = 1;
+        setsockopt(listeningSocket, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+        if (bind(listeningSocket, address, length) == 0) {
+            if (listen(listeningSocket, (int)maxPendingConnections) == 0) {
+                GWS_LOG_DEBUG(@"Did open %s listening socket %i", useIPv6 ? "IPv6" : "IPv4", listeningSocket);
+                return listeningSocket;
+            } else {
+                if (error) {
+                    *error = GCDWebServerMakePosixError(errno);
+                }
+
+                GWS_LOG_ERROR(@"Failed starting %s listening socket: %s (%i)", useIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+                close(listeningSocket);
+            }
+        } else {
+            if (error) {
+                *error = GCDWebServerMakePosixError(errno);
+            }
+
+            GWS_LOG_ERROR(@"Failed binding %s listening socket: %s (%i)", useIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+            close(listeningSocket);
         }
-        GWS_LOG_ERROR(@"Failed starting %s listening socket: %s (%i)", useIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
-        close(listeningSocket);
-      }
     } else {
-      if (error) {
-        *error = GCDWebServerMakePosixError(errno);
-      }
-      GWS_LOG_ERROR(@"Failed binding %s listening socket: %s (%i)", useIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
-      close(listeningSocket);
+        if (error) {
+            *error = GCDWebServerMakePosixError(errno);
+        }
+
+        GWS_LOG_ERROR(@"Failed creating %s listening socket: %s (%i)", useIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
     }
 
-  } else {
-    if (error) {
-      *error = GCDWebServerMakePosixError(errno);
-    }
-    GWS_LOG_ERROR(@"Failed creating %s listening socket: %s (%i)", useIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
-  }
-  return -1;
+    return -1;
 }
 
 - (dispatch_source_t)_createDispatchSourceWithListeningSocket:(int)listeningSocket isIPv6:(BOOL)isIPv6 {
-  dispatch_group_enter(_sourceGroup);
-  dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, listeningSocket, 0, dispatch_get_global_queue(_dispatchQueuePriority, 0));
-  dispatch_source_set_cancel_handler(source, ^{
-    @autoreleasepool {
-      int result = close(listeningSocket);
-      if (result != 0) {
-        GWS_LOG_ERROR(@"Failed closing %s listening socket: %s (%i)", isIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
-      } else {
-        GWS_LOG_DEBUG(@"Did close %s listening socket %i", isIPv6 ? "IPv6" : "IPv4", listeningSocket);
-      }
-    }
-    dispatch_group_leave(self->_sourceGroup);
-  });
-  dispatch_source_set_event_handler(source, ^{
-    @autoreleasepool {
-      struct sockaddr_storage remoteSockAddr;
-      socklen_t remoteAddrLen = sizeof(remoteSockAddr);
-      int socket = accept(listeningSocket, (struct sockaddr*)&remoteSockAddr, &remoteAddrLen);
-      if (socket > 0) {
-        NSData* remoteAddress = [NSData dataWithBytes:&remoteSockAddr length:remoteAddrLen];
+    dispatch_group_enter(_sourceGroup);
+    dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, listeningSocket, 0, dispatch_get_global_queue(_dispatchQueuePriority, 0));
+    dispatch_source_set_cancel_handler(source, ^{
+        @autoreleasepool {
+            int result = close(listeningSocket);
 
-        struct sockaddr_storage localSockAddr;
-        socklen_t localAddrLen = sizeof(localSockAddr);
-        NSData* localAddress = nil;
-        if (getsockname(socket, (struct sockaddr*)&localSockAddr, &localAddrLen) == 0) {
-          localAddress = [NSData dataWithBytes:&localSockAddr length:localAddrLen];
-          GWS_DCHECK((!isIPv6 && localSockAddr.ss_family == AF_INET) || (isIPv6 && localSockAddr.ss_family == AF_INET6));
-        } else {
-          GWS_DNOT_REACHED();
+            if (result != 0) {
+                GWS_LOG_ERROR(@"Failed closing %s listening socket: %s (%i)", isIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+            } else {
+                GWS_LOG_DEBUG(@"Did close %s listening socket %i", isIPv6 ? "IPv6" : "IPv4", listeningSocket);
+            }
         }
+        dispatch_group_leave(self->_sourceGroup);
+    });
+    dispatch_source_set_event_handler(source, ^{
+        @autoreleasepool {
+            struct sockaddr_storage remoteSockAddr;
+            socklen_t remoteAddrLen = sizeof(remoteSockAddr);
+            int socket = accept(listeningSocket, (struct sockaddr *)&remoteSockAddr, &remoteAddrLen);
 
-        int noSigPipe = 1;
-        setsockopt(socket, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe));  // Make sure this socket cannot generate SIG_PIPE
+            if (socket > 0) {
+                NSData *remoteAddress = [NSData dataWithBytes:&remoteSockAddr length:remoteAddrLen];
 
-        GCDWebServerConnection* connection = [(GCDWebServerConnection*)[self->_connectionClass alloc] initWithServer:self localAddress:localAddress remoteAddress:remoteAddress socket:socket];  // Connection will automatically retain itself while opened
-        [connection self];  // Prevent compiler from complaining about unused variable / useless statement
-      } else {
-        GWS_LOG_ERROR(@"Failed accepting %s socket: %s (%i)", isIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
-      }
-    }
-  });
-  return source;
+                struct sockaddr_storage localSockAddr;
+                socklen_t localAddrLen = sizeof(localSockAddr);
+                NSData *localAddress = nil;
+
+                if (getsockname(socket, (struct sockaddr *)&localSockAddr, &localAddrLen) == 0) {
+                    localAddress = [NSData dataWithBytes:&localSockAddr length:localAddrLen];
+                    GWS_DCHECK((!isIPv6 && localSockAddr.ss_family == AF_INET) || (isIPv6 && localSockAddr.ss_family == AF_INET6));
+                } else {
+                    GWS_DNOT_REACHED();
+                }
+
+                int noSigPipe = 1;
+                setsockopt(socket, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe)); // Make sure this socket cannot generate SIG_PIPE
+
+                GCDWebServerConnection *connection = [(GCDWebServerConnection *)[self->_connectionClass alloc] initWithServer:self localAddress:localAddress remoteAddress:remoteAddress socket:socket]; // Connection will automatically retain itself while opened
+                [connection self]; // Prevent compiler from complaining about unused variable / useless statement
+            } else {
+                GWS_LOG_ERROR(@"Failed accepting %s socket: %s (%i)", isIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+            }
+        }
+    });
+    return source;
 }
 
-- (BOOL)_start:(NSError**)error {
-  GWS_DCHECK(_source4 == NULL);
+- (BOOL)_start:(NSError **)error {
+    GWS_DCHECK(_source4 == NULL);
 
-  NSUInteger port = [(NSNumber*)_GetOption(_options, GCDWebServerOption_Port, @0) unsignedIntegerValue];
-  BOOL bindToLocalhost = [(NSNumber*)_GetOption(_options, GCDWebServerOption_BindToLocalhost, @NO) boolValue];
-  NSUInteger maxPendingConnections = [(NSNumber*)_GetOption(_options, GCDWebServerOption_MaxPendingConnections, @16) unsignedIntegerValue];
+    NSUInteger port = [(NSNumber *)_GetOption (_options, GCDWebServerOption_Port, @0) unsignedIntegerValue];
+    BOOL bindToLocalhost = [(NSNumber *)_GetOption (_options, GCDWebServerOption_BindToLocalhost, @NO) boolValue];
+    NSUInteger maxPendingConnections = [(NSNumber *)_GetOption (_options, GCDWebServerOption_MaxPendingConnections, @16) unsignedIntegerValue];
 
-  struct sockaddr_in addr4;
-  bzero(&addr4, sizeof(addr4));
-  addr4.sin_len = sizeof(addr4);
-  addr4.sin_family = AF_INET;
-  addr4.sin_port = htons(port);
-  addr4.sin_addr.s_addr = bindToLocalhost ? htonl(INADDR_LOOPBACK) : htonl(INADDR_ANY);
-  int listeningSocket4 = [self _createListeningSocket:NO localAddress:&addr4 length:sizeof(addr4) maxPendingConnections:maxPendingConnections error:error];
-  if (listeningSocket4 <= 0) {
-    return NO;
-  }
-  if (port == 0) {
-    struct sockaddr_in addr;
-    socklen_t addrlen = sizeof(addr);
-    if (getsockname(listeningSocket4, (struct sockaddr*)&addr, &addrlen) == 0) {
-      port = ntohs(addr.sin_port);
-    } else {
-      GWS_LOG_ERROR(@"Failed retrieving socket address: %s (%i)", strerror(errno), errno);
+    struct sockaddr_in addr4;
+    bzero(&addr4, sizeof(addr4));
+    addr4.sin_len = sizeof(addr4);
+    addr4.sin_family = AF_INET;
+    addr4.sin_port = htons(port);
+    addr4.sin_addr.s_addr = bindToLocalhost ? htonl(INADDR_LOOPBACK) : htonl(INADDR_ANY);
+    int listeningSocket4 = [self _createListeningSocket:NO localAddress:&addr4 length:sizeof(addr4) maxPendingConnections:maxPendingConnections error:error];
+
+    if (listeningSocket4 <= 0) {
+        return NO;
     }
-  }
 
-  struct sockaddr_in6 addr6;
-  bzero(&addr6, sizeof(addr6));
-  addr6.sin6_len = sizeof(addr6);
-  addr6.sin6_family = AF_INET6;
-  addr6.sin6_port = htons(port);
-  addr6.sin6_addr = bindToLocalhost ? in6addr_loopback : in6addr_any;
-  int listeningSocket6 = [self _createListeningSocket:YES localAddress:&addr6 length:sizeof(addr6) maxPendingConnections:maxPendingConnections error:error];
-  if (listeningSocket6 <= 0) {
-    close(listeningSocket4);
-    return NO;
-  }
+    if (port == 0) {
+        struct sockaddr_in addr;
+        socklen_t addrlen = sizeof(addr);
 
-  _serverName = [(NSString*)_GetOption(_options, GCDWebServerOption_ServerName, NSStringFromClass([self class])) copy];
-  NSString* authenticationMethod = _GetOption(_options, GCDWebServerOption_AuthenticationMethod, nil);
-  if ([authenticationMethod isEqualToString:GCDWebServerAuthenticationMethod_Basic]) {
-    _authenticationRealm = [(NSString*)_GetOption(_options, GCDWebServerOption_AuthenticationRealm, _serverName) copy];
-    _authenticationBasicAccounts = [[NSMutableDictionary alloc] init];
-    NSDictionary* accounts = _GetOption(_options, GCDWebServerOption_AuthenticationAccounts, @{});
-    [accounts enumerateKeysAndObjectsUsingBlock:^(NSString* username, NSString* password, BOOL* stop) {
-      [self->_authenticationBasicAccounts setObject:_EncodeBase64([NSString stringWithFormat:@"%@:%@", username, password]) forKey:username];
-    }];
-  } else if ([authenticationMethod isEqualToString:GCDWebServerAuthenticationMethod_DigestAccess]) {
-    _authenticationRealm = [(NSString*)_GetOption(_options, GCDWebServerOption_AuthenticationRealm, _serverName) copy];
-    _authenticationDigestAccounts = [[NSMutableDictionary alloc] init];
-    NSDictionary* accounts = _GetOption(_options, GCDWebServerOption_AuthenticationAccounts, @{});
-    [accounts enumerateKeysAndObjectsUsingBlock:^(NSString* username, NSString* password, BOOL* stop) {
-      [self->_authenticationDigestAccounts setObject:GCDWebServerComputeMD5Digest(@"%@:%@:%@", username, self->_authenticationRealm, password) forKey:username];
-    }];
-  }
-  _connectionClass = _GetOption(_options, GCDWebServerOption_ConnectionClass, [GCDWebServerConnection class]);
-  _shouldAutomaticallyMapHEADToGET = [(NSNumber*)_GetOption(_options, GCDWebServerOption_AutomaticallyMapHEADToGET, @YES) boolValue];
-  _disconnectDelay = [(NSNumber*)_GetOption(_options, GCDWebServerOption_ConnectedStateCoalescingInterval, @1.0) doubleValue];
-  _dispatchQueuePriority = [(NSNumber*)_GetOption(_options, GCDWebServerOption_DispatchQueuePriority, @(DISPATCH_QUEUE_PRIORITY_DEFAULT)) longValue];
-
-  _source4 = [self _createDispatchSourceWithListeningSocket:listeningSocket4 isIPv6:NO];
-  _source6 = [self _createDispatchSourceWithListeningSocket:listeningSocket6 isIPv6:YES];
-  _port = port;
-  _bindToLocalhost = bindToLocalhost;
-
-  NSString* bonjourName = _GetOption(_options, GCDWebServerOption_BonjourName, nil);
-  NSString* bonjourType = _GetOption(_options, GCDWebServerOption_BonjourType, @"_http._tcp");
-  if (bonjourName) {
-    _registrationService = CFNetServiceCreate(kCFAllocatorDefault, CFSTR("local."), (__bridge CFStringRef)bonjourType, (__bridge CFStringRef)(bonjourName.length ? bonjourName : _serverName), (SInt32)_port);
-    if (_registrationService) {
-      CFNetServiceClientContext context = {0, (__bridge void*)self, NULL, NULL, NULL};
-
-      CFNetServiceSetClient(_registrationService, _NetServiceRegisterCallBack, &context);
-      CFNetServiceScheduleWithRunLoop(_registrationService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
-      CFStreamError streamError = {0};
-      
-      NSDictionary* txtDataDictionary = _GetOption(_options, GCDWebServerOption_BonjourTXTData, nil);
-      if (txtDataDictionary != nil) {
-        NSUInteger count = txtDataDictionary.count;
-        CFStringRef keys[count];
-        CFStringRef values[count];
-        NSUInteger index = 0;
-        for (NSString *key in txtDataDictionary) {
-          NSString *value = txtDataDictionary[key];
-          keys[index] = (__bridge CFStringRef)(key);
-          values[index] = (__bridge CFStringRef)(value);
-          index ++;
-        }
-        CFDictionaryRef txtDictionary = CFDictionaryCreate(CFAllocatorGetDefault(), (void *)keys, (void *)values, count, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-        if (txtDictionary != NULL) {
-          CFDataRef txtData = CFNetServiceCreateTXTDataWithDictionary(nil, txtDictionary);
-          Boolean setTXTDataResult = CFNetServiceSetTXTData(_registrationService, txtData);
-          if (!setTXTDataResult) {
-            GWS_LOG_ERROR(@"Failed setting TXTData");
-          }
-          CFRelease(txtData);
-        }
-      }
-      
-      CFNetServiceRegisterWithOptions(_registrationService, 0, &streamError);
-
-      _resolutionService = CFNetServiceCreateCopy(kCFAllocatorDefault, _registrationService);
-      if (_resolutionService) {
-        CFNetServiceSetClient(_resolutionService, _NetServiceResolveCallBack, &context);
-        CFNetServiceScheduleWithRunLoop(_resolutionService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
-      } else {
-        GWS_LOG_ERROR(@"Failed creating CFNetService for resolution");
-      }
-    } else {
-      GWS_LOG_ERROR(@"Failed creating CFNetService for registration");
-    }
-  }
-
-  if ([(NSNumber*)_GetOption(_options, GCDWebServerOption_RequestNATPortMapping, @NO) boolValue]) {
-    DNSServiceErrorType status = DNSServiceNATPortMappingCreate(&_dnsService, 0, 0, kDNSServiceProtocol_TCP, htons(port), htons(port), 0, _DNSServiceCallBack, (__bridge void*)self);
-    if (status == kDNSServiceErr_NoError) {
-      CFSocketContext context = {0, (__bridge void*)self, NULL, NULL, NULL};
-      _dnsSocket = CFSocketCreateWithNative(kCFAllocatorDefault, DNSServiceRefSockFD(_dnsService), kCFSocketReadCallBack, _SocketCallBack, &context);
-      if (_dnsSocket) {
-        CFSocketSetSocketFlags(_dnsSocket, CFSocketGetSocketFlags(_dnsSocket) & ~kCFSocketCloseOnInvalidate);
-        _dnsSource = CFSocketCreateRunLoopSource(kCFAllocatorDefault, _dnsSocket, 0);
-        if (_dnsSource) {
-          CFRunLoopAddSource(CFRunLoopGetMain(), _dnsSource, kCFRunLoopCommonModes);
+        if (getsockname(listeningSocket4, (struct sockaddr *)&addr, &addrlen) == 0) {
+            port = ntohs(addr.sin_port);
         } else {
-          GWS_LOG_ERROR(@"Failed creating CFRunLoopSource");
-          GWS_DNOT_REACHED();
+            GWS_LOG_ERROR(@"Failed retrieving socket address: %s (%i)", strerror(errno), errno);
         }
-      } else {
-        GWS_LOG_ERROR(@"Failed creating CFSocket");
-        GWS_DNOT_REACHED();
-      }
-    } else {
-      GWS_LOG_ERROR(@"Failed creating NAT port mapping (%i)", status);
     }
-  }
 
-  dispatch_resume(_source4);
-  dispatch_resume(_source6);
-  GWS_LOG_INFO(@"%@ started on port %i and reachable at %@", [self class], (int)_port, self.serverURL);
-  if ([_delegate respondsToSelector:@selector(webServerDidStart:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self->_delegate webServerDidStart:self];
-    });
-  }
+    struct sockaddr_in6 addr6;
+    bzero(&addr6, sizeof(addr6));
+    addr6.sin6_len = sizeof(addr6);
+    addr6.sin6_family = AF_INET6;
+    addr6.sin6_port = htons(port);
+    addr6.sin6_addr = bindToLocalhost ? in6addr_loopback : in6addr_any;
+    int listeningSocket6 = [self _createListeningSocket:YES localAddress:&addr6 length:sizeof(addr6) maxPendingConnections:maxPendingConnections error:error];
 
-  return YES;
+    if (listeningSocket6 <= 0) {
+        close(listeningSocket4);
+        return NO;
+    }
+
+    _serverName = [(NSString *)_GetOption (_options, GCDWebServerOption_ServerName, NSStringFromClass([self class])) copy];
+    NSString *authenticationMethod = _GetOption(_options, GCDWebServerOption_AuthenticationMethod, nil);
+
+    if ([authenticationMethod isEqualToString:GCDWebServerAuthenticationMethod_Basic]) {
+        _authenticationRealm = [(NSString *)_GetOption (_options, GCDWebServerOption_AuthenticationRealm, _serverName) copy];
+        _authenticationBasicAccounts = [[NSMutableDictionary alloc] init];
+        NSDictionary *accounts = _GetOption(_options, GCDWebServerOption_AuthenticationAccounts, @{});
+        [accounts enumerateKeysAndObjectsUsingBlock:^(NSString *username, NSString *password, BOOL *stop) {
+                      [self->_authenticationBasicAccounts setObject:_EncodeBase64([NSString stringWithFormat:@"%@:%@", username, password]) forKey:username];
+                  }];
+    } else if ([authenticationMethod isEqualToString:GCDWebServerAuthenticationMethod_DigestAccess]) {
+        _authenticationRealm = [(NSString *)_GetOption (_options, GCDWebServerOption_AuthenticationRealm, _serverName) copy];
+        _authenticationDigestAccounts = [[NSMutableDictionary alloc] init];
+        NSDictionary *accounts = _GetOption(_options, GCDWebServerOption_AuthenticationAccounts, @{});
+        [accounts enumerateKeysAndObjectsUsingBlock:^(NSString *username, NSString *password, BOOL *stop) {
+                      [self->_authenticationDigestAccounts setObject:GCDWebServerComputeMD5Digest(@"%@:%@:%@", username, self->_authenticationRealm, password) forKey:username];
+                  }];
+    }
+
+    _connectionClass = _GetOption(_options, GCDWebServerOption_ConnectionClass, [GCDWebServerConnection class]);
+    _shouldAutomaticallyMapHEADToGET = [(NSNumber *)_GetOption (_options, GCDWebServerOption_AutomaticallyMapHEADToGET, @YES) boolValue];
+    _disconnectDelay = [(NSNumber *)_GetOption (_options, GCDWebServerOption_ConnectedStateCoalescingInterval, @1.0) doubleValue];
+    _dispatchQueuePriority = [(NSNumber *)_GetOption (_options, GCDWebServerOption_DispatchQueuePriority, @(DISPATCH_QUEUE_PRIORITY_DEFAULT)) longValue];
+
+    _source4 = [self _createDispatchSourceWithListeningSocket:listeningSocket4 isIPv6:NO];
+    _source6 = [self _createDispatchSourceWithListeningSocket:listeningSocket6 isIPv6:YES];
+    _port = port;
+    _bindToLocalhost = bindToLocalhost;
+
+    NSString *bonjourName = _GetOption(_options, GCDWebServerOption_BonjourName, nil);
+    NSString *bonjourType = _GetOption(_options, GCDWebServerOption_BonjourType, @"_http._tcp");
+
+    if (bonjourName) {
+        _registrationService = CFNetServiceCreate(kCFAllocatorDefault, CFSTR("local."), (__bridge CFStringRef)bonjourType, (__bridge CFStringRef)(bonjourName.length ? bonjourName : _serverName), (SInt32)_port);
+
+        if (_registrationService) {
+            CFNetServiceClientContext context = {
+                0, (__bridge void *)self, NULL, NULL, NULL
+            };
+
+            CFNetServiceSetClient(_registrationService, _NetServiceRegisterCallBack, &context);
+            CFNetServiceScheduleWithRunLoop(_registrationService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+            CFStreamError streamError = {
+                0
+            };
+
+            NSDictionary *txtDataDictionary = _GetOption(_options, GCDWebServerOption_BonjourTXTData, nil);
+
+            if (txtDataDictionary != nil) {
+                NSUInteger count = txtDataDictionary.count;
+                CFStringRef keys[count];
+                CFStringRef values[count];
+                NSUInteger index = 0;
+
+                for (NSString *key in txtDataDictionary) {
+                    NSString *value = txtDataDictionary[key];
+                    keys[index] = (__bridge CFStringRef)(key);
+                    values[index] = (__bridge CFStringRef)(value);
+                    index++;
+                }
+
+                CFDictionaryRef txtDictionary = CFDictionaryCreate(CFAllocatorGetDefault(), (void *)keys, (void *)values, count, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+                if (txtDictionary != NULL) {
+                    CFDataRef txtData = CFNetServiceCreateTXTDataWithDictionary(nil, txtDictionary);
+                    Boolean setTXTDataResult = CFNetServiceSetTXTData(_registrationService, txtData);
+
+                    if (!setTXTDataResult) {
+                        GWS_LOG_ERROR(@"Failed setting TXTData");
+                    }
+
+                    CFRelease(txtData);
+                }
+            }
+
+            CFNetServiceRegisterWithOptions(_registrationService, 0, &streamError);
+
+            _resolutionService = CFNetServiceCreateCopy(kCFAllocatorDefault, _registrationService);
+
+            if (_resolutionService) {
+                CFNetServiceSetClient(_resolutionService, _NetServiceResolveCallBack, &context);
+                CFNetServiceScheduleWithRunLoop(_resolutionService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+            } else {
+                GWS_LOG_ERROR(@"Failed creating CFNetService for resolution");
+            }
+        } else {
+            GWS_LOG_ERROR(@"Failed creating CFNetService for registration");
+        }
+    }
+
+    if ([(NSNumber *)_GetOption (_options, GCDWebServerOption_RequestNATPortMapping, @NO) boolValue]) {
+        DNSServiceErrorType status = DNSServiceNATPortMappingCreate(&_dnsService, 0, 0, kDNSServiceProtocol_TCP, htons(port), htons(port), 0, _DNSServiceCallBack, (__bridge void *)self);
+
+        if (status == kDNSServiceErr_NoError) {
+            CFSocketContext context = {
+                0, (__bridge void *)self, NULL, NULL, NULL
+            };
+            _dnsSocket = CFSocketCreateWithNative(kCFAllocatorDefault, DNSServiceRefSockFD(_dnsService), kCFSocketReadCallBack, _SocketCallBack, &context);
+
+            if (_dnsSocket) {
+                CFSocketSetSocketFlags(_dnsSocket, CFSocketGetSocketFlags(_dnsSocket) & ~kCFSocketCloseOnInvalidate);
+                _dnsSource = CFSocketCreateRunLoopSource(kCFAllocatorDefault, _dnsSocket, 0);
+
+                if (_dnsSource) {
+                    CFRunLoopAddSource(CFRunLoopGetMain(), _dnsSource, kCFRunLoopCommonModes);
+                } else {
+                    GWS_LOG_ERROR(@"Failed creating CFRunLoopSource");
+                    GWS_DNOT_REACHED();
+                }
+            } else {
+                GWS_LOG_ERROR(@"Failed creating CFSocket");
+                GWS_DNOT_REACHED();
+            }
+        } else {
+            GWS_LOG_ERROR(@"Failed creating NAT port mapping (%i)", status);
+        }
+    }
+
+    dispatch_resume(_source4);
+    dispatch_resume(_source6);
+    GWS_LOG_INFO(@"%@ started on port %i and reachable at %@", [self class], (int)_port, self.serverURL);
+
+    if ([_delegate respondsToSelector:@selector(webServerDidStart:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self->_delegate webServerDidStart:self];
+        });
+    }
+
+    return YES;
 }
 
 - (void)_stop {
-  GWS_DCHECK(_source4 != NULL);
+    GWS_DCHECK(_source4 != NULL);
 
-  if (_dnsService) {
-    _dnsAddress = nil;
-    _dnsPort = 0;
-    if (_dnsSource) {
-      CFRunLoopSourceInvalidate(_dnsSource);
-      CFRelease(_dnsSource);
-      _dnsSource = NULL;
-    }
-    if (_dnsSocket) {
-      CFRelease(_dnsSocket);
-      _dnsSocket = NULL;
-    }
-    DNSServiceRefDeallocate(_dnsService);
-    _dnsService = NULL;
-  }
+    if (_dnsService) {
+        _dnsAddress = nil;
+        _dnsPort = 0;
 
-  if (_registrationService) {
-    if (_resolutionService) {
-      CFNetServiceUnscheduleFromRunLoop(_resolutionService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
-      CFNetServiceSetClient(_resolutionService, NULL, NULL);
-      CFNetServiceCancel(_resolutionService);
-      CFRelease(_resolutionService);
-      _resolutionService = NULL;
-    }
-    CFNetServiceUnscheduleFromRunLoop(_registrationService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
-    CFNetServiceSetClient(_registrationService, NULL, NULL);
-    CFNetServiceCancel(_registrationService);
-    CFRelease(_registrationService);
-    _registrationService = NULL;
-  }
+        if (_dnsSource) {
+            CFRunLoopSourceInvalidate(_dnsSource);
+            CFRelease(_dnsSource);
+            _dnsSource = NULL;
+        }
 
-  dispatch_source_cancel(_source6);
-  dispatch_source_cancel(_source4);
-  dispatch_group_wait(_sourceGroup, DISPATCH_TIME_FOREVER);  // Wait until the cancellation handlers have been called which guarantees the listening sockets are closed
+        if (_dnsSocket) {
+            CFRelease(_dnsSocket);
+            _dnsSocket = NULL;
+        }
+
+        DNSServiceRefDeallocate(_dnsService);
+        _dnsService = NULL;
+    }
+
+    if (_registrationService) {
+        if (_resolutionService) {
+            CFNetServiceUnscheduleFromRunLoop(_resolutionService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+            CFNetServiceSetClient(_resolutionService, NULL, NULL);
+            CFNetServiceCancel(_resolutionService);
+            CFRelease(_resolutionService);
+            _resolutionService = NULL;
+        }
+
+        CFNetServiceUnscheduleFromRunLoop(_registrationService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+        CFNetServiceSetClient(_registrationService, NULL, NULL);
+        CFNetServiceCancel(_registrationService);
+        CFRelease(_registrationService);
+        _registrationService = NULL;
+    }
+
+    dispatch_source_cancel(_source6);
+    dispatch_source_cancel(_source4);
+    dispatch_group_wait(_sourceGroup, DISPATCH_TIME_FOREVER); // Wait until the cancellation handlers have been called which guarantees the listening sockets are closed
 #if !OS_OBJECT_USE_OBJC_RETAIN_RELEASE
-  dispatch_release(_source6);
+    dispatch_release(_source6);
 #endif
-  _source6 = NULL;
+    _source6 = NULL;
 #if !OS_OBJECT_USE_OBJC_RETAIN_RELEASE
-  dispatch_release(_source4);
+    dispatch_release(_source4);
 #endif
-  _source4 = NULL;
-  _port = 0;
-  _bindToLocalhost = NO;
+    _source4 = NULL;
+    _port = 0;
+    _bindToLocalhost = NO;
 
-  _serverName = nil;
-  _authenticationRealm = nil;
-  _authenticationBasicAccounts = nil;
-  _authenticationDigestAccounts = nil;
+    _serverName = nil;
+    _authenticationRealm = nil;
+    _authenticationBasicAccounts = nil;
+    _authenticationDigestAccounts = nil;
 
-  dispatch_async(dispatch_get_main_queue(), ^{
-    if (self->_disconnectTimer) {
-      CFRunLoopTimerInvalidate(self->_disconnectTimer);
-      CFRelease(self->_disconnectTimer);
-      self->_disconnectTimer = NULL;
-      [self _didDisconnect];
-    }
-  });
-
-  GWS_LOG_INFO(@"%@ stopped", [self class]);
-  if ([_delegate respondsToSelector:@selector(webServerDidStop:)]) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [self->_delegate webServerDidStop:self];
+        if (self->_disconnectTimer) {
+            CFRunLoopTimerInvalidate(self->_disconnectTimer);
+            CFRelease(self->_disconnectTimer);
+            self->_disconnectTimer = NULL;
+            [self _didDisconnect];
+        }
     });
-  }
+
+    GWS_LOG_INFO(@"%@ stopped", [self class]);
+
+    if ([_delegate respondsToSelector:@selector(webServerDidStop:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self->_delegate webServerDidStop:self];
+        });
+    }
 }
 
 #if TARGET_OS_IPHONE
 
-- (void)_didEnterBackground:(NSNotification*)notification {
-  GWS_DCHECK([NSThread isMainThread]);
-  GWS_LOG_DEBUG(@"Did enter background");
-  if ((_backgroundTask == UIBackgroundTaskInvalid) && _source4) {
-    [self _stop];
-  }
+- (void)_didEnterBackground:(NSNotification *)notification {
+    GWS_DCHECK([NSThread isMainThread]);
+    GWS_LOG_DEBUG(@"Did enter background");
+
+    if ((_backgroundTask == UIBackgroundTaskInvalid) && _source4) {
+        [self _stop];
+    }
 }
 
-- (void)_willEnterForeground:(NSNotification*)notification {
-  GWS_DCHECK([NSThread isMainThread]);
-  GWS_LOG_DEBUG(@"Will enter foreground");
-  if (!_source4) {
-    [self _start:NULL];  // TODO: There's probably nothing we can do on failure
-  }
+- (void)_willEnterForeground:(NSNotification *)notification {
+    GWS_DCHECK([NSThread isMainThread]);
+    GWS_LOG_DEBUG(@"Will enter foreground");
+
+    if (!_source4) {
+        [self _start:NULL]; // TODO: There's probably nothing we can do on failure
+    }
 }
 
 #endif
 
-- (BOOL)startWithOptions:(NSDictionary<NSString*, id>*)options error:(NSError**)error {
-  if (_options == nil) {
-    _options = options ? [options copy] : @{};
+- (BOOL)startWithOptions:(NSDictionary<NSString *, id> *)options error:(NSError **)error {
+    if (_options == nil) {
+        _options = options ? [options copy] : @{};
 #if TARGET_OS_IPHONE
-    _suspendInBackground = [(NSNumber*)_GetOption(_options, GCDWebServerOption_AutomaticallySuspendInBackground, @YES) boolValue];
-    if (((_suspendInBackground == NO) || ([[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground)) && ![self _start:error])
+        _suspendInBackground = [(NSNumber *)_GetOption (_options, GCDWebServerOption_AutomaticallySuspendInBackground, @YES) boolValue];
+
+        if (((_suspendInBackground == NO) || ([[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground)) && ![self _start:error])
 #else
-    if (![self _start:error])
+
+        if (![self _start:error])
 #endif
-    {
-      _options = nil;
-      return NO;
-    }
+        {
+            _options = nil;
+            return NO;
+        }
+
 #if TARGET_OS_IPHONE
-    if (_suspendInBackground) {
-      [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
-      [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_willEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
-    }
+
+        if (_suspendInBackground) {
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_willEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
+        }
+
 #endif
-    return YES;
-  } else {
-    GWS_DNOT_REACHED();
-  }
-  return NO;
+        return YES;
+    } else {
+        GWS_DNOT_REACHED();
+    }
+
+    return NO;
 }
 
 - (BOOL)isRunning {
-  return (_options ? YES : NO);
+    return (_options ? YES : NO);
 }
 
 - (void)stop {
-  if (_options) {
+    if (_options) {
 #if TARGET_OS_IPHONE
-    if (_suspendInBackground) {
-      [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
-      [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
-    }
+
+        if (_suspendInBackground) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
+        }
+
 #endif
-    if (_source4) {
-      [self _stop];
+
+        if (_source4) {
+            [self _stop];
+        }
+
+        _options = nil;
+    } else {
+        GWS_DNOT_REACHED();
     }
-    _options = nil;
-  } else {
-    GWS_DNOT_REACHED();
-  }
 }
 
 @end
 
 @implementation GCDWebServer (Extensions)
 
-- (NSURL*)serverURL {
-  if (_source4) {
-    NSString* ipAddress = _bindToLocalhost ? @"localhost" : GCDWebServerGetPrimaryIPAddress(NO);  // We can't really use IPv6 anyway as it doesn't work great with HTTP URLs in practice
-    if (ipAddress) {
-      if (_port != 80) {
-        return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", ipAddress, (int)_port]];
-      } else {
-        return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/", ipAddress]];
-      }
+- (NSURL *)serverURL {
+    if (_source4) {
+        NSString *ipAddress = _bindToLocalhost ? @"localhost" : GCDWebServerGetPrimaryIPAddress(NO); // We can't really use IPv6 anyway as it doesn't work great with HTTP URLs in practice
+
+        if (ipAddress) {
+            if (_port != 80) {
+                return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", ipAddress, (int)_port]];
+            } else {
+                return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/", ipAddress]];
+            }
+        }
     }
-  }
-  return nil;
+
+    return nil;
 }
 
-- (NSURL*)bonjourServerURL {
-  if (_source4 && _resolutionService) {
-    NSString* name = (__bridge NSString*)CFNetServiceGetTargetHost(_resolutionService);
-    if (name.length) {
-      name = [name substringToIndex:(name.length - 1)];  // Strip trailing period at end of domain
-      if (_port != 80) {
-        return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", name, (int)_port]];
-      } else {
-        return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/", name]];
-      }
+- (NSURL *)bonjourServerURL {
+    if (_source4 && _resolutionService) {
+        NSString *name = (__bridge NSString *)CFNetServiceGetTargetHost(_resolutionService);
+
+        if (name.length) {
+            name = [name substringToIndex:(name.length - 1)]; // Strip trailing period at end of domain
+
+            if (_port != 80) {
+                return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", name, (int)_port]];
+            } else {
+                return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/", name]];
+            }
+        }
     }
-  }
-  return nil;
+
+    return nil;
 }
 
-- (NSURL*)publicServerURL {
-  if (_source4 && _dnsService && _dnsAddress && _dnsPort) {
-    if (_dnsPort != 80) {
-      return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", _dnsAddress, (int)_dnsPort]];
-    } else {
-      return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/", _dnsAddress]];
+- (NSURL *)publicServerURL {
+    if (_source4 && _dnsService && _dnsAddress && _dnsPort) {
+        if (_dnsPort != 80) {
+            return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", _dnsAddress, (int)_dnsPort]];
+        } else {
+            return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/", _dnsAddress]];
+        }
     }
-  }
-  return nil;
+
+    return nil;
 }
 
 - (BOOL)start {
-  return [self startWithPort:kDefaultPort bonjourName:@""];
+    return [self startWithPort:kDefaultPort bonjourName:@""];
 }
 
-- (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name {
-  NSMutableDictionary* options = [NSMutableDictionary dictionary];
-  [options setObject:[NSNumber numberWithInteger:port] forKey:GCDWebServerOption_Port];
-  [options setValue:name forKey:GCDWebServerOption_BonjourName];
-  return [self startWithOptions:options error:NULL];
+- (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString *)name {
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+
+    [options setObject:[NSNumber numberWithInteger:port] forKey:GCDWebServerOption_Port];
+    [options setValue:name forKey:GCDWebServerOption_BonjourName];
+    return [self startWithOptions:options error:NULL];
 }
 
 #if !TARGET_OS_IPHONE
 
-- (BOOL)runWithPort:(NSUInteger)port bonjourName:(NSString*)name {
-  NSMutableDictionary* options = [NSMutableDictionary dictionary];
-  [options setObject:[NSNumber numberWithInteger:port] forKey:GCDWebServerOption_Port];
-  [options setValue:name forKey:GCDWebServerOption_BonjourName];
-  return [self runWithOptions:options error:NULL];
+- (BOOL)runWithPort:(NSUInteger)port bonjourName:(NSString *)name {
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+
+    [options setObject:[NSNumber numberWithInteger:port] forKey:GCDWebServerOption_Port];
+    [options setValue:name forKey:GCDWebServerOption_BonjourName];
+    return [self runWithOptions:options error:NULL];
 }
 
-- (BOOL)runWithOptions:(NSDictionary<NSString*, id>*)options error:(NSError**)error {
-  GWS_DCHECK([NSThread isMainThread]);
-  BOOL success = NO;
-  _run = YES;
-  void (*termHandler)(int) = signal(SIGTERM, _SignalHandler);
-  void (*intHandler)(int) = signal(SIGINT, _SignalHandler);
-  if ((termHandler != SIG_ERR) && (intHandler != SIG_ERR)) {
-    if ([self startWithOptions:options error:error]) {
-      while (_run) {
-        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1.0, true);
-      }
-      [self stop];
-      success = YES;
+- (BOOL)runWithOptions:(NSDictionary<NSString *, id> *)options error:(NSError **)error {
+    GWS_DCHECK([NSThread isMainThread]);
+    BOOL success = NO;
+    _run = YES;
+    void (*termHandler)(int) = signal(SIGTERM, _SignalHandler);
+    void (*intHandler)(int) = signal(SIGINT, _SignalHandler);
+
+    if ((termHandler != SIG_ERR) && (intHandler != SIG_ERR)) {
+        if ([self startWithOptions:options error:error]) {
+            while (_run)
+                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1.0, true);
+            [self stop];
+            success = YES;
+        }
+
+        _ExecuteMainThreadRunLoopSources();
+        signal(SIGINT, intHandler);
+        signal(SIGTERM, termHandler);
     }
-    _ExecuteMainThreadRunLoopSources();
-    signal(SIGINT, intHandler);
-    signal(SIGTERM, termHandler);
-  }
-  return success;
+
+    return success;
 }
 
-#endif
+#endif /* if !TARGET_OS_IPHONE */
 
 @end
 
 @implementation GCDWebServer (Handlers)
 
-- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block {
-  [self addDefaultHandlerForMethod:method
-                      requestClass:aClass
-                 asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock) {
-                   completionBlock(block(request));
-                 }];
+- (void)addDefaultHandlerForMethod:(NSString *)method requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block {
+    [self addDefaultHandlerForMethod:method
+                        requestClass:aClass
+                   asyncProcessBlock:^(GCDWebServerRequest *request, GCDWebServerCompletionBlock completionBlock) {
+                       completionBlock(block(request));
+                   }];
 }
 
-- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
-  [self
-      addHandlerWithMatchBlock:^GCDWebServerRequest*(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery) {
-        if (![requestMethod isEqualToString:method]) {
-          return nil;
-        }
-        return [(GCDWebServerRequest*)[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
-      }
-             asyncProcessBlock:block];
-}
-
-- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block {
-  [self addHandlerForMethod:method
-                       path:path
-               requestClass:aClass
-          asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock) {
-            completionBlock(block(request));
-          }];
-}
-
-- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
-  if ([path hasPrefix:@"/"] && [aClass isSubclassOfClass:[GCDWebServerRequest class]]) {
+- (void)addDefaultHandlerForMethod:(NSString *)method requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
     [self
-        addHandlerWithMatchBlock:^GCDWebServerRequest*(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery) {
-          if (![requestMethod isEqualToString:method]) {
-            return nil;
-          }
-          if ([urlPath caseInsensitiveCompare:path] != NSOrderedSame) {
-            return nil;
-          }
-          return [(GCDWebServerRequest*)[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
-        }
-               asyncProcessBlock:block];
-  } else {
-    GWS_DNOT_REACHED();
-  }
+     addHandlerWithMatchBlock:^GCDWebServerRequest *(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery) {
+         if (![requestMethod isEqualToString:method]) {
+             return nil;
+         }
+
+         return [(GCDWebServerRequest *)[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+     }
+            asyncProcessBlock:block];
 }
 
-- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block {
-  [self addHandlerForMethod:method
-                  pathRegex:regex
-               requestClass:aClass
-          asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock) {
-            completionBlock(block(request));
-          }];
+- (void)addHandlerForMethod:(NSString *)method path:(NSString *)path requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block {
+    [self addHandlerForMethod:method
+                         path:path
+                 requestClass:aClass
+            asyncProcessBlock:^(GCDWebServerRequest *request, GCDWebServerCompletionBlock completionBlock) {
+                completionBlock(block(request));
+            }];
 }
 
-- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
-  NSRegularExpression* expression = [NSRegularExpression regularExpressionWithPattern:regex options:NSRegularExpressionCaseInsensitive error:NULL];
-  if (expression && [aClass isSubclassOfClass:[GCDWebServerRequest class]]) {
-    [self
-        addHandlerWithMatchBlock:^GCDWebServerRequest*(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery) {
-          if (![requestMethod isEqualToString:method]) {
-            return nil;
-          }
+- (void)addHandlerForMethod:(NSString *)method path:(NSString *)path requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
+    if ([path hasPrefix:@"/"] && [aClass isSubclassOfClass:[GCDWebServerRequest class]]) {
+        [self
+         addHandlerWithMatchBlock:^GCDWebServerRequest *(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery) {
+             if (![requestMethod isEqualToString:method]) {
+                 return nil;
+             }
 
-          NSArray* matches = [expression matchesInString:urlPath options:0 range:NSMakeRange(0, urlPath.length)];
-          if (matches.count == 0) {
-            return nil;
-          }
+             if ([urlPath caseInsensitiveCompare:path] != NSOrderedSame) {
+                 return nil;
+             }
 
-          NSMutableArray* captures = [NSMutableArray array];
-          for (NSTextCheckingResult* result in matches) {
-            // Start at 1; index 0 is the whole string
-            for (NSUInteger i = 1; i < result.numberOfRanges; i++) {
-              NSRange range = [result rangeAtIndex:i];
-              // range is {NSNotFound, 0} "if one of the capture groups did not participate in this particular match"
-              // see discussion in -[NSRegularExpression firstMatchInString:options:range:]
-              if (range.location != NSNotFound) {
-                [captures addObject:[urlPath substringWithRange:range]];
-              }
-            }
-          }
+             return [(GCDWebServerRequest *)[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+         }
+                asyncProcessBlock:block];
+    } else {
+        GWS_DNOT_REACHED();
+    }
+}
 
-          GCDWebServerRequest* request = [(GCDWebServerRequest*)[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
-          [request setAttribute:captures forKey:GCDWebServerRequestAttribute_RegexCaptures];
-          return request;
-        }
-               asyncProcessBlock:block];
-  } else {
-    GWS_DNOT_REACHED();
-  }
+- (void)addHandlerForMethod:(NSString *)method pathRegex:(NSString *)regex requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block {
+    [self addHandlerForMethod:method
+                    pathRegex:regex
+                 requestClass:aClass
+            asyncProcessBlock:^(GCDWebServerRequest *request, GCDWebServerCompletionBlock completionBlock) {
+                completionBlock(block(request));
+            }];
+}
+
+- (void)addHandlerForMethod:(NSString *)method pathRegex:(NSString *)regex requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
+    NSRegularExpression *expression = [NSRegularExpression regularExpressionWithPattern:regex options:NSRegularExpressionCaseInsensitive error:NULL];
+
+    if (expression && [aClass isSubclassOfClass:[GCDWebServerRequest class]]) {
+        [self
+         addHandlerWithMatchBlock:^GCDWebServerRequest *(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery) {
+             if (![requestMethod isEqualToString:method]) {
+                 return nil;
+             }
+
+             NSArray *matches = [expression matchesInString:urlPath options:0 range:NSMakeRange(0, urlPath.length)];
+
+             if (matches.count == 0) {
+                 return nil;
+             }
+
+             NSMutableArray *captures = [NSMutableArray array];
+
+             for (NSTextCheckingResult *result in matches) {
+                 // Start at 1; index 0 is the whole string
+                 for (NSUInteger i = 1; i < result.numberOfRanges; i++) {
+                     NSRange range = [result rangeAtIndex:i];
+
+                     // range is {NSNotFound, 0} "if one of the capture groups did not participate in this particular match"
+                     // see discussion in -[NSRegularExpression firstMatchInString:options:range:]
+                     if (range.location != NSNotFound) {
+                         [captures addObject:[urlPath substringWithRange:range]];
+                     }
+                 }
+             }
+
+             GCDWebServerRequest *request = [(GCDWebServerRequest *)[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+             [request setAttribute:captures forKey:GCDWebServerRequestAttribute_RegexCaptures];
+             return request;
+         }
+                asyncProcessBlock:block];
+    } else {
+        GWS_DNOT_REACHED();
+    }
 }
 
 @end
 
 @implementation GCDWebServer (GETHandlers)
 
-- (void)addGETHandlerForPath:(NSString*)path staticData:(NSData*)staticData contentType:(NSString*)contentType cacheAge:(NSUInteger)cacheAge {
-  [self addHandlerForMethod:@"GET"
-                       path:path
-               requestClass:[GCDWebServerRequest class]
-               processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                 GCDWebServerResponse* response = [GCDWebServerDataResponse responseWithData:staticData contentType:contentType];
-                 response.cacheControlMaxAge = cacheAge;
-                 return response;
-               }];
+- (void)addGETHandlerForPath:(NSString *)path staticData:(NSData *)staticData contentType:(NSString *)contentType cacheAge:(NSUInteger)cacheAge {
+    [self addHandlerForMethod:@"GET"
+                         path:path
+                 requestClass:[GCDWebServerRequest class]
+                 processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                     GCDWebServerResponse *response = [GCDWebServerDataResponse responseWithData:staticData contentType:contentType];
+                     response.cacheControlMaxAge = cacheAge;
+                     return response;
+                 }];
 }
 
-- (void)addGETHandlerForPath:(NSString*)path filePath:(NSString*)filePath isAttachment:(BOOL)isAttachment cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests {
-  [self addHandlerForMethod:@"GET"
-                       path:path
-               requestClass:[GCDWebServerRequest class]
-               processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                 GCDWebServerResponse* response = nil;
-                 if (allowRangeRequests) {
-                   response = [GCDWebServerFileResponse responseWithFile:filePath byteRange:request.byteRange isAttachment:isAttachment];
-                   [response setValue:@"bytes" forAdditionalHeader:@"Accept-Ranges"];
-                 } else {
-                   response = [GCDWebServerFileResponse responseWithFile:filePath isAttachment:isAttachment];
-                 }
-                 response.cacheControlMaxAge = cacheAge;
-                 return response;
-               }];
+- (void)addGETHandlerForPath:(NSString *)path filePath:(NSString *)filePath isAttachment:(BOOL)isAttachment cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests {
+    [self addHandlerForMethod:@"GET"
+                         path:path
+                 requestClass:[GCDWebServerRequest class]
+                 processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                     GCDWebServerResponse *response = nil;
+
+                     if (allowRangeRequests) {
+                         response = [GCDWebServerFileResponse responseWithFile:filePath byteRange:request.byteRange isAttachment:isAttachment];
+                         [response setValue:@"bytes" forAdditionalHeader:@"Accept-Ranges"];
+                     } else {
+                         response = [GCDWebServerFileResponse responseWithFile:filePath isAttachment:isAttachment];
+                     }
+
+                     response.cacheControlMaxAge = cacheAge;
+                     return response;
+                 }];
 }
 
-- (GCDWebServerResponse*)_responseWithContentsOfDirectory:(NSString*)path {
-  NSArray* contents = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:NULL] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
-  if (contents == nil) {
-    return nil;
-  }
-  NSMutableString* html = [NSMutableString string];
-  [html appendString:@"<!DOCTYPE html>\n"];
-  [html appendString:@"<html><head><meta charset=\"utf-8\"></head><body>\n"];
-  [html appendString:@"<ul>\n"];
-  for (NSString* entry in contents) {
-    if (![entry hasPrefix:@"."]) {
-      NSString* type = [[[NSFileManager defaultManager] attributesOfItemAtPath:[path stringByAppendingPathComponent:entry] error:NULL] objectForKey:NSFileType];
-      GWS_DCHECK(type);
+- (GCDWebServerResponse *)_responseWithContentsOfDirectory:(NSString *)path {
+    NSArray *contents = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:NULL] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
+
+    if (contents == nil) {
+        return nil;
+    }
+
+    NSMutableString *html = [NSMutableString string];
+    [html appendString:@"<!DOCTYPE html>\n"];
+    [html appendString:@"<html><head><meta charset=\"utf-8\"></head><body>\n"];
+    [html appendString:@"<ul>\n"];
+
+    for (NSString *entry in contents) {
+        if (![entry hasPrefix:@"."]) {
+            NSString *type = [[[NSFileManager defaultManager] attributesOfItemAtPath:[path stringByAppendingPathComponent:entry] error:NULL] objectForKey:NSFileType];
+            GWS_DCHECK(type);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      NSString* escapedFile = [entry stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            NSString *escapedFile = [entry stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 #pragma clang diagnostic pop
-      GWS_DCHECK(escapedFile);
-      if ([type isEqualToString:NSFileTypeRegular]) {
-        [html appendFormat:@"<li><a href=\"%@\">%@</a></li>\n", escapedFile, entry];
-      } else if ([type isEqualToString:NSFileTypeDirectory]) {
-        [html appendFormat:@"<li><a href=\"%@/\">%@/</a></li>\n", escapedFile, entry];
-      }
+            GWS_DCHECK(escapedFile);
+
+            if ([type isEqualToString:NSFileTypeRegular]) {
+                [html appendFormat:@"<li><a href=\"%@\">%@</a></li>\n", escapedFile, entry];
+            } else if ([type isEqualToString:NSFileTypeDirectory]) {
+                [html appendFormat:@"<li><a href=\"%@/\">%@/</a></li>\n", escapedFile, entry];
+            }
+        }
     }
-  }
-  [html appendString:@"</ul>\n"];
-  [html appendString:@"</body></html>\n"];
-  return [GCDWebServerDataResponse responseWithHTML:html];
+
+    [html appendString:@"</ul>\n"];
+    [html appendString:@"</body></html>\n"];
+    return [GCDWebServerDataResponse responseWithHTML:html];
 }
 
-- (void)addGETHandlerForBasePath:(NSString*)basePath directoryPath:(NSString*)directoryPath indexFilename:(NSString*)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests {
-  if ([basePath hasPrefix:@"/"] && [basePath hasSuffix:@"/"]) {
-    GCDWebServer* __unsafe_unretained server = self;
-    [self
-        addHandlerWithMatchBlock:^GCDWebServerRequest*(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery) {
-          if (![requestMethod isEqualToString:@"GET"]) {
-            return nil;
-          }
-          if (![urlPath hasPrefix:basePath]) {
-            return nil;
-          }
-          return [[GCDWebServerRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
-        }
-        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-          GCDWebServerResponse* response = nil;
-          NSString* filePath = [directoryPath stringByAppendingPathComponent:GCDWebServerNormalizePath([request.path substringFromIndex:basePath.length])];
-          NSString* fileType = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:NULL] fileType];
-          if (fileType) {
-            if ([fileType isEqualToString:NSFileTypeDirectory]) {
-              if (indexFilename) {
-                NSString* indexPath = [filePath stringByAppendingPathComponent:indexFilename];
-                NSString* indexType = [[[NSFileManager defaultManager] attributesOfItemAtPath:indexPath error:NULL] fileType];
-                if ([indexType isEqualToString:NSFileTypeRegular]) {
-                  return [GCDWebServerFileResponse responseWithFile:indexPath];
-                }
-              }
-              response = [server _responseWithContentsOfDirectory:filePath];
-            } else if ([fileType isEqualToString:NSFileTypeRegular]) {
-              if (allowRangeRequests) {
-                response = [GCDWebServerFileResponse responseWithFile:filePath byteRange:request.byteRange];
-                [response setValue:@"bytes" forAdditionalHeader:@"Accept-Ranges"];
-              } else {
-                response = [GCDWebServerFileResponse responseWithFile:filePath];
-              }
-            }
-          }
-          if (response) {
-            response.cacheControlMaxAge = cacheAge;
-          } else {
-            response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NotFound];
-          }
-          return response;
-        }];
-  } else {
-    GWS_DNOT_REACHED();
-  }
+- (void)addGETHandlerForBasePath:(NSString *)basePath directoryPath:(NSString *)directoryPath indexFilename:(NSString *)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests {
+    if ([basePath hasPrefix:@"/"] && [basePath hasSuffix:@"/"]) {
+        GCDWebServer * __unsafe_unretained server = self;
+        [self
+         addHandlerWithMatchBlock:^GCDWebServerRequest *(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery) {
+             if (![requestMethod isEqualToString:@"GET"]) {
+                 return nil;
+             }
+
+             if (![urlPath hasPrefix:basePath]) {
+                 return nil;
+             }
+
+             return [[GCDWebServerRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+         }
+                     processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                         GCDWebServerResponse *response = nil;
+                         NSString *filePath = [directoryPath stringByAppendingPathComponent:GCDWebServerNormalizePath([request.path substringFromIndex:basePath.length])];
+                         NSString *fileType = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:NULL] fileType];
+
+                         if (fileType) {
+                             if ([fileType isEqualToString:NSFileTypeDirectory]) {
+                                 if (indexFilename) {
+                                     NSString *indexPath = [filePath stringByAppendingPathComponent:indexFilename];
+                                     NSString *indexType = [[[NSFileManager defaultManager] attributesOfItemAtPath:indexPath error:NULL] fileType];
+
+                                     if ([indexType isEqualToString:NSFileTypeRegular]) {
+                                         return [GCDWebServerFileResponse responseWithFile:indexPath];
+                                     }
+                                 }
+
+                                 response = [server _responseWithContentsOfDirectory:filePath];
+                             } else if ([fileType isEqualToString:NSFileTypeRegular]) {
+                                 if (allowRangeRequests) {
+                                     response = [GCDWebServerFileResponse responseWithFile:filePath byteRange:request.byteRange];
+                                     [response setValue:@"bytes" forAdditionalHeader:@"Accept-Ranges"];
+                                 } else {
+                                     response = [GCDWebServerFileResponse responseWithFile:filePath];
+                                 }
+                             }
+                         }
+
+                         if (response) {
+                             response.cacheControlMaxAge = cacheAge;
+                         } else {
+                             response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NotFound];
+                         }
+
+                         return response;
+                     }];
+    } else {
+        GWS_DNOT_REACHED();
+    }
 }
 
 @end
@@ -1100,46 +1212,50 @@ static inline NSString* _EncodeBase64(NSString* string) {
 
 + (void)setLogLevel:(int)level {
 #if defined(__GCDWEBSERVER_LOGGING_FACILITY_XLFACILITY__)
-  [XLSharedFacility setMinLogLevel:level];
+    [XLSharedFacility setMinLogLevel:level];
 #elif defined(__GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__)
-  GCDWebServerLogLevel = level;
+    GCDWebServerLogLevel = level;
 #endif
 }
 
 + (void)setBuiltInLogger:(GCDWebServerBuiltInLoggerBlock)block {
 #if defined(__GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__)
-  _builtInLoggerBlock = block;
+    _builtInLoggerBlock = block;
 #else
-  GWS_DNOT_REACHED();  // Built-in logger must be enabled in order to override
+    GWS_DNOT_REACHED(); // Built-in logger must be enabled in order to override
 #endif
 }
 
-- (void)logVerbose:(NSString*)format, ... {
-  va_list arguments;
-  va_start(arguments, format);
-  GWS_LOG_VERBOSE(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
-  va_end(arguments);
+- (void)logVerbose:(NSString *)format, ... {
+    va_list arguments;
+
+    va_start(arguments, format);
+    GWS_LOG_VERBOSE(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+    va_end(arguments);
 }
 
-- (void)logInfo:(NSString*)format, ... {
-  va_list arguments;
-  va_start(arguments, format);
-  GWS_LOG_INFO(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
-  va_end(arguments);
+- (void)logInfo:(NSString *)format, ... {
+    va_list arguments;
+
+    va_start(arguments, format);
+    GWS_LOG_INFO(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+    va_end(arguments);
 }
 
-- (void)logWarning:(NSString*)format, ... {
-  va_list arguments;
-  va_start(arguments, format);
-  GWS_LOG_WARNING(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
-  va_end(arguments);
+- (void)logWarning:(NSString *)format, ... {
+    va_list arguments;
+
+    va_start(arguments, format);
+    GWS_LOG_WARNING(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+    va_end(arguments);
 }
 
-- (void)logError:(NSString*)format, ... {
-  va_list arguments;
-  va_start(arguments, format);
-  GWS_LOG_ERROR(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
-  va_end(arguments);
+- (void)logError:(NSString *)format, ... {
+    va_list arguments;
+
+    va_start(arguments, format);
+    GWS_LOG_ERROR(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+    va_end(arguments);
 }
 
 @end
@@ -1149,187 +1265,224 @@ static inline NSString* _EncodeBase64(NSString* string) {
 @implementation GCDWebServer (Testing)
 
 - (void)setRecordingEnabled:(BOOL)flag {
-  _recording = flag;
+    _recording = flag;
 }
 
 - (BOOL)isRecordingEnabled {
-  return _recording;
+    return _recording;
 }
 
-static CFHTTPMessageRef _CreateHTTPMessageFromData(NSData* data, BOOL isRequest) {
-  CFHTTPMessageRef message = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, isRequest);
-  if (CFHTTPMessageAppendBytes(message, data.bytes, data.length)) {
-    return message;
-  }
-  CFRelease(message);
-  return NULL;
-}
+static CFHTTPMessageRef _CreateHTTPMessageFromData(NSData *data, BOOL isRequest) {
+    CFHTTPMessageRef message = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, isRequest);
 
-static CFHTTPMessageRef _CreateHTTPMessageFromPerformingRequest(NSData* inData, NSUInteger port) {
-  CFHTTPMessageRef response = NULL;
-  int httpSocket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
-  if (httpSocket > 0) {
-    struct sockaddr_in addr4;
-    bzero(&addr4, sizeof(addr4));
-    addr4.sin_len = sizeof(addr4);
-    addr4.sin_family = AF_INET;
-    addr4.sin_port = htons(port);
-    addr4.sin_addr.s_addr = htonl(INADDR_ANY);
-    if (connect(httpSocket, (void*)&addr4, sizeof(addr4)) == 0) {
-      if (write(httpSocket, inData.bytes, inData.length) == (ssize_t)inData.length) {
-        NSMutableData* outData = [[NSMutableData alloc] initWithLength:(256 * 1024)];
-        NSUInteger length = 0;
-        while (1) {
-          ssize_t result = read(httpSocket, (char*)outData.mutableBytes + length, outData.length - length);
-          if (result < 0) {
-            length = NSUIntegerMax;
-            break;
-          } else if (result == 0) {
-            break;
-          }
-          length += result;
-          if (length >= outData.length) {
-            outData.length = 2 * outData.length;
-          }
-        }
-        if (length != NSUIntegerMax) {
-          outData.length = length;
-          response = _CreateHTTPMessageFromData(outData, NO);
-        } else {
-          GWS_DNOT_REACHED();
-        }
-      }
+    if (CFHTTPMessageAppendBytes(message, data.bytes, data.length)) {
+        return message;
     }
-    close(httpSocket);
-  }
-  return response;
+
+    CFRelease(message);
+    return NULL;
 }
 
-static void _LogResult(NSString* format, ...) {
-  va_list arguments;
-  va_start(arguments, format);
-  NSString* message = [[NSString alloc] initWithFormat:format arguments:arguments];
-  va_end(arguments);
-  fprintf(stdout, "%s\n", [message UTF8String]);
+static CFHTTPMessageRef _CreateHTTPMessageFromPerformingRequest(NSData *inData, NSUInteger port) {
+    CFHTTPMessageRef response = NULL;
+    int httpSocket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+    if (httpSocket > 0) {
+        struct sockaddr_in addr4;
+        bzero(&addr4, sizeof(addr4));
+        addr4.sin_len = sizeof(addr4);
+        addr4.sin_family = AF_INET;
+        addr4.sin_port = htons(port);
+        addr4.sin_addr.s_addr = htonl(INADDR_ANY);
+
+        if (connect(httpSocket, (void *)&addr4, sizeof(addr4)) == 0) {
+            if (write(httpSocket, inData.bytes, inData.length) == (ssize_t)inData.length) {
+                NSMutableData *outData = [[NSMutableData alloc] initWithLength:(256 * 1024)];
+                NSUInteger length = 0;
+
+                while (1) {
+                    ssize_t result = read(httpSocket, (char *)outData.mutableBytes + length, outData.length - length);
+
+                    if (result < 0) {
+                        length = NSUIntegerMax;
+                        break;
+                    } else if (result == 0) {
+                        break;
+                    }
+
+                    length += result;
+
+                    if (length >= outData.length) {
+                        outData.length = 2 * outData.length;
+                    }
+                }
+
+                if (length != NSUIntegerMax) {
+                    outData.length = length;
+                    response = _CreateHTTPMessageFromData(outData, NO);
+                } else {
+                    GWS_DNOT_REACHED();
+                }
+            }
+        }
+
+        close(httpSocket);
+    }
+
+    return response;
 }
 
-- (NSInteger)runTestsWithOptions:(NSDictionary<NSString*, id>*)options inDirectory:(NSString*)path {
-  GWS_DCHECK([NSThread isMainThread]);
-  NSArray* ignoredHeaders = @[ @"Date", @"Etag" ];  // Dates are always different by definition and ETags depend on file system node IDs
-  NSInteger result = -1;
-  if ([self startWithOptions:options error:NULL]) {
-    _ExecuteMainThreadRunLoopSources();
+static void _LogResult(NSString *format, ...) {
+    va_list arguments;
 
-    result = 0;
-    NSArray* files = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:NULL] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
-    for (NSString* requestFile in files) {
-      if (![requestFile hasSuffix:@".request"]) {
-        continue;
-      }
-      @autoreleasepool {
-        NSString* index = [[requestFile componentsSeparatedByString:@"-"] firstObject];
-        BOOL success = NO;
-        NSData* requestData = [NSData dataWithContentsOfFile:[path stringByAppendingPathComponent:requestFile]];
-        if (requestData) {
-          CFHTTPMessageRef request = _CreateHTTPMessageFromData(requestData, YES);
-          if (request) {
-            NSString* requestMethod = CFBridgingRelease(CFHTTPMessageCopyRequestMethod(request));
-            NSURL* requestURL = CFBridgingRelease(CFHTTPMessageCopyRequestURL(request));
-            _LogResult(@"[%i] %@ %@", (int)[index integerValue], requestMethod, requestURL.path);
-            NSString* prefix = [index stringByAppendingString:@"-"];
-            for (NSString* responseFile in files) {
-              if ([responseFile hasPrefix:prefix] && [responseFile hasSuffix:@".response"]) {
-                NSData* responseData = [NSData dataWithContentsOfFile:[path stringByAppendingPathComponent:responseFile]];
-                if (responseData) {
-                  CFHTTPMessageRef expectedResponse = _CreateHTTPMessageFromData(responseData, NO);
-                  if (expectedResponse) {
-                    CFHTTPMessageRef actualResponse = _CreateHTTPMessageFromPerformingRequest(requestData, self.port);
-                    if (actualResponse) {
-                      success = YES;
+    va_start(arguments, format);
+    NSString *message = [[NSString alloc] initWithFormat:format arguments:arguments];
+    va_end(arguments);
+    fprintf(stdout, "%s\n", [message UTF8String]);
+}
 
-                      CFIndex expectedStatusCode = CFHTTPMessageGetResponseStatusCode(expectedResponse);
-                      CFIndex actualStatusCode = CFHTTPMessageGetResponseStatusCode(actualResponse);
-                      if (actualStatusCode != expectedStatusCode) {
-                        _LogResult(@"  Status code not matching:\n    Expected: %i\n      Actual: %i", (int)expectedStatusCode, (int)actualStatusCode);
-                        success = NO;
-                      }
+- (NSInteger)runTestsWithOptions:(NSDictionary<NSString *, id> *)options inDirectory:(NSString *)path {
+    GWS_DCHECK([NSThread isMainThread]);
+    NSArray *ignoredHeaders = @[ @"Date", @"Etag" ]; // Dates are always different by definition and ETags depend on file system node IDs
+    NSInteger result = -1;
 
-                      NSDictionary* expectedHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(expectedResponse));
-                      NSDictionary* actualHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(actualResponse));
-                      for (NSString* expectedHeader in expectedHeaders) {
-                        if ([ignoredHeaders containsObject:expectedHeader]) {
-                          continue;
-                        }
-                        NSString* expectedValue = [expectedHeaders objectForKey:expectedHeader];
-                        NSString* actualValue = [actualHeaders objectForKey:expectedHeader];
-                        if (![actualValue isEqualToString:expectedValue]) {
-                          _LogResult(@"  Header '%@' not matching:\n    Expected: \"%@\"\n      Actual: \"%@\"", expectedHeader, expectedValue, actualValue);
-                          success = NO;
-                        }
-                      }
-                      for (NSString* actualHeader in actualHeaders) {
-                        if (![expectedHeaders objectForKey:actualHeader]) {
-                          _LogResult(@"  Header '%@' not matching:\n    Expected: \"%@\"\n      Actual: \"%@\"", actualHeader, nil, [actualHeaders objectForKey:actualHeader]);
-                          success = NO;
-                        }
-                      }
+    if ([self startWithOptions:options error:NULL]) {
+        _ExecuteMainThreadRunLoopSources();
 
-                      NSString* expectedContentLength = CFBridgingRelease(CFHTTPMessageCopyHeaderFieldValue(expectedResponse, CFSTR("Content-Length")));
-                      NSData* expectedBody = CFBridgingRelease(CFHTTPMessageCopyBody(expectedResponse));
-                      NSString* actualContentLength = CFBridgingRelease(CFHTTPMessageCopyHeaderFieldValue(actualResponse, CFSTR("Content-Length")));
-                      NSData* actualBody = CFBridgingRelease(CFHTTPMessageCopyBody(actualResponse));
-                      if ([actualContentLength isEqualToString:expectedContentLength] && (actualBody.length > expectedBody.length)) {  // Handle web browser closing connection before retrieving entire body (e.g. when playing a video file)
-                        actualBody = [actualBody subdataWithRange:NSMakeRange(0, expectedBody.length)];
-                      }
-                      if ((actualBody && expectedBody && ![actualBody isEqualToData:expectedBody]) || (actualBody && !expectedBody) || (!actualBody && expectedBody)) {
-                        _LogResult(@"  Bodies not matching:\n    Expected: %lu bytes\n      Actual: %lu bytes", (unsigned long)expectedBody.length, (unsigned long)actualBody.length);
-                        success = NO;
+        result = 0;
+        NSArray *files = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:NULL] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
+
+        for (NSString *requestFile in files) {
+            if (![requestFile hasSuffix:@".request"]) {
+                continue;
+            }
+
+            @autoreleasepool {
+                NSString *index = [[requestFile componentsSeparatedByString:@"-"] firstObject];
+                BOOL success = NO;
+                NSData *requestData = [NSData dataWithContentsOfFile:[path stringByAppendingPathComponent:requestFile]];
+
+                if (requestData) {
+                    CFHTTPMessageRef request = _CreateHTTPMessageFromData(requestData, YES);
+
+                    if (request) {
+                        NSString *requestMethod = CFBridgingRelease(CFHTTPMessageCopyRequestMethod(request));
+                        NSURL *requestURL = CFBridgingRelease(CFHTTPMessageCopyRequestURL(request));
+                        _LogResult(@"[%i] %@ %@", (int)[index integerValue], requestMethod, requestURL.path);
+                        NSString *prefix = [index stringByAppendingString:@"-"];
+
+                        for (NSString *responseFile in files) {
+                            if ([responseFile hasPrefix:prefix] && [responseFile hasSuffix:@".response"]) {
+                                NSData *responseData = [NSData dataWithContentsOfFile:[path stringByAppendingPathComponent:responseFile]];
+
+                                if (responseData) {
+                                    CFHTTPMessageRef expectedResponse = _CreateHTTPMessageFromData(responseData, NO);
+
+                                    if (expectedResponse) {
+                                        CFHTTPMessageRef actualResponse = _CreateHTTPMessageFromPerformingRequest(requestData, self.port);
+
+                                        if (actualResponse) {
+                                            success = YES;
+
+                                            CFIndex expectedStatusCode = CFHTTPMessageGetResponseStatusCode(expectedResponse);
+                                            CFIndex actualStatusCode = CFHTTPMessageGetResponseStatusCode(actualResponse);
+
+                                            if (actualStatusCode != expectedStatusCode) {
+                                                _LogResult(@"  Status code not matching:\n    Expected: %i\n      Actual: %i", (int)expectedStatusCode, (int)actualStatusCode);
+                                                success = NO;
+                                            }
+
+                                            NSDictionary *expectedHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(expectedResponse));
+                                            NSDictionary *actualHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(actualResponse));
+
+                                            for (NSString *expectedHeader in expectedHeaders) {
+                                                if ([ignoredHeaders containsObject:expectedHeader]) {
+                                                    continue;
+                                                }
+
+                                                NSString *expectedValue = [expectedHeaders objectForKey:expectedHeader];
+                                                NSString *actualValue = [actualHeaders objectForKey:expectedHeader];
+
+                                                if (![actualValue isEqualToString:expectedValue]) {
+                                                    _LogResult(@"  Header '%@' not matching:\n    Expected: \"%@\"\n      Actual: \"%@\"", expectedHeader, expectedValue, actualValue);
+                                                    success = NO;
+                                                }
+                                            }
+
+                                            for (NSString *actualHeader in actualHeaders) {
+                                                if (![expectedHeaders objectForKey:actualHeader]) {
+                                                    _LogResult(@"  Header '%@' not matching:\n    Expected: \"%@\"\n      Actual: \"%@\"", actualHeader, nil, [actualHeaders objectForKey:actualHeader]);
+                                                    success = NO;
+                                                }
+                                            }
+
+                                            NSString *expectedContentLength = CFBridgingRelease(CFHTTPMessageCopyHeaderFieldValue(expectedResponse, CFSTR("Content-Length")));
+                                            NSData *expectedBody = CFBridgingRelease(CFHTTPMessageCopyBody(expectedResponse));
+                                            NSString *actualContentLength = CFBridgingRelease(CFHTTPMessageCopyHeaderFieldValue(actualResponse, CFSTR("Content-Length")));
+                                            NSData *actualBody = CFBridgingRelease(CFHTTPMessageCopyBody(actualResponse));
+
+                                            if ([actualContentLength isEqualToString:expectedContentLength] && (actualBody.length > expectedBody.length)) { // Handle web browser closing connection before retrieving entire body (e.g. when playing a video file)
+                                                actualBody = [actualBody subdataWithRange:NSMakeRange(0, expectedBody.length)];
+                                            }
+
+                                            if ((actualBody && expectedBody && ![actualBody isEqualToData:expectedBody]) || (actualBody && !expectedBody) || (!actualBody && expectedBody)) {
+                                                _LogResult(@"  Bodies not matching:\n    Expected: %lu bytes\n      Actual: %lu bytes", (unsigned long)expectedBody.length, (unsigned long)actualBody.length);
+                                                success = NO;
 #if !TARGET_OS_IPHONE
 #if DEBUG
-                        if (GCDWebServerIsTextContentType((NSString*)[expectedHeaders objectForKey:@"Content-Type"])) {
-                          NSString* expectedPath = [NSTemporaryDirectory() stringByAppendingPathComponent:(NSString*)[[[NSProcessInfo processInfo] globallyUniqueString] stringByAppendingPathExtension:@"txt"]];
-                          NSString* actualPath = [NSTemporaryDirectory() stringByAppendingPathComponent:(NSString*)[[[NSProcessInfo processInfo] globallyUniqueString] stringByAppendingPathExtension:@"txt"]];
-                          if ([expectedBody writeToFile:expectedPath atomically:YES] && [actualBody writeToFile:actualPath atomically:YES]) {
-                            NSTask* task = [[NSTask alloc] init];
-                            [task setLaunchPath:@"/usr/bin/opendiff"];
-                            [task setArguments:@[ expectedPath, actualPath ]];
-                            [task launch];
-                          }
-                        }
-#endif
-#endif
-                      }
 
-                      CFRelease(actualResponse);
+                                                if (GCDWebServerIsTextContentType((NSString *)[expectedHeaders objectForKey:@"Content-Type"])) {
+                                                    NSString *expectedPath = [NSTemporaryDirectory() stringByAppendingPathComponent:(NSString *)[[[NSProcessInfo processInfo] globallyUniqueString] stringByAppendingPathExtension:@"txt"]];
+                                                    NSString *actualPath = [NSTemporaryDirectory() stringByAppendingPathComponent:(NSString *)[[[NSProcessInfo processInfo] globallyUniqueString] stringByAppendingPathExtension:@"txt"]];
+
+                                                    if ([expectedBody writeToFile:expectedPath atomically:YES] && [actualBody writeToFile:actualPath atomically:YES]) {
+                                                        NSTask *task = [[NSTask alloc] init];
+                                                        [task setLaunchPath:@"/usr/bin/opendiff"];
+                                                        [task setArguments:@[ expectedPath, actualPath ]];
+                                                        [task launch];
+                                                    }
+                                                }
+
+#endif
+#endif
+                                            }
+
+                                            CFRelease(actualResponse);
+                                        }
+
+                                        CFRelease(expectedResponse);
+                                    }
+                                } else {
+                                    GWS_DNOT_REACHED();
+                                }
+
+                                break;
+                            }
+                        }
+
+                        CFRelease(request);
                     }
-                    CFRelease(expectedResponse);
-                  }
                 } else {
-                  GWS_DNOT_REACHED();
+                    GWS_DNOT_REACHED();
                 }
-                break;
-              }
+
+                _LogResult(@"");
+
+                if (!success) {
+                    ++result;
+                }
             }
-            CFRelease(request);
-          }
-        } else {
-          GWS_DNOT_REACHED();
+            _ExecuteMainThreadRunLoopSources();
         }
-        _LogResult(@"");
-        if (!success) {
-          ++result;
-        }
-      }
-      _ExecuteMainThreadRunLoopSources();
+
+        [self stop];
+
+        _ExecuteMainThreadRunLoopSources();
     }
 
-    [self stop];
-
-    _ExecuteMainThreadRunLoopSources();
-  }
-  return result;
+    return result;
 }
 
 @end
 
-#endif
+#endif /* ifdef __GCDWEBSERVER_ENABLE_TESTING__ */

--- a/GCDWebServer/Core/GCDWebServerConnection.h
+++ b/GCDWebServer/Core/GCDWebServerConnection.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServer.h"
@@ -48,47 +48,47 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns the GCDWebServer that owns the connection.
  */
-@property(nonatomic, readonly) GCDWebServer* server;
+@property (nonatomic, readonly) GCDWebServer *server;
 
 /**
  *  Returns YES if the connection is using IPv6.
  */
-@property(nonatomic, readonly, getter=isUsingIPv6) BOOL usingIPv6;
+@property (nonatomic, readonly, getter = isUsingIPv6) BOOL usingIPv6;
 
 /**
  *  Returns the address of the local peer (i.e. server) of the connection
  *  as a raw "struct sockaddr".
  */
-@property(nonatomic, readonly) NSData* localAddressData;
+@property (nonatomic, readonly) NSData *localAddressData;
 
 /**
  *  Returns the address of the local peer (i.e. server) of the connection
  *  as a string.
  */
-@property(nonatomic, readonly) NSString* localAddressString;
+@property (nonatomic, readonly) NSString *localAddressString;
 
 /**
  *  Returns the address of the remote peer (i.e. client) of the connection
  *  as a raw "struct sockaddr".
  */
-@property(nonatomic, readonly) NSData* remoteAddressData;
+@property (nonatomic, readonly) NSData *remoteAddressData;
 
 /**
  *  Returns the address of the remote peer (i.e. client) of the connection
  *  as a string.
  */
-@property(nonatomic, readonly) NSString* remoteAddressString;
+@property (nonatomic, readonly) NSString *remoteAddressString;
 
 /**
  *  Returns the total number of bytes received from the remote peer (i.e. client)
  *  so far.
  */
-@property(nonatomic, readonly) NSUInteger totalBytesRead;
+@property (nonatomic, readonly) NSUInteger totalBytesRead;
 
 /**
  *  Returns the total number of bytes sent to the remote peer (i.e. client) so far.
  */
-@property(nonatomic, readonly) NSUInteger totalBytesWritten;
+@property (nonatomic, readonly) NSUInteger totalBytesWritten;
 
 @end
 
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @warning Do not attempt to modify this data.
  */
-- (void)didReadBytes:(const void*)bytes length:(NSUInteger)length;
+- (void)didReadBytes:(const void *)bytes length:(NSUInteger)length;
 
 /**
  *  This method is called whenever data has been sent
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @warning Do not attempt to modify this data.
  */
-- (void)didWriteBytes:(const void*)bytes length:(NSUInteger)length;
+- (void)didWriteBytes:(const void *)bytes length:(NSUInteger)length;
 
 /**
  *  This method is called after the HTTP headers have been received to
@@ -130,7 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The default implementation returns the original URL.
  */
-- (NSURL*)rewriteRequestURL:(NSURL*)url withMethod:(NSString*)method headers:(NSDictionary<NSString*, NSString*>*)headers;
+- (NSURL *)rewriteRequestURL:(NSURL *)url withMethod:(NSString *)method headers:(NSDictionary<NSString *, NSString *> *)headers;
 
 /**
  *  Assuming a valid HTTP request was received, this method is called before
@@ -141,14 +141,14 @@ NS_ASSUME_NONNULL_BEGIN
  *  The default implementation checks for HTTP authentication if applicable
  *  and returns a barebone 401 status code response if authentication failed.
  */
-- (nullable GCDWebServerResponse*)preflightRequest:(GCDWebServerRequest*)request;
+- (nullable GCDWebServerResponse *)preflightRequest:(GCDWebServerRequest *)request;
 
 /**
  *  Assuming a valid HTTP request was received and -preflightRequest: returned nil,
  *  this method is called to process the request by executing the handler's
  *  process block.
  */
-- (void)processRequest:(GCDWebServerRequest*)request completion:(GCDWebServerCompletionBlock)completion;
+- (void)processRequest:(GCDWebServerRequest *)request completion:(GCDWebServerCompletionBlock)completion;
 
 /**
  *  Assuming a valid HTTP request was received and either -preflightRequest:
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  "Last-Modified-Date" header of the request by a barebone "Not-Modified" (304)
  *  one.
  */
-- (GCDWebServerResponse*)overrideResponse:(GCDWebServerResponse*)response forRequest:(GCDWebServerRequest*)request;
+- (GCDWebServerResponse *)overrideResponse:(GCDWebServerResponse *)response forRequest:(GCDWebServerRequest *)request;
 
 /**
  *  This method is called if any error happens while validing or processing
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning If the request was invalid (e.g. the HTTP headers were malformed),
  *  the "request" argument will be nil.
  */
-- (void)abortRequest:(nullable GCDWebServerRequest*)request withStatusCode:(NSInteger)statusCode;
+- (void)abortRequest:(nullable GCDWebServerRequest *)request withStatusCode:(NSInteger)statusCode;
 
 /**
  *  Called when the connection is closed.

--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -38,21 +38,21 @@
 #import "GCDWebServerPrivate.h"
 
 #define kHeadersReadCapacity (1 * 1024)
-#define kBodyReadCapacity (256 * 1024)
+#define kBodyReadCapacity    (256 * 1024)
 
 typedef void (^ReadDataCompletionBlock)(BOOL success);
-typedef void (^ReadHeadersCompletionBlock)(NSData* extraData);
+typedef void (^ReadHeadersCompletionBlock)(NSData *extraData);
 typedef void (^ReadBodyCompletionBlock)(BOOL success);
 
 typedef void (^WriteDataCompletionBlock)(BOOL success);
 typedef void (^WriteHeadersCompletionBlock)(BOOL success);
 typedef void (^WriteBodyCompletionBlock)(BOOL success);
 
-static NSData* _CRLFData = nil;
-static NSData* _CRLFCRLFData = nil;
-static NSData* _continueData = nil;
-static NSData* _lastChunkData = nil;
-static NSString* _digestAuthenticationNonce = nil;
+static NSData *_CRLFData = nil;
+static NSData *_CRLFCRLFData = nil;
+static NSData *_continueData = nil;
+static NSData *_lastChunkData = nil;
+static NSString *_digestAuthenticationNonce = nil;
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
 static int32_t _connectionCounter = 0;
 #endif
@@ -60,14 +60,14 @@ static int32_t _connectionCounter = 0;
 NS_ASSUME_NONNULL_BEGIN
 
 @interface GCDWebServerConnection (Read)
-- (void)readData:(NSMutableData*)data withLength:(NSUInteger)length completionBlock:(ReadDataCompletionBlock)block;
-- (void)readHeaders:(NSMutableData*)headersData withCompletionBlock:(ReadHeadersCompletionBlock)block;
+- (void)readData:(NSMutableData *)data withLength:(NSUInteger)length completionBlock:(ReadDataCompletionBlock)block;
+- (void)readHeaders:(NSMutableData *)headersData withCompletionBlock:(ReadHeadersCompletionBlock)block;
 - (void)readBodyWithRemainingLength:(NSUInteger)length completionBlock:(ReadBodyCompletionBlock)block;
-- (void)readNextBodyChunk:(NSMutableData*)chunkData completionBlock:(ReadBodyCompletionBlock)block;
+- (void)readNextBodyChunk:(NSMutableData *)chunkData completionBlock:(ReadBodyCompletionBlock)block;
 @end
 
 @interface GCDWebServerConnection (Write)
-- (void)writeData:(NSData*)data withCompletionBlock:(WriteDataCompletionBlock)block;
+- (void)writeData:(NSData *)data withCompletionBlock:(WriteDataCompletionBlock)block;
 - (void)writeHeadersWithCompletionBlock:(WriteHeadersCompletionBlock)block;
 - (void)writeBodyWithCompletionBlock:(WriteBodyCompletionBlock)block;
 @end
@@ -75,576 +75,633 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 @implementation GCDWebServerConnection {
-  CFSocketNativeHandle _socket;
-  BOOL _virtualHEAD;
+    CFSocketNativeHandle _socket;
+    BOOL _virtualHEAD;
 
-  CFHTTPMessageRef _requestMessage;
-  GCDWebServerRequest* _request;
-  GCDWebServerHandler* _handler;
-  CFHTTPMessageRef _responseMessage;
-  GCDWebServerResponse* _response;
-  NSInteger _statusCode;
+    CFHTTPMessageRef _requestMessage;
+    GCDWebServerRequest *_request;
+    GCDWebServerHandler *_handler;
+    CFHTTPMessageRef _responseMessage;
+    GCDWebServerResponse *_response;
+    NSInteger _statusCode;
 
-  BOOL _opened;
+    BOOL _opened;
+
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
-  NSUInteger _connectionIndex;
-  NSString* _requestPath;
-  int _requestFD;
-  NSString* _responsePath;
-  int _responseFD;
+    NSUInteger _connectionIndex;
+    NSString *_requestPath;
+    int _requestFD;
+    NSString *_responsePath;
+    int _responseFD;
 #endif
 }
 
 + (void)initialize {
-  if (_CRLFData == nil) {
-    _CRLFData = [[NSData alloc] initWithBytes:"\r\n" length:2];
-    GWS_DCHECK(_CRLFData);
-  }
-  if (_CRLFCRLFData == nil) {
-    _CRLFCRLFData = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
-    GWS_DCHECK(_CRLFCRLFData);
-  }
-  if (_continueData == nil) {
-    CFHTTPMessageRef message = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 100, NULL, kCFHTTPVersion1_1);
-    _continueData = CFBridgingRelease(CFHTTPMessageCopySerializedMessage(message));
-    CFRelease(message);
-    GWS_DCHECK(_continueData);
-  }
-  if (_lastChunkData == nil) {
-    _lastChunkData = [[NSData alloc] initWithBytes:"0\r\n\r\n" length:5];
-  }
-  if (_digestAuthenticationNonce == nil) {
-    CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
-    _digestAuthenticationNonce = GCDWebServerComputeMD5Digest(@"%@", CFBridgingRelease(CFUUIDCreateString(kCFAllocatorDefault, uuid)));
-    CFRelease(uuid);
-  }
+    if (_CRLFData == nil) {
+        _CRLFData = [[NSData alloc] initWithBytes:"\r\n" length:2];
+        GWS_DCHECK(_CRLFData);
+    }
+
+    if (_CRLFCRLFData == nil) {
+        _CRLFCRLFData = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
+        GWS_DCHECK(_CRLFCRLFData);
+    }
+
+    if (_continueData == nil) {
+        CFHTTPMessageRef message = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 100, NULL, kCFHTTPVersion1_1);
+        _continueData = CFBridgingRelease(CFHTTPMessageCopySerializedMessage(message));
+        CFRelease(message);
+        GWS_DCHECK(_continueData);
+    }
+
+    if (_lastChunkData == nil) {
+        _lastChunkData = [[NSData alloc] initWithBytes:"0\r\n\r\n" length:5];
+    }
+
+    if (_digestAuthenticationNonce == nil) {
+        CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
+        _digestAuthenticationNonce = GCDWebServerComputeMD5Digest(@"%@", CFBridgingRelease(CFUUIDCreateString(kCFAllocatorDefault, uuid)));
+        CFRelease(uuid);
+    }
 }
 
 - (BOOL)isUsingIPv6 {
-  const struct sockaddr* localSockAddr = _localAddressData.bytes;
-  return (localSockAddr->sa_family == AF_INET6);
+    const struct sockaddr *localSockAddr = _localAddressData.bytes;
+
+    return (localSockAddr->sa_family == AF_INET6);
 }
 
 - (void)_initializeResponseHeadersWithStatusCode:(NSInteger)statusCode {
-  _statusCode = statusCode;
-  _responseMessage = CFHTTPMessageCreateResponse(kCFAllocatorDefault, statusCode, NULL, kCFHTTPVersion1_1);
-  CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Connection"), CFSTR("Close"));
-  CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Server"), (__bridge CFStringRef)_server.serverName);
-  CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Date"), (__bridge CFStringRef)GCDWebServerFormatRFC822([NSDate date]));
+    _statusCode = statusCode;
+    _responseMessage = CFHTTPMessageCreateResponse(kCFAllocatorDefault, statusCode, NULL, kCFHTTPVersion1_1);
+    CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Connection"), CFSTR("Close"));
+    CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Server"), (__bridge CFStringRef)_server.serverName);
+    CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Date"), (__bridge CFStringRef)GCDWebServerFormatRFC822([NSDate date]));
 }
 
 - (void)_startProcessingRequest {
-  GWS_DCHECK(_responseMessage == NULL);
+    GWS_DCHECK(_responseMessage == NULL);
 
-  GCDWebServerResponse* preflightResponse = [self preflightRequest:_request];
-  if (preflightResponse) {
-    [self _finishProcessingRequest:preflightResponse];
-  } else {
-    [self processRequest:_request
-              completion:^(GCDWebServerResponse* processResponse) {
-                [self _finishProcessingRequest:processResponse];
-              }];
-  }
+    GCDWebServerResponse *preflightResponse = [self preflightRequest:_request];
+
+    if (preflightResponse) {
+        [self _finishProcessingRequest:preflightResponse];
+    } else {
+        [self processRequest:_request
+                  completion:^(GCDWebServerResponse *processResponse) {
+                      [self _finishProcessingRequest:processResponse];
+                  }];
+    }
 }
 
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-- (void)_finishProcessingRequest:(GCDWebServerResponse*)response {
-  GWS_DCHECK(_responseMessage == NULL);
-  BOOL hasBody = NO;
+- (void)_finishProcessingRequest:(GCDWebServerResponse *)response {
+    GWS_DCHECK(_responseMessage == NULL);
+    BOOL hasBody = NO;
 
-  if (response) {
-    response = [self overrideResponse:response forRequest:_request];
-  }
-  if (response) {
-    if ([response hasBody]) {
-      [response prepareForReading];
-      hasBody = !_virtualHEAD;
+    if (response) {
+        response = [self overrideResponse:response forRequest:_request];
     }
-    NSError* error = nil;
-    if (hasBody && ![response performOpen:&error]) {
-      GWS_LOG_ERROR(@"Failed opening response body for socket %i: %@", _socket, error);
-    } else {
-      _response = response;
-    }
-  }
 
-  if (_response) {
-    [self _initializeResponseHeadersWithStatusCode:_response.statusCode];
-    if (_response.lastModifiedDate) {
-      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Last-Modified"), (__bridge CFStringRef)GCDWebServerFormatRFC822((NSDate*)_response.lastModifiedDate));
-    }
-    if (_response.eTag) {
-      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("ETag"), (__bridge CFStringRef)_response.eTag);
-    }
-    if ((_response.statusCode >= 200) && (_response.statusCode < 300)) {
-      if (_response.cacheControlMaxAge > 0) {
-        CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Cache-Control"), (__bridge CFStringRef)[NSString stringWithFormat:@"max-age=%i, public", (int)_response.cacheControlMaxAge]);
-      } else {
-        CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Cache-Control"), CFSTR("no-cache"));
-      }
-    }
-    if (_response.contentType != nil) {
-      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Content-Type"), (__bridge CFStringRef)GCDWebServerNormalizeHeaderValue(_response.contentType));
-    }
-    if (_response.contentLength != NSUIntegerMax) {
-      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Content-Length"), (__bridge CFStringRef)[NSString stringWithFormat:@"%lu", (unsigned long)_response.contentLength]);
-    }
-    if (_response.usesChunkedTransferEncoding) {
-      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Transfer-Encoding"), CFSTR("chunked"));
-    }
-    [_response.additionalHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL* stop) {
-      CFHTTPMessageSetHeaderFieldValue(self->_responseMessage, (__bridge CFStringRef)key, (__bridge CFStringRef)obj);
-    }];
-    [self writeHeadersWithCompletionBlock:^(BOOL success) {
-      if (success) {
-        if (hasBody) {
-          [self writeBodyWithCompletionBlock:^(BOOL successInner) {
-            [self->_response performClose];  // TODO: There's nothing we can do on failure as headers have already been sent
-          }];
+    if (response) {
+        if ([response hasBody]) {
+            [response prepareForReading];
+            hasBody = !_virtualHEAD;
         }
-      } else if (hasBody) {
-        [self->_response performClose];
-      }
-    }];
-  } else {
-    [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
-  }
-}
 
-- (void)_readBodyWithLength:(NSUInteger)length initialData:(NSData*)initialData {
-  NSError* error = nil;
-  if (![_request performOpen:&error]) {
-    GWS_LOG_ERROR(@"Failed opening request body for socket %i: %@", _socket, error);
-    [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
-    return;
-  }
+        NSError *error = nil;
 
-  if (initialData.length) {
-    if (![_request performWriteData:initialData error:&error]) {
-      GWS_LOG_ERROR(@"Failed writing request body on socket %i: %@", _socket, error);
-      if (![_request performClose:&error]) {
-        GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", _socket, error);
-      }
-      [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
-      return;
+        if (hasBody && ![response performOpen:&error]) {
+            GWS_LOG_ERROR(@"Failed opening response body for socket %i: %@", _socket, error);
+        } else {
+            _response = response;
+        }
     }
-    length -= initialData.length;
-  }
 
-  if (length) {
-    [self readBodyWithRemainingLength:length
-                      completionBlock:^(BOOL success) {
-                        NSError* localError = nil;
-                        if ([self->_request performClose:&localError]) {
-                          [self _startProcessingRequest];
-                        } else {
-                          GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", self->_socket, error);
-                          [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
-                        }
-                      }];
-  } else {
-    if ([_request performClose:&error]) {
-      [self _startProcessingRequest];
-    } else {
-      GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", _socket, error);
-      [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
-    }
-  }
-}
+    if (_response) {
+        [self _initializeResponseHeadersWithStatusCode:_response.statusCode];
 
-- (void)_readChunkedBodyWithInitialData:(NSData*)initialData {
-  NSError* error = nil;
-  if (![_request performOpen:&error]) {
-    GWS_LOG_ERROR(@"Failed opening request body for socket %i: %@", _socket, error);
-    [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
-    return;
-  }
+        if (_response.lastModifiedDate) {
+            CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Last-Modified"), (__bridge CFStringRef)GCDWebServerFormatRFC822((NSDate *)_response.lastModifiedDate));
+        }
 
-  NSMutableData* chunkData = [[NSMutableData alloc] initWithData:initialData];
-  [self readNextBodyChunk:chunkData
-          completionBlock:^(BOOL success) {
-            NSError* localError = nil;
-            if ([self->_request performClose:&localError]) {
-              [self _startProcessingRequest];
+        if (_response.eTag) {
+            CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("ETag"), (__bridge CFStringRef)_response.eTag);
+        }
+
+        if ((_response.statusCode >= 200) && (_response.statusCode < 300)) {
+            if (_response.cacheControlMaxAge > 0) {
+                CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Cache-Control"), (__bridge CFStringRef)[NSString stringWithFormat:@"max-age=%i, public", (int)_response.cacheControlMaxAge]);
             } else {
-              GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", self->_socket, error);
-              [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+                CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Cache-Control"), CFSTR("no-cache"));
             }
-          }];
+        }
+
+        if (_response.contentType != nil) {
+            CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Content-Type"), (__bridge CFStringRef)GCDWebServerNormalizeHeaderValue(_response.contentType));
+        }
+
+        if (_response.contentLength != NSUIntegerMax) {
+            CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Content-Length"), (__bridge CFStringRef)[NSString stringWithFormat:@"%lu", (unsigned long)_response.contentLength]);
+        }
+
+        if (_response.usesChunkedTransferEncoding) {
+            CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Transfer-Encoding"), CFSTR("chunked"));
+        }
+
+        [_response.additionalHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+                                         CFHTTPMessageSetHeaderFieldValue(self->_responseMessage, (__bridge CFStringRef)key, (__bridge CFStringRef)obj);
+                                     }];
+        [self writeHeadersWithCompletionBlock:^(BOOL success) {
+                  if (success) {
+                  if (hasBody) {
+                    [self writeBodyWithCompletionBlock:^(BOOL successInner) {
+                              [self->_response performClose]; // TODO: There's nothing we can do on failure as headers have already been sent
+                    }];
+                  }
+                  } else if (hasBody) {
+                  [self->_response performClose];
+                  }
+              }];
+    } else {
+        [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+    }
+}
+
+- (void)_readBodyWithLength:(NSUInteger)length initialData:(NSData *)initialData {
+    NSError *error = nil;
+
+    if (![_request performOpen:&error]) {
+        GWS_LOG_ERROR(@"Failed opening request body for socket %i: %@", _socket, error);
+        [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+        return;
+    }
+
+    if (initialData.length) {
+        if (![_request performWriteData:initialData error:&error]) {
+            GWS_LOG_ERROR(@"Failed writing request body on socket %i: %@", _socket, error);
+
+            if (![_request performClose:&error]) {
+                GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", _socket, error);
+            }
+
+            [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+            return;
+        }
+
+        length -= initialData.length;
+    }
+
+    if (length) {
+        [self readBodyWithRemainingLength:length
+                          completionBlock:^(BOOL success) {
+                              NSError *localError = nil;
+
+                              if ([self->_request performClose:&localError]) {
+                                  [self _startProcessingRequest];
+                              } else {
+                                  GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", self->_socket, error);
+                                  [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+                              }
+                          }];
+    } else {
+        if ([_request performClose:&error]) {
+            [self _startProcessingRequest];
+        } else {
+            GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", _socket, error);
+            [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+        }
+    }
+}
+
+- (void)_readChunkedBodyWithInitialData:(NSData *)initialData {
+    NSError *error = nil;
+
+    if (![_request performOpen:&error]) {
+        GWS_LOG_ERROR(@"Failed opening request body for socket %i: %@", _socket, error);
+        [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+        return;
+    }
+
+    NSMutableData *chunkData = [[NSMutableData alloc] initWithData:initialData];
+    [self readNextBodyChunk:chunkData
+            completionBlock:^(BOOL success) {
+                NSError *localError = nil;
+
+                if ([self->_request performClose:&localError]) {
+                    [self _startProcessingRequest];
+                } else {
+                    GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", self->_socket, error);
+                    [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+                }
+            }];
 }
 
 - (void)_readRequestHeaders {
-  _requestMessage = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, true);
-  NSMutableData* headersData = [[NSMutableData alloc] initWithCapacity:kHeadersReadCapacity];
-  [self readHeaders:headersData
-      withCompletionBlock:^(NSData* extraData) {
-        if (extraData) {
-          NSString* requestMethod = CFBridgingRelease(CFHTTPMessageCopyRequestMethod(self->_requestMessage));  // Method verbs are case-sensitive and uppercase
-          if (self->_server.shouldAutomaticallyMapHEADToGET && [requestMethod isEqualToString:@"HEAD"]) {
-            requestMethod = @"GET";
-            self->_virtualHEAD = YES;
-          }
-          NSDictionary* requestHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(self->_requestMessage));  // Header names are case-insensitive but CFHTTPMessageCopyAllHeaderFields() will standardize the common ones
-          NSURL* requestURL = CFBridgingRelease(CFHTTPMessageCopyRequestURL(self->_requestMessage));
-          if (requestURL) {
-            requestURL = [self rewriteRequestURL:requestURL withMethod:requestMethod headers:requestHeaders];
-            GWS_DCHECK(requestURL);
-          }
-          NSString* urlPath = requestURL ? CFBridgingRelease(CFURLCopyPath((CFURLRef)requestURL)) : nil;  // Don't use -[NSURL path] which strips the ending slash
-          if (urlPath == nil) {
-            urlPath = @"/";  // CFURLCopyPath() returns NULL for a relative URL with path "//" contrary to -[NSURL path] which returns "/"
-          }
-          NSString* requestPath = urlPath ? GCDWebServerUnescapeURLString(urlPath) : nil;
-          NSString* queryString = requestURL ? CFBridgingRelease(CFURLCopyQueryString((CFURLRef)requestURL, NULL)) : nil;  // Don't use -[NSURL query] to make sure query is not unescaped;
-          NSDictionary* requestQuery = queryString ? GCDWebServerParseURLEncodedForm(queryString) : @{};
-          if (requestMethod && requestURL && requestHeaders && requestPath && requestQuery) {
-            for (self->_handler in self->_server.handlers) {
-              self->_request = self->_handler.matchBlock(requestMethod, requestURL, requestHeaders, requestPath, requestQuery);
-              if (self->_request) {
-                break;
-              }
-            }
-            if (self->_request) {
-              self->_request.localAddressData = self.localAddressData;
-              self->_request.remoteAddressData = self.remoteAddressData;
-              if ([self->_request hasBody]) {
-                [self->_request prepareForWriting];
-                if (self->_request.usesChunkedTransferEncoding || (extraData.length <= self->_request.contentLength)) {
-                  NSString* expectHeader = [requestHeaders objectForKey:@"Expect"];
-                  if (expectHeader) {
-                    if ([expectHeader caseInsensitiveCompare:@"100-continue"] == NSOrderedSame) {  // TODO: Actually validate request before continuing
-                      [self writeData:_continueData
-                          withCompletionBlock:^(BOOL success) {
-                            if (success) {
-                              if (self->_request.usesChunkedTransferEncoding) {
-                                [self _readChunkedBodyWithInitialData:extraData];
-                              } else {
-                                [self _readBodyWithLength:self->_request.contentLength initialData:extraData];
-                              }
-                            }
-                          }];
-                    } else {
-                      GWS_LOG_ERROR(@"Unsupported 'Expect' / 'Content-Length' header combination on socket %i", self->_socket);
-                      [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_ExpectationFailed];
-                    }
-                  } else {
-                    if (self->_request.usesChunkedTransferEncoding) {
-                      [self _readChunkedBodyWithInitialData:extraData];
-                    } else {
-                      [self _readBodyWithLength:self->_request.contentLength initialData:extraData];
-                    }
-                  }
-                } else {
-                  GWS_LOG_ERROR(@"Unexpected 'Content-Length' header value on socket %i", self->_socket);
-                  [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_BadRequest];
-                }
-              } else {
-                [self _startProcessingRequest];
-              }
-            } else {
-              self->_request = [[GCDWebServerRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:requestPath query:requestQuery];
-              GWS_DCHECK(self->_request);
-              [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_NotImplemented];
-            }
-          } else {
-            [self abortRequest:nil withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
-            GWS_DNOT_REACHED();
-          }
-        } else {
-          [self abortRequest:nil withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
-        }
+    _requestMessage = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, true);
+    NSMutableData *headersData = [[NSMutableData alloc] initWithCapacity:kHeadersReadCapacity];
+    [self readHeaders:headersData
+   withCompletionBlock:^(NSData *extraData) {
+      if (extraData) {
+       NSString *requestMethod = CFBridgingRelease(CFHTTPMessageCopyRequestMethod(self->_requestMessage));     // Method verbs are case-sensitive and uppercase
+
+       if (self->_server.shouldAutomaticallyMapHEADToGET && [requestMethod isEqualToString:@"HEAD"]) {
+           requestMethod = @"GET";
+           self->_virtualHEAD = YES;
+       }
+
+       NSDictionary *requestHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(self->_requestMessage));     // Header names are case-insensitive but CFHTTPMessageCopyAllHeaderFields() will standardize the common ones
+       NSURL *requestURL = CFBridgingRelease(CFHTTPMessageCopyRequestURL(self->_requestMessage));
+
+       if (requestURL) {
+           requestURL = [self rewriteRequestURL:requestURL withMethod:requestMethod headers:requestHeaders];
+           GWS_DCHECK(requestURL);
+       }
+
+       NSString *urlPath = requestURL ? CFBridgingRelease(CFURLCopyPath((CFURLRef)requestURL)) : nil;     // Don't use -[NSURL path] which strips the ending slash
+
+       if (urlPath == nil) {
+           urlPath = @"/";   // CFURLCopyPath() returns NULL for a relative URL with path "//" contrary to -[NSURL path] which returns "/"
+       }
+
+       NSString *requestPath = urlPath ? GCDWebServerUnescapeURLString(urlPath) : nil;
+       NSString *queryString = requestURL ? CFBridgingRelease(CFURLCopyQueryString((CFURLRef)requestURL, NULL)) : nil;     // Don't use -[NSURL query] to make sure query is not unescaped;
+       NSDictionary *requestQuery = queryString ? GCDWebServerParseURLEncodedForm(queryString) : @{};
+
+       if (requestMethod && requestURL && requestHeaders && requestPath && requestQuery) {
+           for (self->_handler in self->_server.handlers) {
+               self->_request = self->_handler.matchBlock(requestMethod, requestURL, requestHeaders, requestPath, requestQuery);
+
+               if (self->_request) {
+                   break;
+               }
+           }
+
+           if (self->_request) {
+               self->_request.localAddressData = self.localAddressData;
+               self->_request.remoteAddressData = self.remoteAddressData;
+
+               if ([self->_request hasBody]) {
+                   [self->_request prepareForWriting];
+
+                   if (self->_request.usesChunkedTransferEncoding || (extraData.length <= self->_request.contentLength)) {
+                       NSString *expectHeader = [requestHeaders objectForKey:@"Expect"];
+
+                       if (expectHeader) {
+                           if ([expectHeader caseInsensitiveCompare:@"100-continue"] == NSOrderedSame) { // TODO: Actually validate request before continuing
+                               [self writeData:_continueData
+                           withCompletionBlock:^(BOOL success) {
+                               if (success) {
+                               if (self->_request.usesChunkedTransferEncoding) {
+                               [self _readChunkedBodyWithInitialData:extraData];
+                               } else {
+                               [self _readBodyWithLength:self->_request.contentLength initialData:extraData];
+                               }
+                               }
       }];
+                           } else {
+                               GWS_LOG_ERROR(@"Unsupported 'Expect' / 'Content-Length' header combination on socket %i", self->_socket);
+                               [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_ExpectationFailed];
+                           }
+                       } else {
+                           if (self->_request.usesChunkedTransferEncoding) {
+                               [self _readChunkedBodyWithInitialData:extraData];
+                           } else {
+                               [self _readBodyWithLength:self->_request.contentLength initialData:extraData];
+                           }
+                       }
+                   } else {
+                       GWS_LOG_ERROR(@"Unexpected 'Content-Length' header value on socket %i", self->_socket);
+                       [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_BadRequest];
+                   }
+               } else {
+                   [self _startProcessingRequest];
+               }
+           } else {
+               self->_request = [[GCDWebServerRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:requestPath query:requestQuery];
+               GWS_DCHECK(self->_request);
+               [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_NotImplemented];
+           }
+       } else {
+           [self abortRequest:nil withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+           GWS_DNOT_REACHED();
+       }
+      } else {
+       [self abortRequest:nil withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+      }
+  }];
 }
 
-- (instancetype)initWithServer:(GCDWebServer*)server localAddress:(NSData*)localAddress remoteAddress:(NSData*)remoteAddress socket:(CFSocketNativeHandle)socket {
-  if ((self = [super init])) {
-    _server = server;
-    _localAddressData = localAddress;
-    _remoteAddressData = remoteAddress;
-    _socket = socket;
-    GWS_LOG_DEBUG(@"Did open connection on socket %i", _socket);
+- (instancetype)initWithServer:(GCDWebServer *)server localAddress:(NSData *)localAddress remoteAddress:(NSData *)remoteAddress socket:(CFSocketNativeHandle)socket {
+    if ((self = [super init])) {
+        _server = server;
+        _localAddressData = localAddress;
+        _remoteAddressData = remoteAddress;
+        _socket = socket;
+        GWS_LOG_DEBUG(@"Did open connection on socket %i", _socket);
 
-    [_server willStartConnection:self];
+        [_server willStartConnection:self];
 
-    if (![self open]) {
-      close(_socket);
-      return nil;
+        if (![self open]) {
+            close(_socket);
+            return nil;
+        }
+
+        _opened = YES;
+
+        [self _readRequestHeaders];
     }
-    _opened = YES;
 
-    [self _readRequestHeaders];
-  }
-  return self;
+    return self;
 }
 
-- (NSString*)localAddressString {
-  return GCDWebServerStringFromSockAddr(_localAddressData.bytes, YES);
+- (NSString *)localAddressString {
+    return GCDWebServerStringFromSockAddr(_localAddressData.bytes, YES);
 }
 
-- (NSString*)remoteAddressString {
-  return GCDWebServerStringFromSockAddr(_remoteAddressData.bytes, YES);
+- (NSString *)remoteAddressString {
+    return GCDWebServerStringFromSockAddr(_remoteAddressData.bytes, YES);
 }
 
 - (void)dealloc {
-  int result = close(_socket);
-  if (result != 0) {
-    GWS_LOG_ERROR(@"Failed closing socket %i for connection: %s (%i)", _socket, strerror(errno), errno);
-  } else {
-    GWS_LOG_DEBUG(@"Did close connection on socket %i", _socket);
-  }
+    int result = close(_socket);
 
-  if (_opened) {
-    [self close];
-  }
+    if (result != 0) {
+        GWS_LOG_ERROR(@"Failed closing socket %i for connection: %s (%i)", _socket, strerror(errno), errno);
+    } else {
+        GWS_LOG_DEBUG(@"Did close connection on socket %i", _socket);
+    }
 
-  [_server didEndConnection:self];
+    if (_opened) {
+        [self close];
+    }
 
-  if (_requestMessage) {
-    CFRelease(_requestMessage);
-  }
+    [_server didEndConnection:self];
 
-  if (_responseMessage) {
-    CFRelease(_responseMessage);
-  }
+    if (_requestMessage) {
+        CFRelease(_requestMessage);
+    }
+
+    if (_responseMessage) {
+        CFRelease(_responseMessage);
+    }
 }
 
 @end
 
 @implementation GCDWebServerConnection (Read)
 
-- (void)readData:(NSMutableData*)data withLength:(NSUInteger)length completionBlock:(ReadDataCompletionBlock)block {
-  dispatch_read(_socket, length, dispatch_get_global_queue(_server.dispatchQueuePriority, 0), ^(dispatch_data_t buffer, int error) {
-    @autoreleasepool {
-      if (error == 0) {
-        size_t size = dispatch_data_get_size(buffer);
-        if (size > 0) {
-          NSUInteger originalLength = data.length;
-          dispatch_data_apply(buffer, ^bool(dispatch_data_t region, size_t chunkOffset, const void* chunkBytes, size_t chunkSize) {
-            [data appendBytes:chunkBytes length:chunkSize];
-            return true;
-          });
-          [self didReadBytes:((char*)data.bytes + originalLength) length:(data.length - originalLength)];
-          block(YES);
-        } else {
-          if (self->_totalBytesRead > 0) {
-            GWS_LOG_ERROR(@"No more data available on socket %i", self->_socket);
-          } else {
-            GWS_LOG_WARNING(@"No data received from socket %i", self->_socket);
-          }
-          block(NO);
+- (void)readData:(NSMutableData *)data withLength:(NSUInteger)length completionBlock:(ReadDataCompletionBlock)block {
+    dispatch_read(_socket, length, dispatch_get_global_queue(_server.dispatchQueuePriority, 0), ^(dispatch_data_t buffer, int error) {
+        @autoreleasepool {
+            if (error == 0) {
+                size_t size = dispatch_data_get_size(buffer);
+
+                if (size > 0) {
+                    NSUInteger originalLength = data.length;
+                    dispatch_data_apply(buffer, ^bool (dispatch_data_t region, size_t chunkOffset, const void *chunkBytes, size_t chunkSize) {
+                        [data appendBytes:chunkBytes length:chunkSize];
+                        return true;
+                    });
+                    [self didReadBytes:((char *)data.bytes + originalLength) length:(data.length - originalLength)];
+                    block(YES);
+                } else {
+                    if (self->_totalBytesRead > 0) {
+                        GWS_LOG_ERROR(@"No more data available on socket %i", self->_socket);
+                    } else {
+                        GWS_LOG_WARNING(@"No data received from socket %i", self->_socket);
+                    }
+
+                    block(NO);
+                }
+            } else {
+                GWS_LOG_ERROR(@"Error while reading from socket %i: %s (%i)", self->_socket, strerror(error), error);
+                block(NO);
+            }
         }
-      } else {
-        GWS_LOG_ERROR(@"Error while reading from socket %i: %s (%i)", self->_socket, strerror(error), error);
-        block(NO);
-      }
-    }
-  });
+    });
 }
 
-- (void)readHeaders:(NSMutableData*)headersData withCompletionBlock:(ReadHeadersCompletionBlock)block {
-  GWS_DCHECK(_requestMessage);
-  [self readData:headersData
-           withLength:NSUIntegerMax
-      completionBlock:^(BOOL success) {
-        if (success) {
-          NSRange range = [headersData rangeOfData:_CRLFCRLFData options:0 range:NSMakeRange(0, headersData.length)];
-          if (range.location == NSNotFound) {
-            [self readHeaders:headersData withCompletionBlock:block];
-          } else {
-            NSUInteger length = range.location + range.length;
-            if (CFHTTPMessageAppendBytes(self->_requestMessage, headersData.bytes, length)) {
-              if (CFHTTPMessageIsHeaderComplete(self->_requestMessage)) {
-                block([headersData subdataWithRange:NSMakeRange(length, headersData.length - length)]);
-              } else {
-                GWS_LOG_ERROR(@"Failed parsing request headers from socket %i", self->_socket);
-                block(nil);
-              }
-            } else {
-              GWS_LOG_ERROR(@"Failed appending request headers data from socket %i", self->_socket);
-              block(nil);
-            }
-          }
-        } else {
-          block(nil);
-        }
-      }];
+- (void)readHeaders:(NSMutableData *)headersData withCompletionBlock:(ReadHeadersCompletionBlock)block {
+    GWS_DCHECK(_requestMessage);
+    [self   readData:headersData
+          withLength:NSUIntegerMax
+     completionBlock:^(BOOL success) {
+         if (success) {
+         NSRange range = [headersData rangeOfData:_CRLFCRLFData options:0 range:NSMakeRange(0, headersData.length)];
+
+         if (range.location == NSNotFound) {
+           [self readHeaders:headersData withCompletionBlock:block];
+         } else {
+           NSUInteger length = range.location + range.length;
+
+           if (CFHTTPMessageAppendBytes(self->_requestMessage, headersData.bytes, length)) {
+               if (CFHTTPMessageIsHeaderComplete(self->_requestMessage)) {
+                   block([headersData subdataWithRange:NSMakeRange(length, headersData.length - length)]);
+               } else {
+                   GWS_LOG_ERROR(@"Failed parsing request headers from socket %i", self->_socket);
+                   block(nil);
+               }
+           } else {
+               GWS_LOG_ERROR(@"Failed appending request headers data from socket %i", self->_socket);
+               block(nil);
+           }
+         }
+         } else {
+         block(nil);
+         }
+     }];
 }
 
 - (void)readBodyWithRemainingLength:(NSUInteger)length completionBlock:(ReadBodyCompletionBlock)block {
-  GWS_DCHECK([_request hasBody] && ![_request usesChunkedTransferEncoding]);
-  NSMutableData* bodyData = [[NSMutableData alloc] initWithCapacity:kBodyReadCapacity];
-  [self readData:bodyData
-           withLength:length
-      completionBlock:^(BOOL success) {
-        if (success) {
-          if (bodyData.length <= length) {
-            NSError* error = nil;
-            if ([self->_request performWriteData:bodyData error:&error]) {
-              NSUInteger remainingLength = length - bodyData.length;
-              if (remainingLength) {
-                [self readBodyWithRemainingLength:remainingLength completionBlock:block];
-              } else {
-                block(YES);
-              }
+    GWS_DCHECK([_request hasBody] && ![_request usesChunkedTransferEncoding]);
+    NSMutableData *bodyData = [[NSMutableData alloc] initWithCapacity:kBodyReadCapacity];
+    [self   readData:bodyData
+          withLength:length
+     completionBlock:^(BOOL success) {
+         if (success) {
+         if (bodyData.length <= length) {
+           NSError *error = nil;
+
+           if ([self->_request performWriteData:bodyData error:&error]) {
+               NSUInteger remainingLength = length - bodyData.length;
+
+               if (remainingLength) {
+                   [self readBodyWithRemainingLength:remainingLength completionBlock:block];
+               } else {
+                   block(YES);
+               }
+           } else {
+               GWS_LOG_ERROR(@"Failed writing request body on socket %i: %@", self->_socket, error);
+               block(NO);
+           }
+         } else {
+           GWS_LOG_ERROR(@"Unexpected extra content reading request body on socket %i", self->_socket);
+           block(NO);
+           GWS_DNOT_REACHED();
+         }
+         } else {
+         block(NO);
+         }
+     }];
+}
+
+static inline NSUInteger _ScanHexNumber(const void *bytes, NSUInteger size) {
+    char buffer[size + 1];
+
+    bcopy(bytes, buffer, size);
+    buffer[size] = 0;
+    char *end = NULL;
+    long result = strtol(buffer, &end, 16);
+    return ((end != NULL) && (*end == 0) && (result >= 0) ? result : NSNotFound);
+}
+
+- (void)readNextBodyChunk:(NSMutableData *)chunkData completionBlock:(ReadBodyCompletionBlock)block {
+    GWS_DCHECK([_request hasBody] && [_request usesChunkedTransferEncoding]);
+
+    while (1) {
+        NSRange range = [chunkData rangeOfData:_CRLFData options:0 range:NSMakeRange(0, chunkData.length)];
+
+        if (range.location == NSNotFound) {
+            break;
+        }
+
+        NSRange extensionRange = [chunkData rangeOfData:[NSData dataWithBytes:";" length:1] options:0 range:NSMakeRange(0, range.location)]; // Ignore chunk extensions
+        NSUInteger length = _ScanHexNumber((char *)chunkData.bytes, extensionRange.location != NSNotFound ? extensionRange.location : range.location);
+
+        if (length != NSNotFound) {
+            if (length) {
+                if (chunkData.length < range.location + range.length + length + 2) {
+                    break;
+                }
+
+                const char *ptr = (char *)chunkData.bytes + range.location + range.length + length;
+
+                if ((*ptr == '\r') && (*(ptr + 1) == '\n')) {
+                    NSError *error = nil;
+
+                    if ([_request performWriteData:[chunkData subdataWithRange:NSMakeRange(range.location + range.length, length)] error:&error]) {
+                        [chunkData replaceBytesInRange:NSMakeRange(0, range.location + range.length + length + 2) withBytes:NULL length:0];
+                    } else {
+                        GWS_LOG_ERROR(@"Failed writing request body on socket %i: %@", _socket, error);
+                        block(NO);
+                        return;
+                    }
+                } else {
+                    GWS_LOG_ERROR(@"Missing terminating CRLF sequence for chunk reading request body on socket %i", _socket);
+                    block(NO);
+                    return;
+                }
             } else {
-              GWS_LOG_ERROR(@"Failed writing request body on socket %i: %@", self->_socket, error);
-              block(NO);
+                NSRange trailerRange = [chunkData rangeOfData:_CRLFCRLFData options:0 range:NSMakeRange(range.location, chunkData.length - range.location)]; // Ignore trailers
+
+                if (trailerRange.location != NSNotFound) {
+                    block(YES);
+                    return;
+                }
             }
-          } else {
-            GWS_LOG_ERROR(@"Unexpected extra content reading request body on socket %i", self->_socket);
-            block(NO);
-            GWS_DNOT_REACHED();
-          }
         } else {
-          block(NO);
-        }
-      }];
-}
-
-static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
-  char buffer[size + 1];
-  bcopy(bytes, buffer, size);
-  buffer[size] = 0;
-  char* end = NULL;
-  long result = strtol(buffer, &end, 16);
-  return ((end != NULL) && (*end == 0) && (result >= 0) ? result : NSNotFound);
-}
-
-- (void)readNextBodyChunk:(NSMutableData*)chunkData completionBlock:(ReadBodyCompletionBlock)block {
-  GWS_DCHECK([_request hasBody] && [_request usesChunkedTransferEncoding]);
-
-  while (1) {
-    NSRange range = [chunkData rangeOfData:_CRLFData options:0 range:NSMakeRange(0, chunkData.length)];
-    if (range.location == NSNotFound) {
-      break;
-    }
-    NSRange extensionRange = [chunkData rangeOfData:[NSData dataWithBytes:";" length:1] options:0 range:NSMakeRange(0, range.location)];  // Ignore chunk extensions
-    NSUInteger length = _ScanHexNumber((char*)chunkData.bytes, extensionRange.location != NSNotFound ? extensionRange.location : range.location);
-    if (length != NSNotFound) {
-      if (length) {
-        if (chunkData.length < range.location + range.length + length + 2) {
-          break;
-        }
-        const char* ptr = (char*)chunkData.bytes + range.location + range.length + length;
-        if ((*ptr == '\r') && (*(ptr + 1) == '\n')) {
-          NSError* error = nil;
-          if ([_request performWriteData:[chunkData subdataWithRange:NSMakeRange(range.location + range.length, length)] error:&error]) {
-            [chunkData replaceBytesInRange:NSMakeRange(0, range.location + range.length + length + 2) withBytes:NULL length:0];
-          } else {
-            GWS_LOG_ERROR(@"Failed writing request body on socket %i: %@", _socket, error);
+            GWS_LOG_ERROR(@"Invalid chunk length reading request body on socket %i", _socket);
             block(NO);
             return;
-          }
-        } else {
-          GWS_LOG_ERROR(@"Missing terminating CRLF sequence for chunk reading request body on socket %i", _socket);
-          block(NO);
-          return;
         }
-      } else {
-        NSRange trailerRange = [chunkData rangeOfData:_CRLFCRLFData options:0 range:NSMakeRange(range.location, chunkData.length - range.location)];  // Ignore trailers
-        if (trailerRange.location != NSNotFound) {
-          block(YES);
-          return;
-        }
-      }
-    } else {
-      GWS_LOG_ERROR(@"Invalid chunk length reading request body on socket %i", _socket);
-      block(NO);
-      return;
     }
-  }
 
-  [self readData:chunkData
-           withLength:NSUIntegerMax
-      completionBlock:^(BOOL success) {
-        if (success) {
-          [self readNextBodyChunk:chunkData completionBlock:block];
-        } else {
-          block(NO);
-        }
-      }];
+    [self   readData:chunkData
+          withLength:NSUIntegerMax
+     completionBlock:^(BOOL success) {
+         if (success) {
+         [self readNextBodyChunk:chunkData completionBlock:block];
+         } else {
+         block(NO);
+         }
+     }];
 }
 
 @end
 
 @implementation GCDWebServerConnection (Write)
 
-- (void)writeData:(NSData*)data withCompletionBlock:(WriteDataCompletionBlock)block {
-  dispatch_data_t buffer = dispatch_data_create(data.bytes, data.length, dispatch_get_global_queue(_server.dispatchQueuePriority, 0), ^{
-    [data self];  // Keeps ARC from releasing data too early
-  });
-  dispatch_write(_socket, buffer, dispatch_get_global_queue(_server.dispatchQueuePriority, 0), ^(dispatch_data_t remainingData, int error) {
-    @autoreleasepool {
-      if (error == 0) {
-        GWS_DCHECK(remainingData == NULL);
-        [self didWriteBytes:data.bytes length:data.length];
-        block(YES);
-      } else {
-        GWS_LOG_ERROR(@"Error while writing to socket %i: %s (%i)", self->_socket, strerror(error), error);
-        block(NO);
-      }
-    }
-  });
+- (void)writeData:(NSData *)data withCompletionBlock:(WriteDataCompletionBlock)block {
+    dispatch_data_t buffer = dispatch_data_create(data.bytes, data.length, dispatch_get_global_queue(_server.dispatchQueuePriority, 0), ^{
+        [data self]; // Keeps ARC from releasing data too early
+    });
+
+    dispatch_write(_socket, buffer, dispatch_get_global_queue(_server.dispatchQueuePriority, 0), ^(dispatch_data_t remainingData, int error) {
+        @autoreleasepool {
+            if (error == 0) {
+                GWS_DCHECK(remainingData == NULL);
+                [self didWriteBytes:data.bytes length:data.length];
+                block(YES);
+            } else {
+                GWS_LOG_ERROR(@"Error while writing to socket %i: %s (%i)", self->_socket, strerror(error), error);
+                block(NO);
+            }
+        }
+    });
 #if !OS_OBJECT_USE_OBJC_RETAIN_RELEASE
-  dispatch_release(buffer);
+    dispatch_release(buffer);
 #endif
 }
 
 - (void)writeHeadersWithCompletionBlock:(WriteHeadersCompletionBlock)block {
-  GWS_DCHECK(_responseMessage);
-  CFDataRef data = CFHTTPMessageCopySerializedMessage(_responseMessage);
-  [self writeData:(__bridge NSData*)data withCompletionBlock:block];
-  CFRelease(data);
+    GWS_DCHECK(_responseMessage);
+    CFDataRef data = CFHTTPMessageCopySerializedMessage(_responseMessage);
+    [self writeData:(__bridge NSData *)data withCompletionBlock:block];
+    CFRelease(data);
 }
 
 - (void)writeBodyWithCompletionBlock:(WriteBodyCompletionBlock)block {
-  GWS_DCHECK([_response hasBody]);
-  [_response performReadDataWithCompletion:^(NSData* data, NSError* error) {
-    if (data) {
-      if (data.length) {
-        if (self->_response.usesChunkedTransferEncoding) {
-          const char* hexString = [[NSString stringWithFormat:@"%lx", (unsigned long)data.length] UTF8String];
-          size_t hexLength = strlen(hexString);
-          NSData* chunk = [NSMutableData dataWithLength:(hexLength + 2 + data.length + 2)];
-          if (chunk == nil) {
-            GWS_LOG_ERROR(@"Failed allocating memory for response body chunk for socket %i: %@", self->_socket, error);
-            block(NO);
-            return;
-          }
-          char* ptr = (char*)[(NSMutableData*)chunk mutableBytes];
-          bcopy(hexString, ptr, hexLength);
-          ptr += hexLength;
-          *ptr++ = '\r';
-          *ptr++ = '\n';
-          bcopy(data.bytes, ptr, data.length);
-          ptr += data.length;
-          *ptr++ = '\r';
-          *ptr = '\n';
-          data = chunk;
-        }
-        [self writeData:data
+    GWS_DCHECK([_response hasBody]);
+    [_response performReadDataWithCompletion:^(NSData *data, NSError *error) {
+                   if (data) {
+                   if (data.length) {
+                   if (self->_response.usesChunkedTransferEncoding) {
+                    const char *hexString = [[NSString stringWithFormat:@"%lx", (unsigned long)data.length] UTF8String];
+                    size_t hexLength = strlen(hexString);
+                    NSData *chunk = [NSMutableData dataWithLength:(hexLength + 2 + data.length + 2)];
+
+                    if (chunk == nil) {
+                        GWS_LOG_ERROR(@"Failed allocating memory for response body chunk for socket %i: %@", self->_socket, error);
+                        block(NO);
+                        return;
+                    }
+
+                    char *ptr = (char *)[(NSMutableData *)chunk mutableBytes];
+                    bcopy(hexString, ptr, hexLength);
+                    ptr += hexLength;
+                    *ptr++ = '\r';
+                    *ptr++ = '\n';
+                    bcopy(data.bytes, ptr, data.length);
+                    ptr += data.length;
+                    *ptr++ = '\r';
+                    *ptr = '\n';
+                    data = chunk;
+                   }
+
+                   [self writeData:data
             withCompletionBlock:^(BOOL success) {
-              if (success) {
+                if (success) {
                 [self writeBodyWithCompletionBlock:block];
-              } else {
+                } else {
                 block(NO);
-              }
-            }];
-      } else {
-        if (self->_response.usesChunkedTransferEncoding) {
-          [self writeData:_lastChunkData
-              withCompletionBlock:^(BOOL success) {
-                block(success);
-              }];
-        } else {
-          block(YES);
-        }
-      }
-    } else {
-      GWS_LOG_ERROR(@"Failed reading response body for socket %i: %@", self->_socket, error);
-      block(NO);
-    }
-  }];
+                }
+                   }];
+                   } else {
+                   if (self->_response.usesChunkedTransferEncoding) {
+                    [self writeData:_lastChunkData
+                withCompletionBlock:^(BOOL success) {
+                    block(success);
+                   }];
+                   } else {
+                    block(YES);
+                   }
+                   }
+                   } else {
+                   GWS_LOG_ERROR(@"Failed reading response body for socket %i: %@", self->_socket, error);
+                   block(NO);
+                   }
+               }];
 }
 
 @end
@@ -653,195 +710,223 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
 
 - (BOOL)open {
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
-  if (_server.recordingEnabled) {
+
+    if (_server.recordingEnabled) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    _connectionIndex = OSAtomicIncrement32(&_connectionCounter);
+        _connectionIndex = OSAtomicIncrement32(&_connectionCounter);
 #pragma clang diagnostic pop
 
-    _requestPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
-    _requestFD = open([_requestPath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-    GWS_DCHECK(_requestFD > 0);
+        _requestPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+        _requestFD = open([_requestPath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        GWS_DCHECK(_requestFD > 0);
 
-    _responsePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
-    _responseFD = open([_responsePath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-    GWS_DCHECK(_responseFD > 0);
-  }
+        _responsePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+        _responseFD = open([_responsePath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        GWS_DCHECK(_responseFD > 0);
+    }
+
 #endif
 
-  return YES;
+    return YES;
 }
 
-- (void)didReadBytes:(const void*)bytes length:(NSUInteger)length {
-  GWS_LOG_DEBUG(@"Connection received %lu bytes on socket %i", (unsigned long)length, _socket);
-  _totalBytesRead += length;
+- (void)didReadBytes:(const void *)bytes length:(NSUInteger)length {
+    GWS_LOG_DEBUG(@"Connection received %lu bytes on socket %i", (unsigned long)length, _socket);
+    _totalBytesRead += length;
 
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
-  if ((_requestFD > 0) && (write(_requestFD, bytes, length) != (ssize_t)length)) {
-    GWS_LOG_ERROR(@"Failed recording request data: %s (%i)", strerror(errno), errno);
-    close(_requestFD);
-    _requestFD = 0;
-  }
+
+    if ((_requestFD > 0) && (write(_requestFD, bytes, length) != (ssize_t)length)) {
+        GWS_LOG_ERROR(@"Failed recording request data: %s (%i)", strerror(errno), errno);
+        close(_requestFD);
+        _requestFD = 0;
+    }
+
 #endif
 }
 
-- (void)didWriteBytes:(const void*)bytes length:(NSUInteger)length {
-  GWS_LOG_DEBUG(@"Connection sent %lu bytes on socket %i", (unsigned long)length, _socket);
-  _totalBytesWritten += length;
+- (void)didWriteBytes:(const void *)bytes length:(NSUInteger)length {
+    GWS_LOG_DEBUG(@"Connection sent %lu bytes on socket %i", (unsigned long)length, _socket);
+    _totalBytesWritten += length;
 
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
-  if ((_responseFD > 0) && (write(_responseFD, bytes, length) != (ssize_t)length)) {
-    GWS_LOG_ERROR(@"Failed recording response data: %s (%i)", strerror(errno), errno);
-    close(_responseFD);
-    _responseFD = 0;
-  }
+
+    if ((_responseFD > 0) && (write(_responseFD, bytes, length) != (ssize_t)length)) {
+        GWS_LOG_ERROR(@"Failed recording response data: %s (%i)", strerror(errno), errno);
+        close(_responseFD);
+        _responseFD = 0;
+    }
+
 #endif
 }
 
-- (NSURL*)rewriteRequestURL:(NSURL*)url withMethod:(NSString*)method headers:(NSDictionary<NSString*, NSString*>*)headers {
-  return url;
+- (NSURL *)rewriteRequestURL:(NSURL *)url withMethod:(NSString *)method headers:(NSDictionary<NSString *, NSString *> *)headers {
+    return url;
 }
 
 // https://tools.ietf.org/html/rfc2617
-- (GCDWebServerResponse*)preflightRequest:(GCDWebServerRequest*)request {
-  GWS_LOG_DEBUG(@"Connection on socket %i preflighting request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead);
-  GCDWebServerResponse* response = nil;
-  if (_server.authenticationBasicAccounts) {
-    __block BOOL authenticated = NO;
-    NSString* authorizationHeader = [request.headers objectForKey:@"Authorization"];
-    if ([authorizationHeader hasPrefix:@"Basic "]) {
-      NSString* basicAccount = [authorizationHeader substringFromIndex:6];
-      [_server.authenticationBasicAccounts enumerateKeysAndObjectsUsingBlock:^(NSString* username, NSString* digest, BOOL* stop) {
-        if ([basicAccount isEqualToString:digest]) {
-          authenticated = YES;
-          *stop = YES;
+- (GCDWebServerResponse *)preflightRequest:(GCDWebServerRequest *)request {
+    GWS_LOG_DEBUG(@"Connection on socket %i preflighting request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead);
+    GCDWebServerResponse *response = nil;
+
+    if (_server.authenticationBasicAccounts) {
+        __block BOOL authenticated = NO;
+        NSString *authorizationHeader = [request.headers objectForKey:@"Authorization"];
+
+        if ([authorizationHeader hasPrefix:@"Basic "]) {
+            NSString *basicAccount = [authorizationHeader substringFromIndex:6];
+            [_server.authenticationBasicAccounts enumerateKeysAndObjectsUsingBlock:^(NSString *username, NSString *digest, BOOL *stop) {
+                                                     if ([basicAccount isEqualToString:digest]) {
+                                                     authenticated = YES;
+                                                     *stop = YES;
+                                                     }
+                                                 }];
         }
-      }];
-    }
-    if (!authenticated) {
-      response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_Unauthorized];
-      [response setValue:[NSString stringWithFormat:@"Basic realm=\"%@\"", _server.authenticationRealm] forAdditionalHeader:@"WWW-Authenticate"];
-    }
-  } else if (_server.authenticationDigestAccounts) {
-    BOOL authenticated = NO;
-    BOOL isStaled = NO;
-    NSString* authorizationHeader = [request.headers objectForKey:@"Authorization"];
-    if ([authorizationHeader hasPrefix:@"Digest "]) {
-      NSString* realm = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"realm");
-      if (realm && [_server.authenticationRealm isEqualToString:realm]) {
-        NSString* nonce = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"nonce");
-        if ([nonce isEqualToString:_digestAuthenticationNonce]) {
-          NSString* username = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"username");
-          NSString* uri = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"uri");
-          NSString* actualResponse = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"response");
-          NSString* ha1 = [_server.authenticationDigestAccounts objectForKey:username];
-          NSString* ha2 = GCDWebServerComputeMD5Digest(@"%@:%@", request.method, uri);  // We cannot use "request.path" as the query string is required
-          NSString* expectedResponse = GCDWebServerComputeMD5Digest(@"%@:%@:%@", ha1, _digestAuthenticationNonce, ha2);
-          if ([actualResponse isEqualToString:expectedResponse]) {
-            authenticated = YES;
-          }
-        } else if (nonce.length) {
-          isStaled = YES;
+
+        if (!authenticated) {
+            response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_Unauthorized];
+            [response setValue:[NSString stringWithFormat:@"Basic realm=\"%@\"", _server.authenticationRealm] forAdditionalHeader:@"WWW-Authenticate"];
         }
-      }
+    } else if (_server.authenticationDigestAccounts) {
+        BOOL authenticated = NO;
+        BOOL isStaled = NO;
+        NSString *authorizationHeader = [request.headers objectForKey:@"Authorization"];
+
+        if ([authorizationHeader hasPrefix:@"Digest "]) {
+            NSString *realm = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"realm");
+
+            if (realm && [_server.authenticationRealm isEqualToString:realm]) {
+                NSString *nonce = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"nonce");
+
+                if ([nonce isEqualToString:_digestAuthenticationNonce]) {
+                    NSString *username = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"username");
+                    NSString *uri = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"uri");
+                    NSString *actualResponse = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"response");
+                    NSString *ha1 = [_server.authenticationDigestAccounts objectForKey:username];
+                    NSString *ha2 = GCDWebServerComputeMD5Digest(@"%@:%@", request.method, uri); // We cannot use "request.path" as the query string is required
+                    NSString *expectedResponse = GCDWebServerComputeMD5Digest(@"%@:%@:%@", ha1, _digestAuthenticationNonce, ha2);
+
+                    if ([actualResponse isEqualToString:expectedResponse]) {
+                        authenticated = YES;
+                    }
+                } else if (nonce.length) {
+                    isStaled = YES;
+                }
+            }
+        }
+
+        if (!authenticated) {
+            response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_Unauthorized];
+            [response setValue:[NSString stringWithFormat:@"Digest realm=\"%@\", nonce=\"%@\"%@", _server.authenticationRealm, _digestAuthenticationNonce, isStaled ? @", stale=TRUE" : @""] forAdditionalHeader:@"WWW-Authenticate"]; // TODO: Support Quality of Protection ("qop")
+        }
     }
-    if (!authenticated) {
-      response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_Unauthorized];
-      [response setValue:[NSString stringWithFormat:@"Digest realm=\"%@\", nonce=\"%@\"%@", _server.authenticationRealm, _digestAuthenticationNonce, isStaled ? @", stale=TRUE" : @""] forAdditionalHeader:@"WWW-Authenticate"];  // TODO: Support Quality of Protection ("qop")
-    }
-  }
-  return response;
+
+    return response;
 }
 
-- (void)processRequest:(GCDWebServerRequest*)request completion:(GCDWebServerCompletionBlock)completion {
-  GWS_LOG_DEBUG(@"Connection on socket %i processing request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead);
-  if (_handler.asyncProcessBlock) {
-    _handler.asyncProcessBlock(request, [completion copy]);
-  } else {
-    completion(nil);
-  }
+- (void)processRequest:(GCDWebServerRequest *)request completion:(GCDWebServerCompletionBlock)completion {
+    GWS_LOG_DEBUG(@"Connection on socket %i processing request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead);
+
+    if (_handler.asyncProcessBlock) {
+        _handler.asyncProcessBlock(request, [completion copy]);
+    } else {
+        completion(nil);
+    }
 }
 
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26
-static inline BOOL _CompareResources(NSString* responseETag, NSString* requestETag, NSDate* responseLastModified, NSDate* requestLastModified) {
-  if (requestLastModified && responseLastModified) {
-    if ([responseLastModified compare:requestLastModified] != NSOrderedDescending) {
-      return YES;
+static inline BOOL _CompareResources(NSString *responseETag, NSString *requestETag, NSDate *responseLastModified, NSDate *requestLastModified) {
+    if (requestLastModified && responseLastModified) {
+        if ([responseLastModified compare:requestLastModified] != NSOrderedDescending) {
+            return YES;
+        }
     }
-  }
-  if (requestETag && responseETag) {  // Per the specs "If-None-Match" must be checked after "If-Modified-Since"
-    if ([requestETag isEqualToString:@"*"]) {
-      return YES;
+
+    if (requestETag && responseETag) { // Per the specs "If-None-Match" must be checked after "If-Modified-Since"
+        if ([requestETag isEqualToString:@"*"]) {
+            return YES;
+        }
+
+        if ([responseETag isEqualToString:requestETag]) {
+            return YES;
+        }
     }
-    if ([responseETag isEqualToString:requestETag]) {
-      return YES;
-    }
-  }
-  return NO;
+
+    return NO;
 }
 
-- (GCDWebServerResponse*)overrideResponse:(GCDWebServerResponse*)response forRequest:(GCDWebServerRequest*)request {
-  if ((response.statusCode >= 200) && (response.statusCode < 300) && _CompareResources(response.eTag, request.ifNoneMatch, response.lastModifiedDate, request.ifModifiedSince)) {
-    NSInteger code = [request.method isEqualToString:@"HEAD"] || [request.method isEqualToString:@"GET"] ? kGCDWebServerHTTPStatusCode_NotModified : kGCDWebServerHTTPStatusCode_PreconditionFailed;
-    GCDWebServerResponse* newResponse = [GCDWebServerResponse responseWithStatusCode:code];
-    newResponse.cacheControlMaxAge = response.cacheControlMaxAge;
-    newResponse.lastModifiedDate = response.lastModifiedDate;
-    newResponse.eTag = response.eTag;
-    GWS_DCHECK(newResponse);
-    return newResponse;
-  }
-  return response;
+- (GCDWebServerResponse *)overrideResponse:(GCDWebServerResponse *)response forRequest:(GCDWebServerRequest *)request {
+    if ((response.statusCode >= 200) && (response.statusCode < 300) && _CompareResources(response.eTag, request.ifNoneMatch, response.lastModifiedDate, request.ifModifiedSince)) {
+        NSInteger code = [request.method isEqualToString:@"HEAD"] || [request.method isEqualToString:@"GET"] ? kGCDWebServerHTTPStatusCode_NotModified : kGCDWebServerHTTPStatusCode_PreconditionFailed;
+        GCDWebServerResponse *newResponse = [GCDWebServerResponse responseWithStatusCode:code];
+        newResponse.cacheControlMaxAge = response.cacheControlMaxAge;
+        newResponse.lastModifiedDate = response.lastModifiedDate;
+        newResponse.eTag = response.eTag;
+        GWS_DCHECK(newResponse);
+        return newResponse;
+    }
+
+    return response;
 }
 
-- (void)abortRequest:(GCDWebServerRequest*)request withStatusCode:(NSInteger)statusCode {
-  GWS_DCHECK(_responseMessage == NULL);
-  GWS_DCHECK((statusCode >= 400) && (statusCode < 600));
-  [self _initializeResponseHeadersWithStatusCode:statusCode];
-  [self writeHeadersWithCompletionBlock:^(BOOL success){
-      // Nothing more to do
-  }];
-  GWS_LOG_DEBUG(@"Connection aborted with status code %i on socket %i", (int)statusCode, _socket);
+- (void)abortRequest:(GCDWebServerRequest *)request withStatusCode:(NSInteger)statusCode {
+    GWS_DCHECK(_responseMessage == NULL);
+    GWS_DCHECK((statusCode >= 400) && (statusCode < 600));
+    [self _initializeResponseHeadersWithStatusCode:statusCode];
+    [self writeHeadersWithCompletionBlock:^(BOOL success) {
+              // Nothing more to do
+          }];
+    GWS_LOG_DEBUG(@"Connection aborted with status code %i on socket %i", (int)statusCode, _socket);
 }
 
 - (void)close {
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
-  if (_requestPath) {
-    BOOL success = NO;
-    NSError* error = nil;
-    if (_requestFD > 0) {
-      close(_requestFD);
-      NSString* name = [NSString stringWithFormat:@"%03lu-%@.request", (unsigned long)_connectionIndex, _virtualHEAD ? @"HEAD" : _request.method];
-      success = [[NSFileManager defaultManager] moveItemAtPath:_requestPath toPath:[[[NSFileManager defaultManager] currentDirectoryPath] stringByAppendingPathComponent:name] error:&error];
-    }
-    if (!success) {
-      GWS_LOG_ERROR(@"Failed saving recorded request: %@", error);
-      GWS_DNOT_REACHED();
-    }
-    unlink([_requestPath fileSystemRepresentation]);
-  }
 
-  if (_responsePath) {
-    BOOL success = NO;
-    NSError* error = nil;
-    if (_responseFD > 0) {
-      close(_responseFD);
-      NSString* name = [NSString stringWithFormat:@"%03lu-%i.response", (unsigned long)_connectionIndex, (int)_statusCode];
-      success = [[NSFileManager defaultManager] moveItemAtPath:_responsePath toPath:[[[NSFileManager defaultManager] currentDirectoryPath] stringByAppendingPathComponent:name] error:&error];
-    }
-    if (!success) {
-      GWS_LOG_ERROR(@"Failed saving recorded response: %@", error);
-      GWS_DNOT_REACHED();
-    }
-    unlink([_responsePath fileSystemRepresentation]);
-  }
-#endif
+    if (_requestPath) {
+        BOOL success = NO;
+        NSError *error = nil;
 
-  if (_request) {
-    GWS_LOG_VERBOSE(@"[%@] %@ %i \"%@ %@\" (%lu | %lu)", self.localAddressString, self.remoteAddressString, (int)_statusCode, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead, (unsigned long)_totalBytesWritten);
-  } else {
-    GWS_LOG_VERBOSE(@"[%@] %@ %i \"(invalid request)\" (%lu | %lu)", self.localAddressString, self.remoteAddressString, (int)_statusCode, (unsigned long)_totalBytesRead, (unsigned long)_totalBytesWritten);
-  }
+        if (_requestFD > 0) {
+            close(_requestFD);
+            NSString *name = [NSString stringWithFormat:@"%03lu-%@.request", (unsigned long)_connectionIndex, _virtualHEAD ? @"HEAD" : _request.method];
+            success = [[NSFileManager defaultManager] moveItemAtPath:_requestPath toPath:[[[NSFileManager defaultManager] currentDirectoryPath] stringByAppendingPathComponent:name] error:&error];
+        }
+
+        if (!success) {
+            GWS_LOG_ERROR(@"Failed saving recorded request: %@", error);
+            GWS_DNOT_REACHED();
+        }
+
+        unlink([_requestPath fileSystemRepresentation]);
+    }
+
+    if (_responsePath) {
+        BOOL success = NO;
+        NSError *error = nil;
+
+        if (_responseFD > 0) {
+            close(_responseFD);
+            NSString *name = [NSString stringWithFormat:@"%03lu-%i.response", (unsigned long)_connectionIndex, (int)_statusCode];
+            success = [[NSFileManager defaultManager] moveItemAtPath:_responsePath toPath:[[[NSFileManager defaultManager] currentDirectoryPath] stringByAppendingPathComponent:name] error:&error];
+        }
+
+        if (!success) {
+            GWS_LOG_ERROR(@"Failed saving recorded response: %@", error);
+            GWS_DNOT_REACHED();
+        }
+
+        unlink([_responsePath fileSystemRepresentation]);
+    }
+
+#endif /* ifdef __GCDWEBSERVER_ENABLE_TESTING__ */
+
+    if (_request) {
+        GWS_LOG_VERBOSE(@"[%@] %@ %i \"%@ %@\" (%lu | %lu)", self.localAddressString, self.remoteAddressString, (int)_statusCode, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead, (unsigned long)_totalBytesWritten);
+    } else {
+        GWS_LOG_VERBOSE(@"[%@] %@ %i \"(invalid request)\" (%lu | %lu)", self.localAddressString, self.remoteAddressString, (int)_statusCode, (unsigned long)_totalBytesRead, (unsigned long)_totalBytesWritten);
+    }
 }
 
 @end

--- a/GCDWebServer/Core/GCDWebServerFunctions.h
+++ b/GCDWebServer/Core/GCDWebServerFunctions.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import <Foundation/Foundation.h>
@@ -41,42 +41,42 @@ extern "C" {
  *  types. Keys of the dictionary must be lowercased file extensions without
  *  the period, and the values must be the corresponding MIME types.
  */
-NSString* GCDWebServerGetMimeTypeForExtension(NSString* extension, NSDictionary<NSString*, NSString*>* _Nullable overrides);
+NSString * GCDWebServerGetMimeTypeForExtension(NSString *extension, NSDictionary<NSString *, NSString *> * _Nullable overrides);
 
 /**
  *  Add percent-escapes to a string so it can be used in a URL.
  *  The legal characters ":@/?&=+" are also escaped to ensure compatibility
  *  with URL encoded forms and URL queries.
  */
-NSString* _Nullable GCDWebServerEscapeURLString(NSString* string);
+NSString * _Nullable GCDWebServerEscapeURLString(NSString *string);
 
 /**
  *  Unescapes a URL percent-encoded string.
  */
-NSString* _Nullable GCDWebServerUnescapeURLString(NSString* string);
+NSString * _Nullable GCDWebServerUnescapeURLString(NSString *string);
 
 /**
  *  Extracts the unescaped names and values from an
  *  "application/x-www-form-urlencoded" form.
  *  http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
  */
-NSDictionary<NSString*, NSString*>* GCDWebServerParseURLEncodedForm(NSString* form);
+NSDictionary<NSString *, NSString *> * GCDWebServerParseURLEncodedForm(NSString *form);
 
 /**
  *  On OS X, returns the IPv4 or IPv6 address as a string of the primary
  *  connected service or nil if not available.
- *  
+ *
  *  On iOS, returns the IPv4 or IPv6 address as a string of the WiFi
  *  interface if connected or nil otherwise.
  */
-NSString* _Nullable GCDWebServerGetPrimaryIPAddress(BOOL useIPv6);
+NSString * _Nullable GCDWebServerGetPrimaryIPAddress(BOOL useIPv6);
 
 /**
  *  Converts a date into a string using RFC822 formatting.
  *  https://tools.ietf.org/html/rfc822#section-5
  *  https://tools.ietf.org/html/rfc1123#section-5.2.14
  */
-NSString* GCDWebServerFormatRFC822(NSDate* date);
+NSString * GCDWebServerFormatRFC822(NSDate *date);
 
 /**
  *  Converts a RFC822 formatted string into a date.
@@ -85,13 +85,13 @@ NSString* GCDWebServerFormatRFC822(NSDate* date);
  *
  *  @warning Timezones other than GMT are not supported by this function.
  */
-NSDate* _Nullable GCDWebServerParseRFC822(NSString* string);
+NSDate * _Nullable GCDWebServerParseRFC822(NSString *string);
 
 /**
  *  Converts a date into a string using IOS 8601 formatting.
  *  http://tools.ietf.org/html/rfc3339#section-5.6
  */
-NSString* GCDWebServerFormatISO8601(NSDate* date);
+NSString * GCDWebServerFormatISO8601(NSDate *date);
 
 /**
  *  Converts a ISO 8601 formatted string into a date.
@@ -100,12 +100,12 @@ NSString* GCDWebServerFormatISO8601(NSDate* date);
  *  @warning Only "calendar" variant is supported at this time and timezones
  *  other than GMT are not supported either.
  */
-NSDate* _Nullable GCDWebServerParseISO8601(NSString* string);
+NSDate * _Nullable GCDWebServerParseISO8601(NSString *string);
 
 /**
  *  Removes "//", "/./" and "/../" components from path as well as any trailing slash.
  */
-NSString* GCDWebServerNormalizePath(NSString* path);
+NSString * GCDWebServerNormalizePath(NSString *path);
 
 #ifdef __cplusplus
 }

--- a/GCDWebServer/Core/GCDWebServerFunctions.m
+++ b/GCDWebServer/Core/GCDWebServerFunctions.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -43,292 +43,351 @@
 
 #import "GCDWebServerPrivate.h"
 
-static NSDateFormatter* _dateFormatterRFC822 = nil;
-static NSDateFormatter* _dateFormatterISO8601 = nil;
+static NSDateFormatter *_dateFormatterRFC822 = nil;
+static NSDateFormatter *_dateFormatterISO8601 = nil;
 static dispatch_queue_t _dateFormatterQueue = NULL;
 
 // TODO: Handle RFC 850 and ANSI C's asctime() format
 void GCDWebServerInitializeFunctions(void) {
-  GWS_DCHECK([NSThread isMainThread]);  // NSDateFormatter should be initialized on main thread
-  if (_dateFormatterRFC822 == nil) {
-    _dateFormatterRFC822 = [[NSDateFormatter alloc] init];
-    _dateFormatterRFC822.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
-    _dateFormatterRFC822.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'";
-    _dateFormatterRFC822.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
-    GWS_DCHECK(_dateFormatterRFC822);
-  }
-  if (_dateFormatterISO8601 == nil) {
-    _dateFormatterISO8601 = [[NSDateFormatter alloc] init];
-    _dateFormatterISO8601.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
-    _dateFormatterISO8601.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'+00:00'";
-    _dateFormatterISO8601.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
-    GWS_DCHECK(_dateFormatterISO8601);
-  }
-  if (_dateFormatterQueue == NULL) {
-    _dateFormatterQueue = dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL);
-    GWS_DCHECK(_dateFormatterQueue);
-  }
+    GWS_DCHECK([NSThread isMainThread]); // NSDateFormatter should be initialized on main thread
+
+    if (_dateFormatterRFC822 == nil) {
+        _dateFormatterRFC822 = [[NSDateFormatter alloc] init];
+        _dateFormatterRFC822.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+        _dateFormatterRFC822.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'";
+        _dateFormatterRFC822.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+        GWS_DCHECK(_dateFormatterRFC822);
+    }
+
+    if (_dateFormatterISO8601 == nil) {
+        _dateFormatterISO8601 = [[NSDateFormatter alloc] init];
+        _dateFormatterISO8601.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+        _dateFormatterISO8601.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'+00:00'";
+        _dateFormatterISO8601.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+        GWS_DCHECK(_dateFormatterISO8601);
+    }
+
+    if (_dateFormatterQueue == NULL) {
+        _dateFormatterQueue = dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL);
+        GWS_DCHECK(_dateFormatterQueue);
+    }
 }
 
-NSString* GCDWebServerNormalizeHeaderValue(NSString* value) {
-  if (value) {
-    NSRange range = [value rangeOfString:@";"];  // Assume part before ";" separator is case-insensitive
-    if (range.location != NSNotFound) {
-      value = [[[value substringToIndex:range.location] lowercaseString] stringByAppendingString:[value substringFromIndex:range.location]];
-    } else {
-      value = [value lowercaseString];
+NSString * GCDWebServerNormalizeHeaderValue(NSString *value) {
+    if (value) {
+        NSRange range = [value rangeOfString:@";"]; // Assume part before ";" separator is case-insensitive
+
+        if (range.location != NSNotFound) {
+            value = [[[value substringToIndex:range.location] lowercaseString] stringByAppendingString:[value substringFromIndex:range.location]];
+        } else {
+            value = [value lowercaseString];
+        }
     }
-  }
-  return value;
+
+    return value;
 }
 
-NSString* GCDWebServerTruncateHeaderValue(NSString* value) {
-  if (value) {
-    NSRange range = [value rangeOfString:@";"];
-    if (range.location != NSNotFound) {
-      return [value substringToIndex:range.location];
+NSString * GCDWebServerTruncateHeaderValue(NSString *value) {
+    if (value) {
+        NSRange range = [value rangeOfString:@";"];
+
+        if (range.location != NSNotFound) {
+            return [value substringToIndex:range.location];
+        }
     }
-  }
-  return value;
+
+    return value;
 }
 
-NSString* GCDWebServerExtractHeaderValueParameter(NSString* value, NSString* name) {
-  NSString* parameter = nil;
-  if (value) {
-    NSScanner* scanner = [[NSScanner alloc] initWithString:value];
-    [scanner setCaseSensitive:NO];  // Assume parameter names are case-insensitive
-    NSString* string = [NSString stringWithFormat:@"%@=", name];
-    if ([scanner scanUpToString:string intoString:NULL]) {
-      [scanner scanString:string intoString:NULL];
-      if ([scanner scanString:@"\"" intoString:NULL]) {
-        [scanner scanUpToString:@"\"" intoString:&parameter];
-      } else {
-        [scanner scanUpToCharactersFromSet:[NSCharacterSet whitespaceCharacterSet] intoString:&parameter];
-      }
+NSString * GCDWebServerExtractHeaderValueParameter(NSString *value, NSString *name) {
+    NSString *parameter = nil;
+
+    if (value) {
+        NSScanner *scanner = [[NSScanner alloc] initWithString:value];
+        [scanner setCaseSensitive:NO]; // Assume parameter names are case-insensitive
+        NSString *string = [NSString stringWithFormat:@"%@=", name];
+
+        if ([scanner scanUpToString:string intoString:NULL]) {
+            [scanner scanString:string intoString:NULL];
+
+            if ([scanner scanString:@"\"" intoString:NULL]) {
+                [scanner scanUpToString:@"\"" intoString:&parameter];
+            } else {
+                [scanner scanUpToCharactersFromSet:[NSCharacterSet whitespaceCharacterSet] intoString:&parameter];
+            }
+        }
     }
-  }
-  return parameter;
+
+    return parameter;
 }
 
 // http://www.w3schools.com/tags/ref_charactersets.asp
-NSStringEncoding GCDWebServerStringEncodingFromCharset(NSString* charset) {
-  NSStringEncoding encoding = kCFStringEncodingInvalidId;
-  if (charset) {
-    encoding = CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding((CFStringRef)charset));
-  }
-  return (encoding != kCFStringEncodingInvalidId ? encoding : NSUTF8StringEncoding);
-}
+NSStringEncoding GCDWebServerStringEncodingFromCharset(NSString *charset) {
+    NSStringEncoding encoding = kCFStringEncodingInvalidId;
 
-NSString* GCDWebServerFormatRFC822(NSDate* date) {
-  __block NSString* string;
-  dispatch_sync(_dateFormatterQueue, ^{
-    string = [_dateFormatterRFC822 stringFromDate:date];
-  });
-  return string;
-}
-
-NSDate* GCDWebServerParseRFC822(NSString* string) {
-  __block NSDate* date;
-  dispatch_sync(_dateFormatterQueue, ^{
-    date = [_dateFormatterRFC822 dateFromString:string];
-  });
-  return date;
-}
-
-NSString* GCDWebServerFormatISO8601(NSDate* date) {
-  __block NSString* string;
-  dispatch_sync(_dateFormatterQueue, ^{
-    string = [_dateFormatterISO8601 stringFromDate:date];
-  });
-  return string;
-}
-
-NSDate* GCDWebServerParseISO8601(NSString* string) {
-  __block NSDate* date;
-  dispatch_sync(_dateFormatterQueue, ^{
-    date = [_dateFormatterISO8601 dateFromString:string];
-  });
-  return date;
-}
-
-BOOL GCDWebServerIsTextContentType(NSString* type) {
-  return ([type hasPrefix:@"text/"] || [type hasPrefix:@"application/json"] || [type hasPrefix:@"application/xml"]);
-}
-
-NSString* GCDWebServerDescribeData(NSData* data, NSString* type) {
-  if (GCDWebServerIsTextContentType(type)) {
-    NSString* charset = GCDWebServerExtractHeaderValueParameter(type, @"charset");
-    NSString* string = [[NSString alloc] initWithData:data encoding:GCDWebServerStringEncodingFromCharset(charset)];
-    if (string) {
-      return string;
+    if (charset) {
+        encoding = CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding((CFStringRef)charset));
     }
-  }
-  return [NSString stringWithFormat:@"<%lu bytes>", (unsigned long)data.length];
+
+    return (encoding != kCFStringEncodingInvalidId ? encoding : NSUTF8StringEncoding);
 }
 
-NSString* GCDWebServerGetMimeTypeForExtension(NSString* extension, NSDictionary<NSString*, NSString*>* overrides) {
-  NSDictionary* builtInOverrides = @{@"css" : @"text/css"};
-  NSString* mimeType = nil;
-  extension = [extension lowercaseString];
-  if (extension.length) {
-    mimeType = [overrides objectForKey:extension];
-    if (mimeType == nil) {
-      mimeType = [builtInOverrides objectForKey:extension];
-    }
-    if (mimeType == nil) {
-      CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
-      if (uti) {
-        mimeType = CFBridgingRelease(UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType));
-        CFRelease(uti);
-      }
-    }
-  }
-  return mimeType ? mimeType : kGCDWebServerDefaultMimeType;
+NSString * GCDWebServerFormatRFC822(NSDate *date) {
+    __block NSString *string;
+
+    dispatch_sync(_dateFormatterQueue, ^{
+        string = [_dateFormatterRFC822 stringFromDate:date];
+    });
+    return string;
 }
 
-NSString* GCDWebServerEscapeURLString(NSString* string) {
+NSDate * GCDWebServerParseRFC822(NSString *string) {
+    __block NSDate *date;
+
+    dispatch_sync(_dateFormatterQueue, ^{
+        date = [_dateFormatterRFC822 dateFromString:string];
+    });
+    return date;
+}
+
+NSString * GCDWebServerFormatISO8601(NSDate *date) {
+    __block NSString *string;
+
+    dispatch_sync(_dateFormatterQueue, ^{
+        string = [_dateFormatterISO8601 stringFromDate:date];
+    });
+    return string;
+}
+
+NSDate * GCDWebServerParseISO8601(NSString *string) {
+    __block NSDate *date;
+
+    dispatch_sync(_dateFormatterQueue, ^{
+        date = [_dateFormatterISO8601 dateFromString:string];
+    });
+    return date;
+}
+
+BOOL GCDWebServerIsTextContentType(NSString *type) {
+    return ([type hasPrefix:@"text/"] || [type hasPrefix:@"application/json"] || [type hasPrefix:@"application/xml"]);
+}
+
+NSString * GCDWebServerDescribeData(NSData *data, NSString *type) {
+    if (GCDWebServerIsTextContentType(type)) {
+        NSString *charset = GCDWebServerExtractHeaderValueParameter(type, @"charset");
+        NSString *string = [[NSString alloc] initWithData:data encoding:GCDWebServerStringEncodingFromCharset(charset)];
+
+        if (string) {
+            return string;
+        }
+    }
+
+    return [NSString stringWithFormat:@"<%lu bytes>", (unsigned long)data.length];
+}
+
+NSString * GCDWebServerGetMimeTypeForExtension(NSString *extension, NSDictionary<NSString *, NSString *> *overrides) {
+    NSDictionary *builtInOverrides = @{
+        @"css": @"text/css"
+    };
+    NSString *mimeType = nil;
+
+    extension = [extension lowercaseString];
+
+    if (extension.length) {
+        mimeType = [overrides objectForKey:extension];
+
+        if (mimeType == nil) {
+            mimeType = [builtInOverrides objectForKey:extension];
+        }
+
+        if (mimeType == nil) {
+            CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
+
+            if (uti) {
+                mimeType = CFBridgingRelease(UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType));
+                CFRelease(uti);
+            }
+        }
+    }
+
+    return mimeType ? mimeType : kGCDWebServerDefaultMimeType;
+}
+
+NSString * GCDWebServerEscapeURLString(NSString *string) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  return CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (CFStringRef)string, NULL, CFSTR(":@/?&=+"), kCFStringEncodingUTF8));
+    return CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (CFStringRef)string, NULL, CFSTR(":@/?&=+"), kCFStringEncodingUTF8));
+
 #pragma clang diagnostic pop
 }
 
-NSString* GCDWebServerUnescapeURLString(NSString* string) {
+NSString * GCDWebServerUnescapeURLString(NSString *string) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  return CFBridgingRelease(CFURLCreateStringByReplacingPercentEscapesUsingEncoding(kCFAllocatorDefault, (CFStringRef)string, CFSTR(""), kCFStringEncodingUTF8));
+    return CFBridgingRelease(CFURLCreateStringByReplacingPercentEscapesUsingEncoding(kCFAllocatorDefault, (CFStringRef)string, CFSTR(""), kCFStringEncodingUTF8));
+
 #pragma clang diagnostic pop
 }
 
-NSDictionary<NSString*, NSString*>* GCDWebServerParseURLEncodedForm(NSString* form) {
-  NSMutableDictionary* parameters = [NSMutableDictionary dictionary];
-  NSScanner* scanner = [[NSScanner alloc] initWithString:form];
-  [scanner setCharactersToBeSkipped:nil];
-  while (1) {
-    NSString* key = nil;
-    if (![scanner scanUpToString:@"=" intoString:&key] || [scanner isAtEnd]) {
-      break;
-    }
-    [scanner setScanLocation:([scanner scanLocation] + 1)];
+NSDictionary<NSString *, NSString *> * GCDWebServerParseURLEncodedForm(NSString *form) {
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+    NSScanner *scanner = [[NSScanner alloc] initWithString:form];
 
-    NSString* value = nil;
-    [scanner scanUpToString:@"&" intoString:&value];
-    if (value == nil) {
-      value = @"";
-    }
+    [scanner setCharactersToBeSkipped:nil];
 
-    key = [key stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-    NSString* unescapedKey = key ? GCDWebServerUnescapeURLString(key) : nil;
-    value = [value stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-    NSString* unescapedValue = value ? GCDWebServerUnescapeURLString(value) : nil;
-    if (unescapedKey && unescapedValue) {
-      [parameters setObject:unescapedValue forKey:unescapedKey];
-    } else {
-      GWS_LOG_WARNING(@"Failed parsing URL encoded form for key \"%@\" and value \"%@\"", key, value);
-      GWS_DNOT_REACHED();
-    }
+    while (1) {
+        NSString *key = nil;
 
-    if ([scanner isAtEnd]) {
-      break;
+        if (![scanner scanUpToString:@"=" intoString:&key] || [scanner isAtEnd]) {
+            break;
+        }
+
+        [scanner setScanLocation:([scanner scanLocation] + 1)];
+
+        NSString *value = nil;
+        [scanner scanUpToString:@"&" intoString:&value];
+
+        if (value == nil) {
+            value = @"";
+        }
+
+        key = [key stringByReplacingOccurrencesOfString:@"+" withString:@" "];
+        NSString *unescapedKey = key ? GCDWebServerUnescapeURLString(key) : nil;
+        value = [value stringByReplacingOccurrencesOfString:@"+" withString:@" "];
+        NSString *unescapedValue = value ? GCDWebServerUnescapeURLString(value) : nil;
+
+        if (unescapedKey && unescapedValue) {
+            [parameters setObject:unescapedValue forKey:unescapedKey];
+        } else {
+            GWS_LOG_WARNING(@"Failed parsing URL encoded form for key \"%@\" and value \"%@\"", key, value);
+            GWS_DNOT_REACHED();
+        }
+
+        if ([scanner isAtEnd]) {
+            break;
+        }
+
+        [scanner setScanLocation:([scanner scanLocation] + 1)];
     }
-    [scanner setScanLocation:([scanner scanLocation] + 1)];
-  }
-  return parameters;
+    return parameters;
 }
 
-NSString* GCDWebServerStringFromSockAddr(const struct sockaddr* addr, BOOL includeService) {
-  char hostBuffer[NI_MAXHOST];
-  char serviceBuffer[NI_MAXSERV];
-  if (getnameinfo(addr, addr->sa_len, hostBuffer, sizeof(hostBuffer), serviceBuffer, sizeof(serviceBuffer), NI_NUMERICHOST | NI_NUMERICSERV | NI_NOFQDN) != 0) {
+NSString * GCDWebServerStringFromSockAddr(const struct sockaddr *addr, BOOL includeService) {
+    char hostBuffer[NI_MAXHOST];
+    char serviceBuffer[NI_MAXSERV];
+
+    if (getnameinfo(addr, addr->sa_len, hostBuffer, sizeof(hostBuffer), serviceBuffer, sizeof(serviceBuffer), NI_NUMERICHOST | NI_NUMERICSERV | NI_NOFQDN) != 0) {
 #if DEBUG
-    GWS_DNOT_REACHED();
+        GWS_DNOT_REACHED();
 #else
-    return @"";
+        return @"";
+
 #endif
-  }
-  return includeService ? [NSString stringWithFormat:@"%s:%s", hostBuffer, serviceBuffer] : (NSString*)[NSString stringWithUTF8String:hostBuffer];
+    }
+
+    return includeService ? [NSString stringWithFormat:@"%s:%s", hostBuffer, serviceBuffer] : (NSString *)[NSString stringWithUTF8String:hostBuffer];
 }
 
-NSString* GCDWebServerGetPrimaryIPAddress(BOOL useIPv6) {
-  NSString* address = nil;
+NSString * GCDWebServerGetPrimaryIPAddress(BOOL useIPv6) {
+    NSString *address = nil;
+
 #if TARGET_OS_IPHONE
 #if !TARGET_IPHONE_SIMULATOR && !TARGET_OS_TV
-  const char* primaryInterface = "en0";  // WiFi interface on iOS
+    const char *primaryInterface = "en0"; // WiFi interface on iOS
 #endif
 #else
-  const char* primaryInterface = NULL;
-  SCDynamicStoreRef store = SCDynamicStoreCreate(kCFAllocatorDefault, CFSTR("GCDWebServer"), NULL, NULL);
-  if (store) {
-    CFPropertyListRef info = SCDynamicStoreCopyValue(store, CFSTR("State:/Network/Global/IPv4"));  // There is no equivalent for IPv6 but the primary interface should be the same
-    if (info) {
-      NSString* interface = [(__bridge NSDictionary*)info objectForKey:@"PrimaryInterface"];
-      if (interface) {
-        primaryInterface = [[NSString stringWithString:interface] UTF8String];  // Copy string to auto-release pool
-      }
-      CFRelease(info);
+    const char *primaryInterface = NULL;
+    SCDynamicStoreRef store = SCDynamicStoreCreate(kCFAllocatorDefault, CFSTR("GCDWebServer"), NULL, NULL);
+
+    if (store) {
+        CFPropertyListRef info = SCDynamicStoreCopyValue(store, CFSTR("State:/Network/Global/IPv4")); // There is no equivalent for IPv6 but the primary interface should be the same
+
+        if (info) {
+            NSString *interface = [(__bridge NSDictionary *)info objectForKey:@"PrimaryInterface"];
+
+            if (interface) {
+                primaryInterface = [[NSString stringWithString:interface] UTF8String]; // Copy string to auto-release pool
+            }
+
+            CFRelease(info);
+        }
+
+        CFRelease(store);
     }
-    CFRelease(store);
-  }
-  if (primaryInterface == NULL) {
-    primaryInterface = "lo0";
-  }
-#endif
-  struct ifaddrs* list;
-  if (getifaddrs(&list) >= 0) {
-    for (struct ifaddrs* ifap = list; ifap; ifap = ifap->ifa_next) {
+
+    if (primaryInterface == NULL) {
+        primaryInterface = "lo0";
+    }
+
+#endif /* if TARGET_OS_IPHONE */
+    struct ifaddrs *list;
+
+    if (getifaddrs(&list) >= 0) {
+        for (struct ifaddrs *ifap = list; ifap; ifap = ifap->ifa_next) {
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_TV
-      // Assume en0 is Ethernet and en1 is WiFi since there is no way to use SystemConfiguration framework in iOS Simulator
-      // Assumption holds for Apple TV running tvOS
-      if (strcmp(ifap->ifa_name, "en0") && strcmp(ifap->ifa_name, "en1"))
+
+            // Assume en0 is Ethernet and en1 is WiFi since there is no way to use SystemConfiguration framework in iOS Simulator
+            // Assumption holds for Apple TV running tvOS
+            if (strcmp(ifap->ifa_name, "en0") && strcmp(ifap->ifa_name, "en1"))
 #else
-      if (strcmp(ifap->ifa_name, primaryInterface))
+
+            if (strcmp(ifap->ifa_name, primaryInterface))
 #endif
-      {
-        continue;
-      }
-      if ((ifap->ifa_flags & IFF_UP) && ((!useIPv6 && (ifap->ifa_addr->sa_family == AF_INET)) || (useIPv6 && (ifap->ifa_addr->sa_family == AF_INET6)))) {
-        address = GCDWebServerStringFromSockAddr(ifap->ifa_addr, NO);
-        break;
-      }
+            {
+                continue;
+            }
+
+            if ((ifap->ifa_flags & IFF_UP) && ((!useIPv6 && (ifap->ifa_addr->sa_family == AF_INET)) || (useIPv6 && (ifap->ifa_addr->sa_family == AF_INET6)))) {
+                address = GCDWebServerStringFromSockAddr(ifap->ifa_addr, NO);
+                break;
+            }
+        }
+
+        freeifaddrs(list);
     }
-    freeifaddrs(list);
-  }
-  return address;
+
+    return address;
 }
 
-NSString* GCDWebServerComputeMD5Digest(NSString* format, ...) {
-  va_list arguments;
-  va_start(arguments, format);
-  const char* string = [[[NSString alloc] initWithFormat:format arguments:arguments] UTF8String];
-  va_end(arguments);
-  unsigned char md5[CC_MD5_DIGEST_LENGTH];
+NSString * GCDWebServerComputeMD5Digest(NSString *format, ...) {
+    va_list arguments;
+
+    va_start(arguments, format);
+    const char *string = [[[NSString alloc] initWithFormat:format arguments:arguments] UTF8String];
+    va_end(arguments);
+    unsigned char md5[CC_MD5_DIGEST_LENGTH];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  CC_MD5(string, (CC_LONG)strlen(string), md5);
+    CC_MD5(string, (CC_LONG)strlen(string), md5);
 #pragma clang diagnostic pop
-  char buffer[2 * CC_MD5_DIGEST_LENGTH + 1];
-  for (int i = 0; i < CC_MD5_DIGEST_LENGTH; ++i) {
-    unsigned char byte = md5[i];
-    unsigned char byteHi = (byte & 0xF0) >> 4;
-    buffer[2 * i + 0] = byteHi >= 10 ? 'a' + byteHi - 10 : '0' + byteHi;
-    unsigned char byteLo = byte & 0x0F;
-    buffer[2 * i + 1] = byteLo >= 10 ? 'a' + byteLo - 10 : '0' + byteLo;
-  }
-  buffer[2 * CC_MD5_DIGEST_LENGTH] = 0;
-  return (NSString*)[NSString stringWithUTF8String:buffer];
+    char buffer[2 * CC_MD5_DIGEST_LENGTH + 1];
+
+    for (int i = 0; i < CC_MD5_DIGEST_LENGTH; ++i) {
+        unsigned char byte = md5[i];
+        unsigned char byteHi = (byte & 0xF0) >> 4;
+        buffer[2 * i + 0] = byteHi >= 10 ? 'a' + byteHi - 10 : '0' + byteHi;
+        unsigned char byteLo = byte & 0x0F;
+        buffer[2 * i + 1] = byteLo >= 10 ? 'a' + byteLo - 10 : '0' + byteLo;
+    }
+
+    buffer[2 * CC_MD5_DIGEST_LENGTH] = 0;
+    return (NSString *)[NSString stringWithUTF8String:buffer];
 }
 
-NSString* GCDWebServerNormalizePath(NSString* path) {
-  NSMutableArray* components = [[NSMutableArray alloc] init];
-  for (NSString* component in [path componentsSeparatedByString:@"/"]) {
-    if ([component isEqualToString:@".."]) {
-      [components removeLastObject];
-    } else if (component.length && ![component isEqualToString:@"."]) {
-      [components addObject:component];
+NSString * GCDWebServerNormalizePath(NSString *path) {
+    NSMutableArray *components = [[NSMutableArray alloc] init];
+
+    for (NSString *component in [path componentsSeparatedByString:@"/"]) {
+        if ([component isEqualToString:@".."]) {
+            [components removeLastObject];
+        } else if (component.length && ![component isEqualToString:@"."]) {
+            [components addObject:component];
+        }
     }
-  }
-  if (path.length && ([path characterAtIndex:0] == '/')) {
-    return [@"/" stringByAppendingString:[components componentsJoinedByString:@"/"]];  // Preserve initial slash
-  }
-  return [components componentsJoinedByString:@"/"];
+
+    if (path.length && ([path characterAtIndex:0] == '/')) {
+        return [@"/" stringByAppendingString:[components componentsJoinedByString:@"/"]]; // Preserve initial slash
+    }
+
+    return [components componentsJoinedByString:@"/"];
 }

--- a/GCDWebServer/Core/GCDWebServerHTTPStatusCodes.h
+++ b/GCDWebServer/Core/GCDWebServerHTTPStatusCodes.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
@@ -34,83 +34,83 @@
  *  Convenience constants for "informational" HTTP status codes.
  */
 typedef NS_ENUM(NSInteger, GCDWebServerInformationalHTTPStatusCode) {
-  kGCDWebServerHTTPStatusCode_Continue = 100,
-  kGCDWebServerHTTPStatusCode_SwitchingProtocols = 101,
-  kGCDWebServerHTTPStatusCode_Processing = 102
+    kGCDWebServerHTTPStatusCode_Continue           = 100,
+    kGCDWebServerHTTPStatusCode_SwitchingProtocols = 101,
+    kGCDWebServerHTTPStatusCode_Processing         = 102
 };
 
 /**
  *  Convenience constants for "successful" HTTP status codes.
  */
 typedef NS_ENUM(NSInteger, GCDWebServerSuccessfulHTTPStatusCode) {
-  kGCDWebServerHTTPStatusCode_OK = 200,
-  kGCDWebServerHTTPStatusCode_Created = 201,
-  kGCDWebServerHTTPStatusCode_Accepted = 202,
-  kGCDWebServerHTTPStatusCode_NonAuthoritativeInformation = 203,
-  kGCDWebServerHTTPStatusCode_NoContent = 204,
-  kGCDWebServerHTTPStatusCode_ResetContent = 205,
-  kGCDWebServerHTTPStatusCode_PartialContent = 206,
-  kGCDWebServerHTTPStatusCode_MultiStatus = 207,
-  kGCDWebServerHTTPStatusCode_AlreadyReported = 208
+    kGCDWebServerHTTPStatusCode_OK                          = 200,
+    kGCDWebServerHTTPStatusCode_Created                     = 201,
+    kGCDWebServerHTTPStatusCode_Accepted                    = 202,
+    kGCDWebServerHTTPStatusCode_NonAuthoritativeInformation = 203,
+    kGCDWebServerHTTPStatusCode_NoContent                   = 204,
+    kGCDWebServerHTTPStatusCode_ResetContent                = 205,
+    kGCDWebServerHTTPStatusCode_PartialContent              = 206,
+    kGCDWebServerHTTPStatusCode_MultiStatus                 = 207,
+    kGCDWebServerHTTPStatusCode_AlreadyReported             = 208
 };
 
 /**
  *  Convenience constants for "redirection" HTTP status codes.
  */
 typedef NS_ENUM(NSInteger, GCDWebServerRedirectionHTTPStatusCode) {
-  kGCDWebServerHTTPStatusCode_MultipleChoices = 300,
-  kGCDWebServerHTTPStatusCode_MovedPermanently = 301,
-  kGCDWebServerHTTPStatusCode_Found = 302,
-  kGCDWebServerHTTPStatusCode_SeeOther = 303,
-  kGCDWebServerHTTPStatusCode_NotModified = 304,
-  kGCDWebServerHTTPStatusCode_UseProxy = 305,
-  kGCDWebServerHTTPStatusCode_TemporaryRedirect = 307,
-  kGCDWebServerHTTPStatusCode_PermanentRedirect = 308
+    kGCDWebServerHTTPStatusCode_MultipleChoices   = 300,
+    kGCDWebServerHTTPStatusCode_MovedPermanently  = 301,
+    kGCDWebServerHTTPStatusCode_Found             = 302,
+    kGCDWebServerHTTPStatusCode_SeeOther          = 303,
+    kGCDWebServerHTTPStatusCode_NotModified       = 304,
+    kGCDWebServerHTTPStatusCode_UseProxy          = 305,
+    kGCDWebServerHTTPStatusCode_TemporaryRedirect = 307,
+    kGCDWebServerHTTPStatusCode_PermanentRedirect = 308
 };
 
 /**
  *  Convenience constants for "client error" HTTP status codes.
  */
 typedef NS_ENUM(NSInteger, GCDWebServerClientErrorHTTPStatusCode) {
-  kGCDWebServerHTTPStatusCode_BadRequest = 400,
-  kGCDWebServerHTTPStatusCode_Unauthorized = 401,
-  kGCDWebServerHTTPStatusCode_PaymentRequired = 402,
-  kGCDWebServerHTTPStatusCode_Forbidden = 403,
-  kGCDWebServerHTTPStatusCode_NotFound = 404,
-  kGCDWebServerHTTPStatusCode_MethodNotAllowed = 405,
-  kGCDWebServerHTTPStatusCode_NotAcceptable = 406,
-  kGCDWebServerHTTPStatusCode_ProxyAuthenticationRequired = 407,
-  kGCDWebServerHTTPStatusCode_RequestTimeout = 408,
-  kGCDWebServerHTTPStatusCode_Conflict = 409,
-  kGCDWebServerHTTPStatusCode_Gone = 410,
-  kGCDWebServerHTTPStatusCode_LengthRequired = 411,
-  kGCDWebServerHTTPStatusCode_PreconditionFailed = 412,
-  kGCDWebServerHTTPStatusCode_RequestEntityTooLarge = 413,
-  kGCDWebServerHTTPStatusCode_RequestURITooLong = 414,
-  kGCDWebServerHTTPStatusCode_UnsupportedMediaType = 415,
-  kGCDWebServerHTTPStatusCode_RequestedRangeNotSatisfiable = 416,
-  kGCDWebServerHTTPStatusCode_ExpectationFailed = 417,
-  kGCDWebServerHTTPStatusCode_UnprocessableEntity = 422,
-  kGCDWebServerHTTPStatusCode_Locked = 423,
-  kGCDWebServerHTTPStatusCode_FailedDependency = 424,
-  kGCDWebServerHTTPStatusCode_UpgradeRequired = 426,
-  kGCDWebServerHTTPStatusCode_PreconditionRequired = 428,
-  kGCDWebServerHTTPStatusCode_TooManyRequests = 429,
-  kGCDWebServerHTTPStatusCode_RequestHeaderFieldsTooLarge = 431
+    kGCDWebServerHTTPStatusCode_BadRequest                   = 400,
+    kGCDWebServerHTTPStatusCode_Unauthorized                 = 401,
+    kGCDWebServerHTTPStatusCode_PaymentRequired              = 402,
+    kGCDWebServerHTTPStatusCode_Forbidden                    = 403,
+    kGCDWebServerHTTPStatusCode_NotFound                     = 404,
+    kGCDWebServerHTTPStatusCode_MethodNotAllowed             = 405,
+    kGCDWebServerHTTPStatusCode_NotAcceptable                = 406,
+    kGCDWebServerHTTPStatusCode_ProxyAuthenticationRequired  = 407,
+    kGCDWebServerHTTPStatusCode_RequestTimeout               = 408,
+    kGCDWebServerHTTPStatusCode_Conflict                     = 409,
+    kGCDWebServerHTTPStatusCode_Gone                         = 410,
+    kGCDWebServerHTTPStatusCode_LengthRequired               = 411,
+    kGCDWebServerHTTPStatusCode_PreconditionFailed           = 412,
+    kGCDWebServerHTTPStatusCode_RequestEntityTooLarge        = 413,
+    kGCDWebServerHTTPStatusCode_RequestURITooLong            = 414,
+    kGCDWebServerHTTPStatusCode_UnsupportedMediaType         = 415,
+    kGCDWebServerHTTPStatusCode_RequestedRangeNotSatisfiable = 416,
+    kGCDWebServerHTTPStatusCode_ExpectationFailed            = 417,
+    kGCDWebServerHTTPStatusCode_UnprocessableEntity          = 422,
+    kGCDWebServerHTTPStatusCode_Locked                       = 423,
+    kGCDWebServerHTTPStatusCode_FailedDependency             = 424,
+    kGCDWebServerHTTPStatusCode_UpgradeRequired              = 426,
+    kGCDWebServerHTTPStatusCode_PreconditionRequired         = 428,
+    kGCDWebServerHTTPStatusCode_TooManyRequests              = 429,
+    kGCDWebServerHTTPStatusCode_RequestHeaderFieldsTooLarge  = 431
 };
 
 /**
  *  Convenience constants for "server error" HTTP status codes.
  */
 typedef NS_ENUM(NSInteger, GCDWebServerServerErrorHTTPStatusCode) {
-  kGCDWebServerHTTPStatusCode_InternalServerError = 500,
-  kGCDWebServerHTTPStatusCode_NotImplemented = 501,
-  kGCDWebServerHTTPStatusCode_BadGateway = 502,
-  kGCDWebServerHTTPStatusCode_ServiceUnavailable = 503,
-  kGCDWebServerHTTPStatusCode_GatewayTimeout = 504,
-  kGCDWebServerHTTPStatusCode_HTTPVersionNotSupported = 505,
-  kGCDWebServerHTTPStatusCode_InsufficientStorage = 507,
-  kGCDWebServerHTTPStatusCode_LoopDetected = 508,
-  kGCDWebServerHTTPStatusCode_NotExtended = 510,
-  kGCDWebServerHTTPStatusCode_NetworkAuthenticationRequired = 511
+    kGCDWebServerHTTPStatusCode_InternalServerError           = 500,
+    kGCDWebServerHTTPStatusCode_NotImplemented                = 501,
+    kGCDWebServerHTTPStatusCode_BadGateway                    = 502,
+    kGCDWebServerHTTPStatusCode_ServiceUnavailable            = 503,
+    kGCDWebServerHTTPStatusCode_GatewayTimeout                = 504,
+    kGCDWebServerHTTPStatusCode_HTTPVersionNotSupported       = 505,
+    kGCDWebServerHTTPStatusCode_InsufficientStorage           = 507,
+    kGCDWebServerHTTPStatusCode_LoopDetected                  = 508,
+    kGCDWebServerHTTPStatusCode_NotExtended                   = 510,
+    kGCDWebServerHTTPStatusCode_NetworkAuthenticationRequired = 511
 };

--- a/GCDWebServer/Core/GCDWebServerPrivate.h
+++ b/GCDWebServer/Core/GCDWebServerPrivate.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import <os/object.h>
@@ -72,61 +72,61 @@
 
 #import "XLFacilityMacros.h"
 
-#define GWS_LOG_DEBUG(...) XLOG_DEBUG(__VA_ARGS__)
-#define GWS_LOG_VERBOSE(...) XLOG_VERBOSE(__VA_ARGS__)
-#define GWS_LOG_INFO(...) XLOG_INFO(__VA_ARGS__)
-#define GWS_LOG_WARNING(...) XLOG_WARNING(__VA_ARGS__)
-#define GWS_LOG_ERROR(...) XLOG_ERROR(__VA_ARGS__)
+#define GWS_LOG_DEBUG(...)        XLOG_DEBUG(__VA_ARGS__)
+#define GWS_LOG_VERBOSE(...)      XLOG_VERBOSE(__VA_ARGS__)
+#define GWS_LOG_INFO(...)         XLOG_INFO(__VA_ARGS__)
+#define GWS_LOG_WARNING(...)      XLOG_WARNING(__VA_ARGS__)
+#define GWS_LOG_ERROR(...)        XLOG_ERROR(__VA_ARGS__)
 
 #define GWS_DCHECK(__CONDITION__) XLOG_DEBUG_CHECK(__CONDITION__)
-#define GWS_DNOT_REACHED() XLOG_DEBUG_UNREACHABLE()
+#define GWS_DNOT_REACHED()        XLOG_DEBUG_UNREACHABLE()
 
 /**
  *  If all of the above fail, then use GCDWebServer built-in
  *  logging facility.
  */
 
-#else
+#else  /* if defined(__GCDWEBSERVER_LOGGING_HEADER__) */
 
 #define __GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__
 
 typedef NS_ENUM(int, GCDWebServerLoggingLevel) {
-  kGCDWebServerLoggingLevel_Debug = 0,
-  kGCDWebServerLoggingLevel_Verbose,
-  kGCDWebServerLoggingLevel_Info,
-  kGCDWebServerLoggingLevel_Warning,
-  kGCDWebServerLoggingLevel_Error
+    kGCDWebServerLoggingLevel_Debug = 0,
+    kGCDWebServerLoggingLevel_Verbose,
+    kGCDWebServerLoggingLevel_Info,
+    kGCDWebServerLoggingLevel_Warning,
+    kGCDWebServerLoggingLevel_Error
 };
 
 extern GCDWebServerLoggingLevel GCDWebServerLogLevel;
-extern void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* _Nonnull format, ...) NS_FORMAT_FUNCTION(2, 3);
+extern void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString * _Nonnull format, ...) NS_FORMAT_FUNCTION(2, 3);
 
 #if DEBUG
-#define GWS_LOG_DEBUG(...)                                                                                                             \
-  do {                                                                                                                                 \
-    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Debug) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Debug, __VA_ARGS__); \
-  } while (0)
+#define GWS_LOG_DEBUG(...)                                                                                                                     \
+        do {                                                                                                                                   \
+            if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Debug) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Debug, __VA_ARGS__); \
+        } while (0)
 #else
 #define GWS_LOG_DEBUG(...)
 #endif
-#define GWS_LOG_VERBOSE(...)                                                                                                               \
-  do {                                                                                                                                     \
-    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Verbose) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Verbose, __VA_ARGS__); \
-  } while (0)
-#define GWS_LOG_INFO(...)                                                                                                            \
-  do {                                                                                                                               \
-    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Info) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Info, __VA_ARGS__); \
-  } while (0)
-#define GWS_LOG_WARNING(...)                                                                                                               \
-  do {                                                                                                                                     \
-    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Warning) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Warning, __VA_ARGS__); \
-  } while (0)
-#define GWS_LOG_ERROR(...)                                                                                                             \
-  do {                                                                                                                                 \
-    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Error) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Error, __VA_ARGS__); \
-  } while (0)
+#define GWS_LOG_VERBOSE(...)                                                                                                                       \
+        do {                                                                                                                                       \
+            if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Verbose) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Verbose, __VA_ARGS__); \
+        } while (0)
+#define GWS_LOG_INFO(...)                                                                                                                    \
+        do {                                                                                                                                 \
+            if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Info) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Info, __VA_ARGS__); \
+        } while (0)
+#define GWS_LOG_WARNING(...)                                                                                                                       \
+        do {                                                                                                                                       \
+            if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Warning) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Warning, __VA_ARGS__); \
+        } while (0)
+#define GWS_LOG_ERROR(...)                                                                                                                     \
+        do {                                                                                                                                   \
+            if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Error) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Error, __VA_ARGS__); \
+        } while (0)
 
-#endif
+#endif /* if defined(__GCDWEBSERVER_LOGGING_HEADER__) */
 
 /**
  *  Consistency check macros used when building Debug only.
@@ -136,12 +136,12 @@ extern void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* _No
 
 #if DEBUG
 
-#define GWS_DCHECK(__CONDITION__) \
-  do {                            \
-    if (!(__CONDITION__)) {       \
-      abort();                    \
-    }                             \
-  } while (0)
+#define GWS_DCHECK(__CONDITION__)   \
+        do {                        \
+            if (!(__CONDITION__)) { \
+                abort();            \
+            }                       \
+        } while (0)
 #define GWS_DNOT_REACHED() abort()
 
 #else
@@ -160,63 +160,63 @@ NS_ASSUME_NONNULL_BEGIN
  */
 
 #define kGCDWebServerDefaultMimeType @"application/octet-stream"
-#define kGCDWebServerErrorDomain @"GCDWebServerErrorDomain"
+#define kGCDWebServerErrorDomain     @"GCDWebServerErrorDomain"
 
 static inline BOOL GCDWebServerIsValidByteRange(NSRange range) {
-  return ((range.location != NSUIntegerMax) || (range.length > 0));
+    return ((range.location != NSUIntegerMax) || (range.length > 0));
 }
 
-static inline NSError* GCDWebServerMakePosixError(int code) {
-  return [NSError errorWithDomain:NSPOSIXErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey : (NSString*)[NSString stringWithUTF8String:strerror(code)]}];
+static inline NSError * GCDWebServerMakePosixError(int code) {
+    return [NSError errorWithDomain:NSPOSIXErrorDomain code:code userInfo:@{ NSLocalizedDescriptionKey: (NSString *)[NSString stringWithUTF8String:strerror(code)] }];
 }
 
 extern void GCDWebServerInitializeFunctions(void);
-extern NSString* _Nullable GCDWebServerNormalizeHeaderValue(NSString* _Nullable value);
-extern NSString* _Nullable GCDWebServerTruncateHeaderValue(NSString* _Nullable value);
-extern NSString* _Nullable GCDWebServerExtractHeaderValueParameter(NSString* _Nullable value, NSString* attribute);
-extern NSStringEncoding GCDWebServerStringEncodingFromCharset(NSString* charset);
-extern BOOL GCDWebServerIsTextContentType(NSString* type);
-extern NSString* GCDWebServerDescribeData(NSData* data, NSString* contentType);
-extern NSString* GCDWebServerComputeMD5Digest(NSString* format, ...) NS_FORMAT_FUNCTION(1, 2);
-extern NSString* GCDWebServerStringFromSockAddr(const struct sockaddr* addr, BOOL includeService);
+extern NSString * _Nullable GCDWebServerNormalizeHeaderValue(NSString * _Nullable value);
+extern NSString * _Nullable GCDWebServerTruncateHeaderValue(NSString * _Nullable value);
+extern NSString * _Nullable GCDWebServerExtractHeaderValueParameter(NSString * _Nullable value, NSString *attribute);
+extern NSStringEncoding GCDWebServerStringEncodingFromCharset(NSString *charset);
+extern BOOL GCDWebServerIsTextContentType(NSString *type);
+extern NSString * GCDWebServerDescribeData(NSData *data, NSString *contentType);
+extern NSString * GCDWebServerComputeMD5Digest(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+extern NSString * GCDWebServerStringFromSockAddr(const struct sockaddr *addr, BOOL includeService);
 
 @interface GCDWebServerConnection ()
-- (instancetype)initWithServer:(GCDWebServer*)server localAddress:(NSData*)localAddress remoteAddress:(NSData*)remoteAddress socket:(CFSocketNativeHandle)socket;
+- (instancetype)initWithServer:(GCDWebServer *)server localAddress:(NSData *)localAddress remoteAddress:(NSData *)remoteAddress socket:(CFSocketNativeHandle)socket;
 @end
 
 @interface GCDWebServer ()
-@property(nonatomic, readonly) NSMutableArray<GCDWebServerHandler*>* handlers;
-@property(nonatomic, readonly, nullable) NSString* serverName;
-@property(nonatomic, readonly, nullable) NSString* authenticationRealm;
-@property(nonatomic, readonly, nullable) NSMutableDictionary<NSString*, NSString*>* authenticationBasicAccounts;
-@property(nonatomic, readonly, nullable) NSMutableDictionary<NSString*, NSString*>* authenticationDigestAccounts;
-@property(nonatomic, readonly) BOOL shouldAutomaticallyMapHEADToGET;
-@property(nonatomic, readonly) dispatch_queue_priority_t dispatchQueuePriority;
-- (void)willStartConnection:(GCDWebServerConnection*)connection;
-- (void)didEndConnection:(GCDWebServerConnection*)connection;
+@property (nonatomic, readonly) NSMutableArray<GCDWebServerHandler *> *handlers;
+@property (nonatomic, readonly, nullable) NSString *serverName;
+@property (nonatomic, readonly, nullable) NSString *authenticationRealm;
+@property (nonatomic, readonly, nullable) NSMutableDictionary<NSString *, NSString *> *authenticationBasicAccounts;
+@property (nonatomic, readonly, nullable) NSMutableDictionary<NSString *, NSString *> *authenticationDigestAccounts;
+@property (nonatomic, readonly) BOOL shouldAutomaticallyMapHEADToGET;
+@property (nonatomic, readonly) dispatch_queue_priority_t dispatchQueuePriority;
+- (void)willStartConnection:(GCDWebServerConnection *)connection;
+- (void)didEndConnection:(GCDWebServerConnection *)connection;
 @end
 
 @interface GCDWebServerHandler : NSObject
-@property(nonatomic, readonly) GCDWebServerMatchBlock matchBlock;
-@property(nonatomic, readonly) GCDWebServerAsyncProcessBlock asyncProcessBlock;
+@property (nonatomic, readonly) GCDWebServerMatchBlock matchBlock;
+@property (nonatomic, readonly) GCDWebServerAsyncProcessBlock asyncProcessBlock;
 @end
 
 @interface GCDWebServerRequest ()
-@property(nonatomic, readonly) BOOL usesChunkedTransferEncoding;
-@property(nonatomic) NSData* localAddressData;
-@property(nonatomic) NSData* remoteAddressData;
+@property (nonatomic, readonly) BOOL usesChunkedTransferEncoding;
+@property (nonatomic) NSData *localAddressData;
+@property (nonatomic) NSData *remoteAddressData;
 - (void)prepareForWriting;
-- (BOOL)performOpen:(NSError**)error;
-- (BOOL)performWriteData:(NSData*)data error:(NSError**)error;
-- (BOOL)performClose:(NSError**)error;
-- (void)setAttribute:(nullable id)attribute forKey:(NSString*)key;
+- (BOOL)performOpen:(NSError **)error;
+- (BOOL)performWriteData:(NSData *)data error:(NSError **)error;
+- (BOOL)performClose:(NSError **)error;
+- (void)setAttribute:(nullable id)attribute forKey:(NSString *)key;
 @end
 
 @interface GCDWebServerResponse ()
-@property(nonatomic, readonly) NSDictionary<NSString*, NSString*>* additionalHeaders;
-@property(nonatomic, readonly) BOOL usesChunkedTransferEncoding;
+@property (nonatomic, readonly) NSDictionary<NSString *, NSString *> *additionalHeaders;
+@property (nonatomic, readonly) BOOL usesChunkedTransferEncoding;
 - (void)prepareForReading;
-- (BOOL)performOpen:(NSError**)error;
+- (BOOL)performOpen:(NSError **)error;
 - (void)performReadDataWithCompletion:(GCDWebServerBodyReaderCompletionBlock)block;
 - (void)performClose;
 @end

--- a/GCDWebServer/Core/GCDWebServerRequest.h
+++ b/GCDWebServer/Core/GCDWebServerRequest.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import <Foundation/Foundation.h>
@@ -33,10 +33,10 @@ NS_ASSUME_NONNULL_BEGIN
  *  Attribute key to retrieve an NSArray containing NSStrings from a GCDWebServerRequest
  *  with the contents of any regular expression captures done on the request path.
  *
- *  @warning This attribute will only be set on the request if adding a handler using 
+ *  @warning This attribute will only be set on the request if adding a handler using
  *  -addHandlerForMethod:pathRegex:requestClass:processBlock:.
  */
-extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
+extern NSString * const GCDWebServerRequestAttribute_RegexCaptures;
 
 /**
  *  This protocol is used by the GCDWebServerConnection to communicate with
@@ -56,7 +56,7 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *  It should return YES on success or NO on failure and set the "error" argument
  *  which is guaranteed to be non-NULL.
  */
-- (BOOL)open:(NSError**)error;
+- (BOOL)open:(NSError **)error;
 
 /**
  *  This method is called whenever body data has been received.
@@ -64,7 +64,7 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *  It should return YES on success or NO on failure and set the "error" argument
  *  which is guaranteed to be non-NULL.
  */
-- (BOOL)writeData:(NSData*)data error:(NSError**)error;
+- (BOOL)writeData:(NSData *)data error:(NSError **)error;
 
 /**
  *  This method is called after all body data has been received.
@@ -72,7 +72,7 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *  It should return YES on success or NO on failure and set the "error" argument
  *  which is guaranteed to be non-NULL.
  */
-- (BOOL)close:(NSError**)error;
+- (BOOL)close:(NSError **)error;
 
 @end
 
@@ -92,29 +92,29 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
 /**
  *  Returns the HTTP method for the request.
  */
-@property(nonatomic, readonly) NSString* method;
+@property (nonatomic, readonly) NSString *method;
 
 /**
  *  Returns the URL for the request.
  */
-@property(nonatomic, readonly) NSURL* URL;
+@property (nonatomic, readonly) NSURL *URL;
 
 /**
  *  Returns the HTTP headers for the request.
  */
-@property(nonatomic, readonly) NSDictionary<NSString*, NSString*>* headers;
+@property (nonatomic, readonly) NSDictionary<NSString *, NSString *> *headers;
 
 /**
  *  Returns the path component of the URL for the request.
  */
-@property(nonatomic, readonly) NSString* path;
+@property (nonatomic, readonly) NSString *path;
 
 /**
  *  Returns the parsed and unescaped query component of the URL for the request.
  *
  *  @warning This property will be nil if there is no query in the URL.
  */
-@property(nonatomic, readonly, nullable) NSDictionary<NSString*, NSString*>* query;
+@property (nonatomic, readonly, nullable) NSDictionary<NSString *, NSString *> *query;
 
 /**
  *  Returns the content type for the body of the request parsed from the
@@ -124,7 +124,7 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *  "application/octet-stream" if a body is present but there was no
  *  "Content-Type" header.
  */
-@property(nonatomic, readonly, nullable) NSString* contentType;
+@property (nonatomic, readonly, nullable) NSString *contentType;
 
 /**
  *  Returns the content length for the body of the request parsed from the
@@ -134,59 +134,59 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *  if there is a body but no "Content-Length" header, typically because
  *  chunked transfer encoding is used.
  */
-@property(nonatomic, readonly) NSUInteger contentLength;
+@property (nonatomic, readonly) NSUInteger contentLength;
 
 /**
  *  Returns the parsed "If-Modified-Since" header or nil if absent or malformed.
  */
-@property(nonatomic, readonly, nullable) NSDate* ifModifiedSince;
+@property (nonatomic, readonly, nullable) NSDate *ifModifiedSince;
 
 /**
  *  Returns the parsed "If-None-Match" header or nil if absent or malformed.
  */
-@property(nonatomic, readonly, nullable) NSString* ifNoneMatch;
+@property (nonatomic, readonly, nullable) NSString *ifNoneMatch;
 
 /**
  *  Returns the parsed "Range" header or (NSUIntegerMax, 0) if absent or malformed.
  *  The range will be set to (offset, length) if expressed from the beginning
  *  of the entity body, or (NSUIntegerMax, length) if expressed from its end.
  */
-@property(nonatomic, readonly) NSRange byteRange;
+@property (nonatomic, readonly) NSRange byteRange;
 
 /**
  *  Returns YES if the client supports gzip content encoding according to the
  *  "Accept-Encoding" header.
  */
-@property(nonatomic, readonly) BOOL acceptsGzipContentEncoding;
+@property (nonatomic, readonly) BOOL acceptsGzipContentEncoding;
 
 /**
  *  Returns the address of the local peer (i.e. server) for the request
  *  as a raw "struct sockaddr".
  */
-@property(nonatomic, readonly) NSData* localAddressData;
+@property (nonatomic, readonly) NSData *localAddressData;
 
 /**
  *  Returns the address of the local peer (i.e. server) for the request
  *  as a string.
  */
-@property(nonatomic, readonly) NSString* localAddressString;
+@property (nonatomic, readonly) NSString *localAddressString;
 
 /**
  *  Returns the address of the remote peer (i.e. client) for the request
  *  as a raw "struct sockaddr".
  */
-@property(nonatomic, readonly) NSData* remoteAddressData;
+@property (nonatomic, readonly) NSData *remoteAddressData;
 
 /**
  *  Returns the address of the remote peer (i.e. client) for the request
  *  as a string.
  */
-@property(nonatomic, readonly) NSString* remoteAddressString;
+@property (nonatomic, readonly) NSString *remoteAddressString;
 
 /**
  *  This method is the designated initializer for the class.
  */
-- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary<NSString*, NSString*>*)headers path:(NSString*)path query:(nullable NSDictionary<NSString*, NSString*>*)query;
+- (instancetype)initWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary<NSString *, NSString *> *)headers path:(NSString *)path query:(nullable NSDictionary<NSString *, NSString *> *)query;
 
 /**
  *  Convenience method that checks if the contentType property is defined.
@@ -203,7 +203,7 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *
  *  @return The attribute value for the key.
  */
-- (nullable id)attributeForKey:(NSString*)key;
+- (nullable id)attributeForKey:(NSString *)key;
 
 @end
 

--- a/GCDWebServer/Core/GCDWebServerRequest.m
+++ b/GCDWebServer/Core/GCDWebServerRequest.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -33,9 +33,9 @@
 
 #import "GCDWebServerPrivate.h"
 
-NSString* const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerRequestAttribute_RegexCaptures";
+NSString * const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerRequestAttribute_RegexCaptures";
 
-#define kZlibErrorDomain @"ZlibErrorDomain"
+#define kZlibErrorDomain       @"ZlibErrorDomain"
 #define kGZipInitialBufferSize (256 * 1024)
 
 @interface GCDWebServerBodyDecoder : NSObject <GCDWebServerBodyWriter>
@@ -45,259 +45,294 @@ NSString* const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerReque
 @end
 
 @implementation GCDWebServerBodyDecoder {
-  GCDWebServerRequest* __unsafe_unretained _request;
-  id<GCDWebServerBodyWriter> __unsafe_unretained _writer;
+    GCDWebServerRequest * __unsafe_unretained _request;
+    id<GCDWebServerBodyWriter> __unsafe_unretained _writer;
 }
 
-- (instancetype)initWithRequest:(GCDWebServerRequest* _Nonnull)request writer:(id<GCDWebServerBodyWriter> _Nonnull)writer {
-  if ((self = [super init])) {
-    _request = request;
-    _writer = writer;
-  }
-  return self;
+- (instancetype)initWithRequest:(GCDWebServerRequest * _Nonnull)request writer:(id<GCDWebServerBodyWriter> _Nonnull)writer {
+    if ((self = [super init])) {
+        _request = request;
+        _writer = writer;
+    }
+
+    return self;
 }
 
-- (BOOL)open:(NSError**)error {
-  return [_writer open:error];
+- (BOOL)open:(NSError **)error {
+    return [_writer open:error];
 }
 
-- (BOOL)writeData:(NSData*)data error:(NSError**)error {
-  return [_writer writeData:data error:error];
+- (BOOL)writeData:(NSData *)data error:(NSError **)error {
+    return [_writer writeData:data error:error];
 }
 
-- (BOOL)close:(NSError**)error {
-  return [_writer close:error];
+- (BOOL)close:(NSError **)error {
+    return [_writer close:error];
 }
 
 @end
 
 @implementation GCDWebServerGZipDecoder {
-  z_stream _stream;
-  BOOL _finished;
+    z_stream _stream;
+    BOOL _finished;
 }
 
-- (BOOL)open:(NSError**)error {
-  int result = inflateInit2(&_stream, 15 + 16);
-  if (result != Z_OK) {
-    if (error) {
-      *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+- (BOOL)open:(NSError **)error {
+    int result = inflateInit2(&_stream, 15 + 16);
+
+    if (result != Z_OK) {
+        if (error) {
+            *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+        }
+
+        return NO;
     }
-    return NO;
-  }
-  if (![super open:error]) {
+
+    if (![super open:error]) {
+        inflateEnd(&_stream);
+        return NO;
+    }
+
+    return YES;
+}
+
+- (BOOL)writeData:(NSData *)data error:(NSError **)error {
+    GWS_DCHECK(!_finished);
+    _stream.next_in = (Bytef *)data.bytes;
+    _stream.avail_in = (uInt)data.length;
+    NSMutableData *decodedData = [[NSMutableData alloc] initWithLength:kGZipInitialBufferSize];
+
+    if (decodedData == nil) {
+        GWS_DNOT_REACHED();
+        return NO;
+    }
+
+    NSUInteger length = 0;
+
+    while (1) {
+        NSUInteger maxLength = decodedData.length - length;
+        _stream.next_out = (Bytef *)((char *)decodedData.mutableBytes + length);
+        _stream.avail_out = (uInt)maxLength;
+        int result = inflate(&_stream, Z_NO_FLUSH);
+
+        if ((result != Z_OK) && (result != Z_STREAM_END)) {
+            if (error) {
+                *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+            }
+
+            return NO;
+        }
+
+        length += maxLength - _stream.avail_out;
+
+        if (_stream.avail_out > 0) {
+            if (result == Z_STREAM_END) {
+                _finished = YES;
+            }
+
+            break;
+        }
+
+        decodedData.length = 2 * decodedData.length; // zlib has used all the output buffer so resize it and try again in case more data is available
+    }
+    decodedData.length = length;
+    BOOL success = length ? [super writeData:decodedData error:error] : YES; // No need to call writer if we have no data yet
+    return success;
+}
+
+- (BOOL)close:(NSError **)error {
+    GWS_DCHECK(_finished);
     inflateEnd(&_stream);
-    return NO;
-  }
-  return YES;
-}
-
-- (BOOL)writeData:(NSData*)data error:(NSError**)error {
-  GWS_DCHECK(!_finished);
-  _stream.next_in = (Bytef*)data.bytes;
-  _stream.avail_in = (uInt)data.length;
-  NSMutableData* decodedData = [[NSMutableData alloc] initWithLength:kGZipInitialBufferSize];
-  if (decodedData == nil) {
-    GWS_DNOT_REACHED();
-    return NO;
-  }
-  NSUInteger length = 0;
-  while (1) {
-    NSUInteger maxLength = decodedData.length - length;
-    _stream.next_out = (Bytef*)((char*)decodedData.mutableBytes + length);
-    _stream.avail_out = (uInt)maxLength;
-    int result = inflate(&_stream, Z_NO_FLUSH);
-    if ((result != Z_OK) && (result != Z_STREAM_END)) {
-      if (error) {
-        *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
-      }
-      return NO;
-    }
-    length += maxLength - _stream.avail_out;
-    if (_stream.avail_out > 0) {
-      if (result == Z_STREAM_END) {
-        _finished = YES;
-      }
-      break;
-    }
-    decodedData.length = 2 * decodedData.length;  // zlib has used all the output buffer so resize it and try again in case more data is available
-  }
-  decodedData.length = length;
-  BOOL success = length ? [super writeData:decodedData error:error] : YES;  // No need to call writer if we have no data yet
-  return success;
-}
-
-- (BOOL)close:(NSError**)error {
-  GWS_DCHECK(_finished);
-  inflateEnd(&_stream);
-  return [super close:error];
+    return [super close:error];
 }
 
 @end
 
 @implementation GCDWebServerRequest {
-  BOOL _opened;
-  NSMutableArray<GCDWebServerBodyDecoder*>* _decoders;
-  id<GCDWebServerBodyWriter> __unsafe_unretained _writer;
-  NSMutableDictionary<NSString*, id>* _attributes;
+    BOOL _opened;
+    NSMutableArray<GCDWebServerBodyDecoder *> *_decoders;
+    id<GCDWebServerBodyWriter> __unsafe_unretained _writer;
+    NSMutableDictionary<NSString *, id> *_attributes;
 }
 
-- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary<NSString*, NSString*>*)headers path:(NSString*)path query:(NSDictionary<NSString*, NSString*>*)query {
-  if ((self = [super init])) {
-    _method = [method copy];
-    _URL = url;
-    _headers = headers;
-    _path = [path copy];
-    _query = query;
+- (instancetype)initWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary<NSString *, NSString *> *)headers path:(NSString *)path query:(NSDictionary<NSString *, NSString *> *)query {
+    if ((self = [super init])) {
+        _method = [method copy];
+        _URL = url;
+        _headers = headers;
+        _path = [path copy];
+        _query = query;
 
-    _contentType = GCDWebServerNormalizeHeaderValue([_headers objectForKey:@"Content-Type"]);
-    _usesChunkedTransferEncoding = [GCDWebServerNormalizeHeaderValue([_headers objectForKey:@"Transfer-Encoding"]) isEqualToString:@"chunked"];
-    NSString* lengthHeader = [_headers objectForKey:@"Content-Length"];
-    if (lengthHeader) {
-      NSInteger length = [lengthHeader integerValue];
-      if (_usesChunkedTransferEncoding || (length < 0)) {
-        GWS_LOG_WARNING(@"Invalid 'Content-Length' header '%@' for '%@' request on \"%@\"", lengthHeader, _method, _URL);
-        GWS_DNOT_REACHED();
-        return nil;
-      }
-      _contentLength = length;
-      if (_contentType == nil) {
-        _contentType = kGCDWebServerDefaultMimeType;
-      }
-    } else if (_usesChunkedTransferEncoding) {
-      if (_contentType == nil) {
-        _contentType = kGCDWebServerDefaultMimeType;
-      }
-      _contentLength = NSUIntegerMax;
-    } else {
-      if (_contentType) {
-        GWS_LOG_WARNING(@"Ignoring 'Content-Type' header for '%@' request on \"%@\"", _method, _URL);
-        _contentType = nil;  // Content-Type without Content-Length or chunked-encoding doesn't make sense
-      }
-      _contentLength = NSUIntegerMax;
-    }
+        _contentType = GCDWebServerNormalizeHeaderValue([_headers objectForKey:@"Content-Type"]);
+        _usesChunkedTransferEncoding = [GCDWebServerNormalizeHeaderValue([_headers objectForKey:@"Transfer-Encoding"]) isEqualToString:@"chunked"];
+        NSString *lengthHeader = [_headers objectForKey:@"Content-Length"];
 
-    NSString* modifiedHeader = [_headers objectForKey:@"If-Modified-Since"];
-    if (modifiedHeader) {
-      _ifModifiedSince = [GCDWebServerParseRFC822(modifiedHeader) copy];
-    }
-    _ifNoneMatch = [_headers objectForKey:@"If-None-Match"];
+        if (lengthHeader) {
+            NSInteger length = [lengthHeader integerValue];
 
-    _byteRange = NSMakeRange(NSUIntegerMax, 0);
-    NSString* rangeHeader = GCDWebServerNormalizeHeaderValue([_headers objectForKey:@"Range"]);
-    if (rangeHeader) {
-      if ([rangeHeader hasPrefix:@"bytes="]) {
-        NSArray* components = [[rangeHeader substringFromIndex:6] componentsSeparatedByString:@","];
-        if (components.count == 1) {
-          components = [(NSString*)[components firstObject] componentsSeparatedByString:@"-"];
-          if (components.count == 2) {
-            NSString* startString = [components objectAtIndex:0];
-            NSInteger startValue = [startString integerValue];
-            NSString* endString = [components objectAtIndex:1];
-            NSInteger endValue = [endString integerValue];
-            if (startString.length && (startValue >= 0) && endString.length && (endValue >= startValue)) {  // The second 500 bytes: "500-999"
-              _byteRange.location = startValue;
-              _byteRange.length = endValue - startValue + 1;
-            } else if (startString.length && (startValue >= 0)) {  // The bytes after 9500 bytes: "9500-"
-              _byteRange.location = startValue;
-              _byteRange.length = NSUIntegerMax;
-            } else if (endString.length && (endValue > 0)) {  // The final 500 bytes: "-500"
-              _byteRange.location = NSUIntegerMax;
-              _byteRange.length = endValue;
+            if (_usesChunkedTransferEncoding || (length < 0)) {
+                GWS_LOG_WARNING(@"Invalid 'Content-Length' header '%@' for '%@' request on \"%@\"", lengthHeader, _method, _URL);
+                GWS_DNOT_REACHED();
+                return nil;
             }
-          }
+
+            _contentLength = length;
+
+            if (_contentType == nil) {
+                _contentType = kGCDWebServerDefaultMimeType;
+            }
+        } else if (_usesChunkedTransferEncoding) {
+            if (_contentType == nil) {
+                _contentType = kGCDWebServerDefaultMimeType;
+            }
+
+            _contentLength = NSUIntegerMax;
+        } else {
+            if (_contentType) {
+                GWS_LOG_WARNING(@"Ignoring 'Content-Type' header for '%@' request on \"%@\"", _method, _URL);
+                _contentType = nil; // Content-Type without Content-Length or chunked-encoding doesn't make sense
+            }
+
+            _contentLength = NSUIntegerMax;
         }
-      }
-      if ((_byteRange.location == NSUIntegerMax) && (_byteRange.length == 0)) {  // Ignore "Range" header if syntactically invalid
-        GWS_LOG_WARNING(@"Failed to parse 'Range' header \"%@\" for url: %@", rangeHeader, url);
-      }
+
+        NSString *modifiedHeader = [_headers objectForKey:@"If-Modified-Since"];
+
+        if (modifiedHeader) {
+            _ifModifiedSince = [GCDWebServerParseRFC822(modifiedHeader) copy];
+        }
+
+        _ifNoneMatch = [_headers objectForKey:@"If-None-Match"];
+
+        _byteRange = NSMakeRange(NSUIntegerMax, 0);
+        NSString *rangeHeader = GCDWebServerNormalizeHeaderValue([_headers objectForKey:@"Range"]);
+
+        if (rangeHeader) {
+            if ([rangeHeader hasPrefix:@"bytes="]) {
+                NSArray *components = [[rangeHeader substringFromIndex:6] componentsSeparatedByString:@","];
+
+                if (components.count == 1) {
+                    components = [(NSString *)[components firstObject] componentsSeparatedByString:@"-"];
+
+                    if (components.count == 2) {
+                        NSString *startString = [components objectAtIndex:0];
+                        NSInteger startValue = [startString integerValue];
+                        NSString *endString = [components objectAtIndex:1];
+                        NSInteger endValue = [endString integerValue];
+
+                        if (startString.length && (startValue >= 0) && endString.length && (endValue >= startValue)) { // The second 500 bytes: "500-999"
+                            _byteRange.location = startValue;
+                            _byteRange.length = endValue - startValue + 1;
+                        } else if (startString.length && (startValue >= 0)) { // The bytes after 9500 bytes: "9500-"
+                            _byteRange.location = startValue;
+                            _byteRange.length = NSUIntegerMax;
+                        } else if (endString.length && (endValue > 0)) { // The final 500 bytes: "-500"
+                            _byteRange.location = NSUIntegerMax;
+                            _byteRange.length = endValue;
+                        }
+                    }
+                }
+            }
+
+            if ((_byteRange.location == NSUIntegerMax) && (_byteRange.length == 0)) { // Ignore "Range" header if syntactically invalid
+                GWS_LOG_WARNING(@"Failed to parse 'Range' header \"%@\" for url: %@", rangeHeader, url);
+            }
+        }
+
+        if ([[_headers objectForKey:@"Accept-Encoding"] rangeOfString:@"gzip"].location != NSNotFound) {
+            _acceptsGzipContentEncoding = YES;
+        }
+
+        _decoders = [[NSMutableArray alloc] init];
+        _attributes = [[NSMutableDictionary alloc] init];
     }
 
-    if ([[_headers objectForKey:@"Accept-Encoding"] rangeOfString:@"gzip"].location != NSNotFound) {
-      _acceptsGzipContentEncoding = YES;
-    }
-
-    _decoders = [[NSMutableArray alloc] init];
-    _attributes = [[NSMutableDictionary alloc] init];
-  }
-  return self;
+    return self;
 }
 
 - (BOOL)hasBody {
-  return _contentType ? YES : NO;
+    return _contentType ? YES : NO;
 }
 
 - (BOOL)hasByteRange {
-  return GCDWebServerIsValidByteRange(_byteRange);
+    return GCDWebServerIsValidByteRange(_byteRange);
 }
 
-- (id)attributeForKey:(NSString*)key {
-  return [_attributes objectForKey:key];
+- (id)attributeForKey:(NSString *)key {
+    return [_attributes objectForKey:key];
 }
 
-- (BOOL)open:(NSError**)error {
-  return YES;
+- (BOOL)open:(NSError **)error {
+    return YES;
 }
 
-- (BOOL)writeData:(NSData*)data error:(NSError**)error {
-  return YES;
+- (BOOL)writeData:(NSData *)data error:(NSError **)error {
+    return YES;
 }
 
-- (BOOL)close:(NSError**)error {
-  return YES;
+- (BOOL)close:(NSError **)error {
+    return YES;
 }
 
 - (void)prepareForWriting {
-  _writer = self;
-  if ([GCDWebServerNormalizeHeaderValue([self.headers objectForKey:@"Content-Encoding"]) isEqualToString:@"gzip"]) {
-    GCDWebServerGZipDecoder* decoder = [[GCDWebServerGZipDecoder alloc] initWithRequest:self writer:_writer];
-    [_decoders addObject:decoder];
-    _writer = decoder;
-  }
+    _writer = self;
+
+    if ([GCDWebServerNormalizeHeaderValue([self.headers objectForKey:@"Content-Encoding"]) isEqualToString:@"gzip"]) {
+        GCDWebServerGZipDecoder *decoder = [[GCDWebServerGZipDecoder alloc] initWithRequest:self writer:_writer];
+        [_decoders addObject:decoder];
+        _writer = decoder;
+    }
 }
 
-- (BOOL)performOpen:(NSError**)error {
-  GWS_DCHECK(_contentType);
-  GWS_DCHECK(_writer);
-  if (_opened) {
-    GWS_DNOT_REACHED();
-    return NO;
-  }
-  _opened = YES;
-  return [_writer open:error];
+- (BOOL)performOpen:(NSError **)error {
+    GWS_DCHECK(_contentType);
+    GWS_DCHECK(_writer);
+
+    if (_opened) {
+        GWS_DNOT_REACHED();
+        return NO;
+    }
+
+    _opened = YES;
+    return [_writer open:error];
 }
 
-- (BOOL)performWriteData:(NSData*)data error:(NSError**)error {
-  GWS_DCHECK(_opened);
-  return [_writer writeData:data error:error];
+- (BOOL)performWriteData:(NSData *)data error:(NSError **)error {
+    GWS_DCHECK(_opened);
+    return [_writer writeData:data error:error];
 }
 
-- (BOOL)performClose:(NSError**)error {
-  GWS_DCHECK(_opened);
-  return [_writer close:error];
+- (BOOL)performClose:(NSError **)error {
+    GWS_DCHECK(_opened);
+    return [_writer close:error];
 }
 
-- (void)setAttribute:(id)attribute forKey:(NSString*)key {
-  [_attributes setValue:attribute forKey:key];
+- (void)setAttribute:(id)attribute forKey:(NSString *)key {
+    [_attributes setValue:attribute forKey:key];
 }
 
-- (NSString*)localAddressString {
-  return GCDWebServerStringFromSockAddr(_localAddressData.bytes, YES);
+- (NSString *)localAddressString {
+    return GCDWebServerStringFromSockAddr(_localAddressData.bytes, YES);
 }
 
-- (NSString*)remoteAddressString {
-  return GCDWebServerStringFromSockAddr(_remoteAddressData.bytes, YES);
+- (NSString *)remoteAddressString {
+    return GCDWebServerStringFromSockAddr(_remoteAddressData.bytes, YES);
 }
 
-- (NSString*)description {
-  NSMutableString* description = [NSMutableString stringWithFormat:@"%@ %@", _method, _path];
-  for (NSString* argument in [[_query allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
-    [description appendFormat:@"\n  %@ = %@", argument, [_query objectForKey:argument]];
-  }
-  [description appendString:@"\n"];
-  for (NSString* header in [[_headers allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
-    [description appendFormat:@"\n%@: %@", header, [_headers objectForKey:header]];
-  }
-  return description;
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithFormat:@"%@ %@", _method, _path];
+
+    for (NSString *argument in [[_query allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+        [description appendFormat:@"\n  %@ = %@", argument, [_query objectForKey:argument]];
+    }
+
+    [description appendString:@"\n"];
+
+    for (NSString *header in [[_headers allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+        [description appendFormat:@"\n%@: %@", header, [_headers objectForKey:header]];
+    }
+
+    return description;
 }
 
 @end

--- a/GCDWebServer/Core/GCDWebServerResponse.h
+++ b/GCDWebServer/Core/GCDWebServerResponse.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import <Foundation/Foundation.h>
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  The GCDWebServerBodyReaderCompletionBlock is passed by GCDWebServer to the
  *  GCDWebServerBodyReader object when reading data from it asynchronously.
  */
-typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NSError* _Nullable error);
+typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData * _Nullable data, NSError * _Nullable error);
 
 /**
  *  This protocol is used by the GCDWebServerConnection to communicate with
@@ -55,7 +55,7 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NS
  *  It should return YES on success or NO on failure and set the "error" argument
  *  which is guaranteed to be non-NULL.
  */
-- (BOOL)open:(NSError**)error;
+- (BOOL)open:(NSError **)error;
 
 /**
  *  This method is called whenever body data is sent.
@@ -64,7 +64,7 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NS
  *  or an empty NSData there is no more body data, or nil on error and set
  *  the "error" argument which is guaranteed to be non-NULL.
  */
-- (nullable NSData*)readData:(NSError**)error;
+- (nullable NSData *)readData:(NSError **)error;
 
 /**
  *  This method is called after all body data has been sent.
@@ -104,7 +104,7 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NS
  *
  *  @warning This property must be set if a body is present.
  */
-@property(nonatomic, copy, nullable) NSString* contentType;
+@property (nonatomic, copy, nullable) NSString *contentType;
 
 /**
  *  Sets the content length for the body of the response. If a body is present
@@ -116,14 +116,14 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NS
  *  The default value is "NSUIntegerMax" i.e. the response has no body or its length
  *  is undefined.
  */
-@property(nonatomic) NSUInteger contentLength;
+@property (nonatomic) NSUInteger contentLength;
 
 /**
  *  Sets the HTTP status code for the response.
  *
  *  The default value is 200 i.e. "OK".
  */
-@property(nonatomic) NSInteger statusCode;
+@property (nonatomic) NSInteger statusCode;
 
 /**
  *  Sets the caching hint for the response using the "Cache-Control" header.
@@ -131,21 +131,21 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NS
  *
  *  The default value is 0 i.e. "no-cache".
  */
-@property(nonatomic) NSUInteger cacheControlMaxAge;
+@property (nonatomic) NSUInteger cacheControlMaxAge;
 
 /**
  *  Sets the last modified date for the response using the "Last-Modified" header.
  *
  *  The default value is nil.
  */
-@property(nonatomic, nullable) NSDate* lastModifiedDate;
+@property (nonatomic, nullable) NSDate *lastModifiedDate;
 
 /**
  *  Sets the ETag for the response using the "ETag" header.
  *
  *  The default value is nil.
  */
-@property(nonatomic, copy, nullable) NSString* eTag;
+@property (nonatomic, copy, nullable) NSString *eTag;
 
 /**
  *  Enables gzip encoding for the response body.
@@ -157,7 +157,7 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NS
  *  be able to determine the body length when connection is closed per
  *  HTTP/1.1 specifications.
  */
-@property(nonatomic, getter=isGZipContentEncodingEnabled) BOOL gzipContentEncodingEnabled;
+@property (nonatomic, getter = isGZipContentEncodingEnabled) BOOL gzipContentEncodingEnabled;
 
 /**
  *  Creates an empty response.
@@ -176,7 +176,7 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NS
  *  @warning Do not attempt to override the primary headers used
  *  by GCDWebServerResponse like "Content-Type", "ETag", etc...
  */
-- (void)setValue:(nullable NSString*)value forAdditionalHeader:(NSString*)header;
+- (void)setValue:(nullable NSString *)value forAdditionalHeader:(NSString *)header;
 
 /**
  *  Convenience method that checks if the contentType property is defined.
@@ -195,7 +195,7 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NS
 /**
  *  Creates an HTTP redirect response to a new URL.
  */
-+ (instancetype)responseWithRedirect:(NSURL*)location permanent:(BOOL)permanent;
++ (instancetype)responseWithRedirect:(NSURL *)location permanent:(BOOL)permanent;
 
 /**
  *  Initializes an empty response with a specific HTTP status code.
@@ -205,7 +205,7 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NS
 /**
  *  Initializes an HTTP redirect response to a new URL.
  */
-- (instancetype)initWithRedirect:(NSURL*)location permanent:(BOOL)permanent;
+- (instancetype)initWithRedirect:(NSURL *)location permanent:(BOOL)permanent;
 
 @end
 

--- a/GCDWebServer/Core/GCDWebServerResponse.m
+++ b/GCDWebServer/Core/GCDWebServerResponse.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -33,7 +33,7 @@
 
 #import "GCDWebServerPrivate.h"
 
-#define kZlibErrorDomain @"ZlibErrorDomain"
+#define kZlibErrorDomain       @"ZlibErrorDomain"
 #define kGZipInitialBufferSize (256 * 1024)
 
 @interface GCDWebServerBodyEncoder : NSObject <GCDWebServerBodyReader>
@@ -43,215 +43,245 @@
 @end
 
 @implementation GCDWebServerBodyEncoder {
-  GCDWebServerResponse* __unsafe_unretained _response;
-  id<GCDWebServerBodyReader> __unsafe_unretained _reader;
+    GCDWebServerResponse * __unsafe_unretained _response;
+    id<GCDWebServerBodyReader> __unsafe_unretained _reader;
 }
 
-- (instancetype)initWithResponse:(GCDWebServerResponse* _Nonnull)response reader:(id<GCDWebServerBodyReader> _Nonnull)reader {
-  if ((self = [super init])) {
-    _response = response;
-    _reader = reader;
-  }
-  return self;
+- (instancetype)initWithResponse:(GCDWebServerResponse * _Nonnull)response reader:(id<GCDWebServerBodyReader> _Nonnull)reader {
+    if ((self = [super init])) {
+        _response = response;
+        _reader = reader;
+    }
+
+    return self;
 }
 
-- (BOOL)open:(NSError**)error {
-  return [_reader open:error];
+- (BOOL)open:(NSError **)error {
+    return [_reader open:error];
 }
 
-- (NSData*)readData:(NSError**)error {
-  return [_reader readData:error];
+- (NSData *)readData:(NSError **)error {
+    return [_reader readData:error];
 }
 
 - (void)close {
-  [_reader close];
+    [_reader close];
 }
 
 @end
 
 @implementation GCDWebServerGZipEncoder {
-  z_stream _stream;
-  BOOL _finished;
+    z_stream _stream;
+    BOOL _finished;
 }
 
-- (instancetype)initWithResponse:(GCDWebServerResponse* _Nonnull)response reader:(id<GCDWebServerBodyReader> _Nonnull)reader {
-  if ((self = [super initWithResponse:response reader:reader])) {
-    response.contentLength = NSUIntegerMax;  // Make sure "Content-Length" header is not set since we don't know it
-    [response setValue:@"gzip" forAdditionalHeader:@"Content-Encoding"];
-  }
-  return self;
-}
-
-- (BOOL)open:(NSError**)error {
-  int result = deflateInit2(&_stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
-  if (result != Z_OK) {
-    if (error) {
-      *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+- (instancetype)initWithResponse:(GCDWebServerResponse * _Nonnull)response reader:(id<GCDWebServerBodyReader> _Nonnull)reader {
+    if ((self = [super initWithResponse:response reader:reader])) {
+        response.contentLength = NSUIntegerMax; // Make sure "Content-Length" header is not set since we don't know it
+        [response setValue:@"gzip" forAdditionalHeader:@"Content-Encoding"];
     }
-    return NO;
-  }
-  if (![super open:error]) {
-    deflateEnd(&_stream);
-    return NO;
-  }
-  return YES;
+
+    return self;
 }
 
-- (NSData*)readData:(NSError**)error {
-  NSMutableData* encodedData;
-  if (_finished) {
-    encodedData = [[NSMutableData alloc] init];
-  } else {
-    encodedData = [[NSMutableData alloc] initWithLength:kGZipInitialBufferSize];
-    if (encodedData == nil) {
-      GWS_DNOT_REACHED();
-      return nil;
-    }
-    NSUInteger length = 0;
-    do {
-      NSData* data = [super readData:error];
-      if (data == nil) {
-        return nil;
-      }
-      _stream.next_in = (Bytef*)data.bytes;
-      _stream.avail_in = (uInt)data.length;
-      while (1) {
-        NSUInteger maxLength = encodedData.length - length;
-        _stream.next_out = (Bytef*)((char*)encodedData.mutableBytes + length);
-        _stream.avail_out = (uInt)maxLength;
-        int result = deflate(&_stream, data.length ? Z_NO_FLUSH : Z_FINISH);
-        if (result == Z_STREAM_END) {
-          _finished = YES;
-        } else if (result != Z_OK) {
-          if (error) {
+- (BOOL)open:(NSError **)error {
+    int result = deflateInit2(&_stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+
+    if (result != Z_OK) {
+        if (error) {
             *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
-          }
-          return nil;
         }
-        length += maxLength - _stream.avail_out;
-        if (_stream.avail_out > 0) {
-          break;
+
+        return NO;
+    }
+
+    if (![super open:error]) {
+        deflateEnd(&_stream);
+        return NO;
+    }
+
+    return YES;
+}
+
+- (NSData *)readData:(NSError **)error {
+    NSMutableData *encodedData;
+
+    if (_finished) {
+        encodedData = [[NSMutableData alloc] init];
+    } else {
+        encodedData = [[NSMutableData alloc] initWithLength:kGZipInitialBufferSize];
+
+        if (encodedData == nil) {
+            GWS_DNOT_REACHED();
+            return nil;
         }
-        encodedData.length = 2 * encodedData.length;  // zlib has used all the output buffer so resize it and try again in case more data is available
-      }
-      GWS_DCHECK(_stream.avail_in == 0);
-    } while (length == 0);  // Make sure we don't return an empty NSData if not in finished state
-    encodedData.length = length;
-  }
-  return encodedData;
+
+        NSUInteger length = 0;
+        do {
+            NSData *data = [super readData:error];
+
+            if (data == nil) {
+                return nil;
+            }
+
+            _stream.next_in = (Bytef *)data.bytes;
+            _stream.avail_in = (uInt)data.length;
+
+            while (1) {
+                NSUInteger maxLength = encodedData.length - length;
+                _stream.next_out = (Bytef *)((char *)encodedData.mutableBytes + length);
+                _stream.avail_out = (uInt)maxLength;
+                int result = deflate(&_stream, data.length ? Z_NO_FLUSH : Z_FINISH);
+
+                if (result == Z_STREAM_END) {
+                    _finished = YES;
+                } else if (result != Z_OK) {
+                    if (error) {
+                        *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+                    }
+
+                    return nil;
+                }
+
+                length += maxLength - _stream.avail_out;
+
+                if (_stream.avail_out > 0) {
+                    break;
+                }
+
+                encodedData.length = 2 * encodedData.length; // zlib has used all the output buffer so resize it and try again in case more data is available
+            }
+            GWS_DCHECK(_stream.avail_in == 0);
+        } while (length == 0); // Make sure we don't return an empty NSData if not in finished state
+        encodedData.length = length;
+    }
+
+    return encodedData;
 }
 
 - (void)close {
-  deflateEnd(&_stream);
-  [super close];
+    deflateEnd(&_stream);
+    [super close];
 }
 
 @end
 
 @implementation GCDWebServerResponse {
-  BOOL _opened;
-  NSMutableArray<GCDWebServerBodyEncoder*>* _encoders;
-  id<GCDWebServerBodyReader> __unsafe_unretained _reader;
+    BOOL _opened;
+    NSMutableArray<GCDWebServerBodyEncoder *> *_encoders;
+    id<GCDWebServerBodyReader> __unsafe_unretained _reader;
 }
 
 + (instancetype)response {
-  return [(GCDWebServerResponse*)[[self class] alloc] init];
+    return [(GCDWebServerResponse *)[[self class] alloc] init];
 }
 
 - (instancetype)init {
-  if ((self = [super init])) {
-    _contentType = nil;
-    _contentLength = NSUIntegerMax;
-    _statusCode = kGCDWebServerHTTPStatusCode_OK;
-    _cacheControlMaxAge = 0;
-    _additionalHeaders = [[NSMutableDictionary alloc] init];
-    _encoders = [[NSMutableArray alloc] init];
-  }
-  return self;
+    if ((self = [super init])) {
+        _contentType = nil;
+        _contentLength = NSUIntegerMax;
+        _statusCode = kGCDWebServerHTTPStatusCode_OK;
+        _cacheControlMaxAge = 0;
+        _additionalHeaders = [[NSMutableDictionary alloc] init];
+        _encoders = [[NSMutableArray alloc] init];
+    }
+
+    return self;
 }
 
-- (void)setValue:(NSString*)value forAdditionalHeader:(NSString*)header {
-  [_additionalHeaders setValue:value forKey:header];
+- (void)setValue:(NSString *)value forAdditionalHeader:(NSString *)header {
+    [_additionalHeaders setValue:value forKey:header];
 }
 
 - (BOOL)hasBody {
-  return _contentType ? YES : NO;
+    return _contentType ? YES : NO;
 }
 
 - (BOOL)usesChunkedTransferEncoding {
-  return (_contentType != nil) && (_contentLength == NSUIntegerMax);
+    return (_contentType != nil) && (_contentLength == NSUIntegerMax);
 }
 
-- (BOOL)open:(NSError**)error {
-  return YES;
+- (BOOL)open:(NSError **)error {
+    return YES;
 }
 
-- (NSData*)readData:(NSError**)error {
-  return [NSData data];
+- (NSData *)readData:(NSError **)error {
+    return [NSData data];
 }
 
 - (void)close {
-  ;
 }
 
 - (void)prepareForReading {
-  _reader = self;
-  if (_gzipContentEncodingEnabled) {
-    GCDWebServerGZipEncoder* encoder = [[GCDWebServerGZipEncoder alloc] initWithResponse:self reader:_reader];
-    [_encoders addObject:encoder];
-    _reader = encoder;
-  }
+    _reader = self;
+
+    if (_gzipContentEncodingEnabled) {
+        GCDWebServerGZipEncoder *encoder = [[GCDWebServerGZipEncoder alloc] initWithResponse:self reader:_reader];
+        [_encoders addObject:encoder];
+        _reader = encoder;
+    }
 }
 
-- (BOOL)performOpen:(NSError**)error {
-  GWS_DCHECK(_contentType);
-  GWS_DCHECK(_reader);
-  if (_opened) {
-    GWS_DNOT_REACHED();
-    return NO;
-  }
-  _opened = YES;
-  return [_reader open:error];
+- (BOOL)performOpen:(NSError **)error {
+    GWS_DCHECK(_contentType);
+    GWS_DCHECK(_reader);
+
+    if (_opened) {
+        GWS_DNOT_REACHED();
+        return NO;
+    }
+
+    _opened = YES;
+    return [_reader open:error];
 }
 
 - (void)performReadDataWithCompletion:(GCDWebServerBodyReaderCompletionBlock)block {
-  GWS_DCHECK(_opened);
-  if ([_reader respondsToSelector:@selector(asyncReadDataWithCompletion:)]) {
-    [_reader asyncReadDataWithCompletion:[block copy]];
-  } else {
-    NSError* error = nil;
-    NSData* data = [_reader readData:&error];
-    block(data, error);
-  }
+    GWS_DCHECK(_opened);
+
+    if ([_reader respondsToSelector:@selector(asyncReadDataWithCompletion:)]) {
+        [_reader asyncReadDataWithCompletion:[block copy]];
+    } else {
+        NSError *error = nil;
+        NSData *data = [_reader readData:&error];
+        block(data, error);
+    }
 }
 
 - (void)performClose {
-  GWS_DCHECK(_opened);
-  [_reader close];
+    GWS_DCHECK(_opened);
+    [_reader close];
 }
 
-- (NSString*)description {
-  NSMutableString* description = [NSMutableString stringWithFormat:@"Status Code = %i", (int)_statusCode];
-  if (_contentType) {
-    [description appendFormat:@"\nContent Type = %@", _contentType];
-  }
-  if (_contentLength != NSUIntegerMax) {
-    [description appendFormat:@"\nContent Length = %lu", (unsigned long)_contentLength];
-  }
-  [description appendFormat:@"\nCache Control Max Age = %lu", (unsigned long)_cacheControlMaxAge];
-  if (_lastModifiedDate) {
-    [description appendFormat:@"\nLast Modified Date = %@", _lastModifiedDate];
-  }
-  if (_eTag) {
-    [description appendFormat:@"\nETag = %@", _eTag];
-  }
-  if (_additionalHeaders.count) {
-    [description appendString:@"\n"];
-    for (NSString* header in [[_additionalHeaders allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
-      [description appendFormat:@"\n%@: %@", header, [_additionalHeaders objectForKey:header]];
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithFormat:@"Status Code = %i", (int)_statusCode];
+
+    if (_contentType) {
+        [description appendFormat:@"\nContent Type = %@", _contentType];
     }
-  }
-  return description;
+
+    if (_contentLength != NSUIntegerMax) {
+        [description appendFormat:@"\nContent Length = %lu", (unsigned long)_contentLength];
+    }
+
+    [description appendFormat:@"\nCache Control Max Age = %lu", (unsigned long)_cacheControlMaxAge];
+
+    if (_lastModifiedDate) {
+        [description appendFormat:@"\nLast Modified Date = %@", _lastModifiedDate];
+    }
+
+    if (_eTag) {
+        [description appendFormat:@"\nETag = %@", _eTag];
+    }
+
+    if (_additionalHeaders.count) {
+        [description appendString:@"\n"];
+
+        for (NSString *header in [[_additionalHeaders allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+            [description appendFormat:@"\n%@: %@", header, [_additionalHeaders objectForKey:header]];
+        }
+    }
+
+    return description;
 }
 
 @end
@@ -259,26 +289,28 @@
 @implementation GCDWebServerResponse (Extensions)
 
 + (instancetype)responseWithStatusCode:(NSInteger)statusCode {
-  return [(GCDWebServerResponse*)[self alloc] initWithStatusCode:statusCode];
+    return [(GCDWebServerResponse *)[self alloc] initWithStatusCode:statusCode];
 }
 
-+ (instancetype)responseWithRedirect:(NSURL*)location permanent:(BOOL)permanent {
-  return [(GCDWebServerResponse*)[self alloc] initWithRedirect:location permanent:permanent];
++ (instancetype)responseWithRedirect:(NSURL *)location permanent:(BOOL)permanent {
+    return [(GCDWebServerResponse *)[self alloc] initWithRedirect:location permanent:permanent];
 }
 
 - (instancetype)initWithStatusCode:(NSInteger)statusCode {
-  if ((self = [self init])) {
-    self.statusCode = statusCode;
-  }
-  return self;
+    if ((self = [self init])) {
+        self.statusCode = statusCode;
+    }
+
+    return self;
 }
 
-- (instancetype)initWithRedirect:(NSURL*)location permanent:(BOOL)permanent {
-  if ((self = [self init])) {
-    self.statusCode = permanent ? kGCDWebServerHTTPStatusCode_MovedPermanently : kGCDWebServerHTTPStatusCode_TemporaryRedirect;
-    [self setValue:[location absoluteString] forAdditionalHeader:@"Location"];
-  }
-  return self;
+- (instancetype)initWithRedirect:(NSURL *)location permanent:(BOOL)permanent {
+    if ((self = [self init])) {
+        self.statusCode = permanent ? kGCDWebServerHTTPStatusCode_MovedPermanently : kGCDWebServerHTTPStatusCode_TemporaryRedirect;
+        [self setValue:[location absoluteString] forAdditionalHeader:@"Location"];
+    }
+
+    return self;
 }
 
 @end

--- a/GCDWebServer/Requests/GCDWebServerDataRequest.h
+++ b/GCDWebServer/Requests/GCDWebServerDataRequest.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServerRequest.h"
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns the data for the request body.
  */
-@property(nonatomic, readonly) NSData* data;
+@property (nonatomic, readonly) NSData *data;
 
 @end
 
@@ -51,13 +51,13 @@ NS_ASSUME_NONNULL_BEGIN
  *  The text encoding used to interpret the data is extracted from the
  *  "Content-Type" header or defaults to UTF-8.
  */
-@property(nonatomic, readonly, nullable) NSString* text;
+@property (nonatomic, readonly, nullable) NSString *text;
 
 /**
  *  Returns the data for the request body interpreted as a JSON object. If the
  *  content type of the body is not JSON, or if an error occurs, nil is returned.
  */
-@property(nonatomic, readonly, nullable) id jsonObject;
+@property (nonatomic, readonly, nullable) id jsonObject;
 
 @end
 

--- a/GCDWebServer/Requests/GCDWebServerDataRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerDataRequest.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -32,73 +32,81 @@
 #import "GCDWebServerPrivate.h"
 
 @interface GCDWebServerDataRequest ()
-@property(nonatomic) NSMutableData* data;
+@property (nonatomic) NSMutableData *data;
 @end
 
 @implementation GCDWebServerDataRequest {
-  NSString* _text;
-  id _jsonObject;
+    NSString *_text;
+    id _jsonObject;
 }
 
-- (BOOL)open:(NSError**)error {
-  if (self.contentLength != NSUIntegerMax) {
-    _data = [[NSMutableData alloc] initWithCapacity:self.contentLength];
-  } else {
-    _data = [[NSMutableData alloc] init];
-  }
-  if (_data == nil) {
-    if (error) {
-      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Failed allocating memory"}];
+- (BOOL)open:(NSError **)error {
+    if (self.contentLength != NSUIntegerMax) {
+        _data = [[NSMutableData alloc] initWithCapacity:self.contentLength];
+    } else {
+        _data = [[NSMutableData alloc] init];
     }
-    return NO;
-  }
-  return YES;
+
+    if (_data == nil) {
+        if (error) {
+            *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{ NSLocalizedDescriptionKey: @"Failed allocating memory" }];
+        }
+
+        return NO;
+    }
+
+    return YES;
 }
 
-- (BOOL)writeData:(NSData*)data error:(NSError**)error {
-  [_data appendData:data];
-  return YES;
+- (BOOL)writeData:(NSData *)data error:(NSError **)error {
+    [_data appendData:data];
+    return YES;
 }
 
-- (BOOL)close:(NSError**)error {
-  return YES;
+- (BOOL)close:(NSError **)error {
+    return YES;
 }
 
-- (NSString*)description {
-  NSMutableString* description = [NSMutableString stringWithString:[super description]];
-  if (_data) {
-    [description appendString:@"\n\n"];
-    [description appendString:GCDWebServerDescribeData(_data, (NSString*)self.contentType)];
-  }
-  return description;
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithString:[super description]];
+
+    if (_data) {
+        [description appendString:@"\n\n"];
+        [description appendString:GCDWebServerDescribeData(_data, (NSString *)self.contentType)];
+    }
+
+    return description;
 }
 
 @end
 
 @implementation GCDWebServerDataRequest (Extensions)
 
-- (NSString*)text {
-  if (_text == nil) {
-    if ([self.contentType hasPrefix:@"text/"]) {
-      NSString* charset = GCDWebServerExtractHeaderValueParameter(self.contentType, @"charset");
-      _text = [[NSString alloc] initWithData:self.data encoding:GCDWebServerStringEncodingFromCharset(charset)];
-    } else {
-      GWS_DNOT_REACHED();
+- (NSString *)text {
+    if (_text == nil) {
+        if ([self.contentType hasPrefix:@"text/"]) {
+            NSString *charset = GCDWebServerExtractHeaderValueParameter(self.contentType, @"charset");
+            _text = [[NSString alloc] initWithData:self.data encoding:GCDWebServerStringEncodingFromCharset(charset)];
+        } else {
+            GWS_DNOT_REACHED();
+        }
     }
-  }
-  return _text;
+
+    return _text;
 }
 
 - (id)jsonObject {
-  if (_jsonObject == nil) {
-    NSString* mimeType = GCDWebServerTruncateHeaderValue(self.contentType);
-    if ([mimeType isEqualToString:@"application/json"] || [mimeType isEqualToString:@"text/json"] || [mimeType isEqualToString:@"text/javascript"]) {
-      _jsonObject = [NSJSONSerialization JSONObjectWithData:_data options:0 error:NULL];
-    } else {
-      GWS_DNOT_REACHED();
+    if (_jsonObject == nil) {
+        NSString *mimeType = GCDWebServerTruncateHeaderValue(self.contentType);
+
+        if ([mimeType isEqualToString:@"application/json"] || [mimeType isEqualToString:@"text/json"] || [mimeType isEqualToString:@"text/javascript"]) {
+            _jsonObject = [NSJSONSerialization JSONObjectWithData:_data options:0 error:NULL];
+        } else {
+            GWS_DNOT_REACHED();
+        }
     }
-  }
-  return _jsonObject;
+
+    return _jsonObject;
 }
 
 @end

--- a/GCDWebServer/Requests/GCDWebServerFileRequest.h
+++ b/GCDWebServer/Requests/GCDWebServerFileRequest.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServerRequest.h"
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  GCDWebServerFileRequest is deallocated. If you want to preserve this file,
  *  you must move it to a different location beforehand.
  */
-@property(nonatomic, readonly) NSString* temporaryPath;
+@property (nonatomic, readonly) NSString *temporaryPath;
 
 @end
 

--- a/GCDWebServer/Requests/GCDWebServerFileRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerFileRequest.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -32,71 +32,86 @@
 #import "GCDWebServerPrivate.h"
 
 @implementation GCDWebServerFileRequest {
-  int _file;
+    int _file;
 }
 
-- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary<NSString*, NSString*>*)headers path:(NSString*)path query:(NSDictionary<NSString*, NSString*>*)query {
-  if ((self = [super initWithMethod:method url:url headers:headers path:path query:query])) {
-    _temporaryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
-  }
-  return self;
+- (instancetype)initWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary<NSString *, NSString *> *)headers path:(NSString *)path query:(NSDictionary<NSString *, NSString *> *)query {
+    if ((self = [super initWithMethod:method url:url headers:headers path:path query:query])) {
+        _temporaryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+    }
+
+    return self;
 }
 
 - (void)dealloc {
-  unlink([_temporaryPath fileSystemRepresentation]);
+    unlink([_temporaryPath fileSystemRepresentation]);
 }
 
-- (BOOL)open:(NSError**)error {
-  _file = open([_temporaryPath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-  if (_file <= 0) {
-    if (error) {
-      *error = GCDWebServerMakePosixError(errno);
+- (BOOL)open:(NSError **)error {
+    _file = open([_temporaryPath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+
+    if (_file <= 0) {
+        if (error) {
+            *error = GCDWebServerMakePosixError(errno);
+        }
+
+        return NO;
     }
-    return NO;
-  }
-  return YES;
+
+    return YES;
 }
 
-- (BOOL)writeData:(NSData*)data error:(NSError**)error {
-  if (write(_file, data.bytes, data.length) != (ssize_t)data.length) {
-    if (error) {
-      *error = GCDWebServerMakePosixError(errno);
+- (BOOL)writeData:(NSData *)data error:(NSError **)error {
+    if (write(_file, data.bytes, data.length) != (ssize_t)data.length) {
+        if (error) {
+            *error = GCDWebServerMakePosixError(errno);
+        }
+
+        return NO;
     }
-    return NO;
-  }
-  return YES;
+
+    return YES;
 }
 
-- (BOOL)close:(NSError**)error {
-  if (close(_file) < 0) {
-    if (error) {
-      *error = GCDWebServerMakePosixError(errno);
+- (BOOL)close:(NSError **)error {
+    if (close(_file) < 0) {
+        if (error) {
+            *error = GCDWebServerMakePosixError(errno);
+        }
+
+        return NO;
     }
-    return NO;
-  }
+
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
-  NSString* creationDateHeader = [self.headers objectForKey:@"X-GCDWebServer-CreationDate"];
-  if (creationDateHeader) {
-    NSDate* date = GCDWebServerParseISO8601(creationDateHeader);
-    if (!date || ![[NSFileManager defaultManager] setAttributes:@{NSFileCreationDate : date} ofItemAtPath:_temporaryPath error:error]) {
-      return NO;
+    NSString *creationDateHeader = [self.headers objectForKey:@"X-GCDWebServer-CreationDate"];
+
+    if (creationDateHeader) {
+        NSDate *date = GCDWebServerParseISO8601(creationDateHeader);
+
+        if (!date || ![[NSFileManager defaultManager] setAttributes:@{ NSFileCreationDate: date } ofItemAtPath:_temporaryPath error:error]) {
+            return NO;
+        }
     }
-  }
-  NSString* modifiedDateHeader = [self.headers objectForKey:@"X-GCDWebServer-ModifiedDate"];
-  if (modifiedDateHeader) {
-    NSDate* date = GCDWebServerParseRFC822(modifiedDateHeader);
-    if (!date || ![[NSFileManager defaultManager] setAttributes:@{NSFileModificationDate : date} ofItemAtPath:_temporaryPath error:error]) {
-      return NO;
+
+    NSString *modifiedDateHeader = [self.headers objectForKey:@"X-GCDWebServer-ModifiedDate"];
+
+    if (modifiedDateHeader) {
+        NSDate *date = GCDWebServerParseRFC822(modifiedDateHeader);
+
+        if (!date || ![[NSFileManager defaultManager] setAttributes:@{ NSFileModificationDate: date } ofItemAtPath:_temporaryPath error:error]) {
+            return NO;
+        }
     }
-  }
-#endif
-  return YES;
+
+#endif /* ifdef __GCDWEBSERVER_ENABLE_TESTING__ */
+    return YES;
 }
 
-- (NSString*)description {
-  NSMutableString* description = [NSMutableString stringWithString:[super description]];
-  [description appendFormat:@"\n\n{%@}", _temporaryPath];
-  return description;
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithString:[super description]];
+
+    [description appendFormat:@"\n\n{%@}", _temporaryPath];
+    return description;
 }
 
 @end

--- a/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.h
+++ b/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServerRequest.h"
@@ -38,18 +38,18 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns the control name retrieved from the part headers.
  */
-@property(nonatomic, readonly) NSString* controlName;
+@property (nonatomic, readonly) NSString *controlName;
 
 /**
  *  Returns the content type retrieved from the part headers or "text/plain"
  *  if not available (per HTTP specifications).
  */
-@property(nonatomic, readonly) NSString* contentType;
+@property (nonatomic, readonly) NSString *contentType;
 
 /**
  *  Returns the MIME type component of the content type for the part.
  */
-@property(nonatomic, readonly) NSString* mimeType;
+@property (nonatomic, readonly) NSString *mimeType;
 
 @end
 
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns the data for the part.
  */
-@property(nonatomic, readonly) NSData* data;
+@property (nonatomic, readonly) NSData *data;
 
 /**
  *  Returns the data for the part interpreted as text. If the content
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  The text encoding used to interpret the data is extracted from the
  *  "Content-Type" header or defaults to UTF-8.
  */
-@property(nonatomic, readonly, nullable) NSString* string;
+@property (nonatomic, readonly, nullable) NSString *string;
 
 @end
 
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns the file name retrieved from the part headers.
  */
-@property(nonatomic, readonly) NSString* fileName;
+@property (nonatomic, readonly) NSString *fileName;
 
 /**
  *  Returns the path to the temporary file containing the part data.
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  GCDWebServerMultiPartFile is deallocated. If you want to preserve this file,
  *  you must move it to a different location beforehand.
  */
-@property(nonatomic, readonly) NSString* temporaryPath;
+@property (nonatomic, readonly) NSString *temporaryPath;
 
 @end
 
@@ -107,29 +107,29 @@ NS_ASSUME_NONNULL_BEGIN
  *  Returns the argument parts from the multipart encoded form as
  *  name / GCDWebServerMultiPartArgument pairs.
  */
-@property(nonatomic, readonly) NSArray<GCDWebServerMultiPartArgument*>* arguments;
+@property (nonatomic, readonly) NSArray<GCDWebServerMultiPartArgument *> *arguments;
 
 /**
  *  Returns the files parts from the multipart encoded form as
  *  name / GCDWebServerMultiPartFile pairs.
  */
-@property(nonatomic, readonly) NSArray<GCDWebServerMultiPartFile*>* files;
+@property (nonatomic, readonly) NSArray<GCDWebServerMultiPartFile *> *files;
 
 /**
  *  Returns the MIME type for multipart encoded forms
  *  i.e. "multipart/form-data".
  */
-+ (NSString*)mimeType;
++ (NSString *)mimeType;
 
 /**
  *  Returns the first argument for a given control name or nil if not found.
  */
-- (nullable GCDWebServerMultiPartArgument*)firstArgumentForControlName:(NSString*)name;
+- (nullable GCDWebServerMultiPartArgument *)firstArgumentForControlName:(NSString *)name;
 
 /**
  *  Returns the first file for a given control name or nil if not found.
  */
-- (nullable GCDWebServerMultiPartFile*)firstFileForControlName:(NSString*)name;
+- (nullable GCDWebServerMultiPartFile *)firstFileForControlName:(NSString *)name;
 
 @end
 

--- a/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -34,372 +34,416 @@
 #define kMultiPartBufferSize (256 * 1024)
 
 typedef enum {
-  kParserState_Undefined = 0,
-  kParserState_Start,
-  kParserState_Headers,
-  kParserState_Content,
-  kParserState_End
+    kParserState_Undefined = 0,
+    kParserState_Start,
+    kParserState_Headers,
+    kParserState_Content,
+    kParserState_End
 } ParserState;
 
 @interface GCDWebServerMIMEStreamParser : NSObject
 @end
 
-static NSData* _newlineData = nil;
-static NSData* _newlinesData = nil;
-static NSData* _dashNewlineData = nil;
+static NSData * _newlineData = nil;
+static NSData *_newlinesData = nil;
+static NSData *_dashNewlineData = nil;
 
 @implementation GCDWebServerMultiPart
 
-- (instancetype)initWithControlName:(NSString* _Nonnull)name contentType:(NSString* _Nonnull)type {
-  if ((self = [super init])) {
-    _controlName = [name copy];
-    _contentType = [type copy];
-    _mimeType = (NSString*)GCDWebServerTruncateHeaderValue(_contentType);
-  }
-  return self;
+- (instancetype)initWithControlName:(NSString * _Nonnull)name contentType:(NSString * _Nonnull)type {
+    if ((self = [super init])) {
+        _controlName = [name copy];
+        _contentType = [type copy];
+        _mimeType = (NSString *)GCDWebServerTruncateHeaderValue(_contentType);
+    }
+
+    return self;
 }
 
 @end
 
 @implementation GCDWebServerMultiPartArgument
 
-- (instancetype)initWithControlName:(NSString* _Nonnull)name contentType:(NSString* _Nonnull)type data:(NSData* _Nonnull)data {
-  if ((self = [super initWithControlName:name contentType:type])) {
-    _data = data;
+- (instancetype)initWithControlName:(NSString * _Nonnull)name contentType:(NSString * _Nonnull)type data:(NSData * _Nonnull)data {
+    if ((self = [super initWithControlName:name contentType:type])) {
+        _data = data;
 
-    if ([self.contentType hasPrefix:@"text/"]) {
-      NSString* charset = GCDWebServerExtractHeaderValueParameter(self.contentType, @"charset");
-      _string = [[NSString alloc] initWithData:_data encoding:GCDWebServerStringEncodingFromCharset(charset)];
+        if ([self.contentType hasPrefix:@"text/"]) {
+            NSString *charset = GCDWebServerExtractHeaderValueParameter(self.contentType, @"charset");
+            _string = [[NSString alloc] initWithData:_data encoding:GCDWebServerStringEncodingFromCharset(charset)];
+        }
     }
-  }
-  return self;
+
+    return self;
 }
 
-- (NSString*)description {
-  return [NSString stringWithFormat:@"<%@ | '%@' | %lu bytes>", [self class], self.mimeType, (unsigned long)_data.length];
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@ | '%@' | %lu bytes>", [self class], self.mimeType, (unsigned long)_data.length];
 }
 
 @end
 
 @implementation GCDWebServerMultiPartFile
 
-- (instancetype)initWithControlName:(NSString* _Nonnull)name contentType:(NSString* _Nonnull)type fileName:(NSString* _Nonnull)fileName temporaryPath:(NSString* _Nonnull)temporaryPath {
-  if ((self = [super initWithControlName:name contentType:type])) {
-    _fileName = [fileName copy];
-    _temporaryPath = [temporaryPath copy];
-  }
-  return self;
+- (instancetype)initWithControlName:(NSString * _Nonnull)name contentType:(NSString * _Nonnull)type fileName:(NSString * _Nonnull)fileName temporaryPath:(NSString * _Nonnull)temporaryPath {
+    if ((self = [super initWithControlName:name contentType:type])) {
+        _fileName = [fileName copy];
+        _temporaryPath = [temporaryPath copy];
+    }
+
+    return self;
 }
 
 - (void)dealloc {
-  unlink([_temporaryPath fileSystemRepresentation]);
+    unlink([_temporaryPath fileSystemRepresentation]);
 }
 
-- (NSString*)description {
-  return [NSString stringWithFormat:@"<%@ | '%@' | '%@>'", [self class], self.mimeType, _fileName];
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@ | '%@' | '%@>'", [self class], self.mimeType, _fileName];
 }
 
 @end
 
 @implementation GCDWebServerMIMEStreamParser {
-  NSData* _boundary;
-  NSString* _defaultcontrolName;
-  ParserState _state;
-  NSMutableData* _data;
-  NSMutableArray<GCDWebServerMultiPartArgument*>* _arguments;
-  NSMutableArray<GCDWebServerMultiPartFile*>* _files;
+    NSData *_boundary;
+    NSString *_defaultcontrolName;
+    ParserState _state;
+    NSMutableData *_data;
+    NSMutableArray<GCDWebServerMultiPartArgument *> *_arguments;
+    NSMutableArray<GCDWebServerMultiPartFile *> *_files;
 
-  NSString* _controlName;
-  NSString* _fileName;
-  NSString* _contentType;
-  NSString* _tmpPath;
-  int _tmpFile;
-  GCDWebServerMIMEStreamParser* _subParser;
+    NSString *_controlName;
+    NSString *_fileName;
+    NSString *_contentType;
+    NSString *_tmpPath;
+    int _tmpFile;
+    GCDWebServerMIMEStreamParser *_subParser;
 }
 
 + (void)initialize {
-  if (_newlineData == nil) {
-    _newlineData = [[NSData alloc] initWithBytes:"\r\n" length:2];
-    GWS_DCHECK(_newlineData);
-  }
-  if (_newlinesData == nil) {
-    _newlinesData = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
-    GWS_DCHECK(_newlinesData);
-  }
-  if (_dashNewlineData == nil) {
-    _dashNewlineData = [[NSData alloc] initWithBytes:"--\r\n" length:4];
-    GWS_DCHECK(_dashNewlineData);
-  }
+    if (_newlineData == nil) {
+        _newlineData = [[NSData alloc] initWithBytes:"\r\n" length:2];
+        GWS_DCHECK(_newlineData);
+    }
+
+    if (_newlinesData == nil) {
+        _newlinesData = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
+        GWS_DCHECK(_newlinesData);
+    }
+
+    if (_dashNewlineData == nil) {
+        _dashNewlineData = [[NSData alloc] initWithBytes:"--\r\n" length:4];
+        GWS_DCHECK(_dashNewlineData);
+    }
 }
 
-- (instancetype)initWithBoundary:(NSString* _Nonnull)boundary defaultControlName:(NSString* _Nullable)name arguments:(NSMutableArray<GCDWebServerMultiPartArgument*>* _Nonnull)arguments files:(NSMutableArray<GCDWebServerMultiPartFile*>* _Nonnull)files {
-  NSData* data = boundary.length ? [[NSString stringWithFormat:@"--%@", boundary] dataUsingEncoding:NSASCIIStringEncoding] : nil;
-  if (data == nil) {
-    GWS_DNOT_REACHED();
-    return nil;
-  }
-  if ((self = [super init])) {
-    _boundary = data;
-    _defaultcontrolName = name;
-    _arguments = arguments;
-    _files = files;
-    _data = [[NSMutableData alloc] initWithCapacity:kMultiPartBufferSize];
-    _state = kParserState_Start;
-  }
-  return self;
+- (instancetype)initWithBoundary:(NSString * _Nonnull)boundary defaultControlName:(NSString * _Nullable)name arguments:(NSMutableArray<GCDWebServerMultiPartArgument *> * _Nonnull)arguments files:(NSMutableArray<GCDWebServerMultiPartFile *> * _Nonnull)files {
+    NSData *data = boundary.length ? [[NSString stringWithFormat:@"--%@", boundary] dataUsingEncoding:NSASCIIStringEncoding] : nil;
+
+    if (data == nil) {
+        GWS_DNOT_REACHED();
+        return nil;
+    }
+
+    if ((self = [super init])) {
+        _boundary = data;
+        _defaultcontrolName = name;
+        _arguments = arguments;
+        _files = files;
+        _data = [[NSMutableData alloc] initWithCapacity:kMultiPartBufferSize];
+        _state = kParserState_Start;
+    }
+
+    return self;
 }
 
 - (void)dealloc {
-  if (_tmpFile > 0) {
-    close(_tmpFile);
-    unlink([_tmpPath fileSystemRepresentation]);
-  }
+    if (_tmpFile > 0) {
+        close(_tmpFile);
+        unlink([_tmpPath fileSystemRepresentation]);
+    }
 }
 
 // http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2
 - (BOOL)_parseData {
-  BOOL success = YES;
+    BOOL success = YES;
 
-  if (_state == kParserState_Headers) {
-    NSRange range = [_data rangeOfData:_newlinesData options:0 range:NSMakeRange(0, _data.length)];
-    if (range.location != NSNotFound) {
-      _controlName = nil;
-      _fileName = nil;
-      _contentType = nil;
-      _tmpPath = nil;
-      _subParser = nil;
-      NSString* headers = [[NSString alloc] initWithData:[_data subdataWithRange:NSMakeRange(0, range.location)] encoding:NSUTF8StringEncoding];
-      if (headers) {
-        for (NSString* header in [headers componentsSeparatedByString:@"\r\n"]) {
-          NSRange subRange = [header rangeOfString:@":"];
-          if (subRange.location != NSNotFound) {
-            NSString* name = [header substringToIndex:subRange.location];
-            NSString* value = [[header substringFromIndex:(subRange.location + subRange.length)] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-            if ([name caseInsensitiveCompare:@"Content-Type"] == NSOrderedSame) {
-              _contentType = GCDWebServerNormalizeHeaderValue(value);
-            } else if ([name caseInsensitiveCompare:@"Content-Disposition"] == NSOrderedSame) {
-              NSString* contentDisposition = GCDWebServerNormalizeHeaderValue(value);
-              if ([GCDWebServerTruncateHeaderValue(contentDisposition) isEqualToString:@"form-data"]) {
-                _controlName = GCDWebServerExtractHeaderValueParameter(contentDisposition, @"name");
-                _fileName = GCDWebServerExtractHeaderValueParameter(contentDisposition, @"filename");
-              } else if ([GCDWebServerTruncateHeaderValue(contentDisposition) isEqualToString:@"file"]) {
-                _controlName = _defaultcontrolName;
-                _fileName = GCDWebServerExtractHeaderValueParameter(contentDisposition, @"filename");
-              }
-            }
-          } else {
-            GWS_DNOT_REACHED();
-          }
-        }
-        if (_contentType == nil) {
-          _contentType = @"text/plain";
-        }
-      } else {
-        GWS_LOG_ERROR(@"Failed decoding headers in part of 'multipart/form-data'");
-        GWS_DNOT_REACHED();
-      }
-      if (_controlName) {
-        if ([GCDWebServerTruncateHeaderValue(_contentType) isEqualToString:@"multipart/mixed"]) {
-          NSString* boundary = GCDWebServerExtractHeaderValueParameter(_contentType, @"boundary");
-          _subParser = [[GCDWebServerMIMEStreamParser alloc] initWithBoundary:boundary defaultControlName:_controlName arguments:_arguments files:_files];
-          if (_subParser == nil) {
-            GWS_DNOT_REACHED();
-            success = NO;
-          }
-        } else if (_fileName) {
-          NSString* path = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
-          _tmpFile = open([path fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-          if (_tmpFile > 0) {
-            _tmpPath = [path copy];
-          } else {
-            GWS_DNOT_REACHED();
-            success = NO;
-          }
-        }
-      } else {
-        GWS_DNOT_REACHED();
-        success = NO;
-      }
+    if (_state == kParserState_Headers) {
+        NSRange range = [_data rangeOfData:_newlinesData options:0 range:NSMakeRange(0, _data.length)];
 
-      [_data replaceBytesInRange:NSMakeRange(0, range.location + range.length) withBytes:NULL length:0];
-      _state = kParserState_Content;
-    }
-  }
-
-  if ((_state == kParserState_Start) || (_state == kParserState_Content)) {
-    NSRange range = [_data rangeOfData:_boundary options:0 range:NSMakeRange(0, _data.length)];
-    if (range.location != NSNotFound) {
-      NSRange subRange = NSMakeRange(range.location + range.length, _data.length - range.location - range.length);
-      NSRange subRange1 = [_data rangeOfData:_newlineData options:NSDataSearchAnchored range:subRange];
-      NSRange subRange2 = [_data rangeOfData:_dashNewlineData options:NSDataSearchAnchored range:subRange];
-      if ((subRange1.location != NSNotFound) || (subRange2.location != NSNotFound)) {
-        if (_state == kParserState_Content) {
-          const void* dataBytes = _data.bytes;
-          NSUInteger dataLength = range.location - 2;
-          if (_subParser) {
-            if (![_subParser appendBytes:dataBytes length:(dataLength + 2)] || ![_subParser isAtEnd]) {
-              GWS_DNOT_REACHED();
-              success = NO;
-            }
+        if (range.location != NSNotFound) {
+            _controlName = nil;
+            _fileName = nil;
+            _contentType = nil;
+            _tmpPath = nil;
             _subParser = nil;
-          } else if (_tmpPath) {
-            ssize_t result = write(_tmpFile, dataBytes, dataLength);
-            if (result == (ssize_t)dataLength) {
-              if (close(_tmpFile) == 0) {
-                _tmpFile = 0;
-                GCDWebServerMultiPartFile* file = [[GCDWebServerMultiPartFile alloc] initWithControlName:_controlName contentType:_contentType fileName:_fileName temporaryPath:_tmpPath];
-                [_files addObject:file];
-              } else {
+            NSString *headers = [[NSString alloc] initWithData:[_data subdataWithRange:NSMakeRange(0, range.location)] encoding:NSUTF8StringEncoding];
+
+            if (headers) {
+                for (NSString *header in [headers componentsSeparatedByString:@"\r\n"]) {
+                    NSRange subRange = [header rangeOfString:@":"];
+
+                    if (subRange.location != NSNotFound) {
+                        NSString *name = [header substringToIndex:subRange.location];
+                        NSString *value = [[header substringFromIndex:(subRange.location + subRange.length)] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+                        if ([name caseInsensitiveCompare:@"Content-Type"] == NSOrderedSame) {
+                            _contentType = GCDWebServerNormalizeHeaderValue(value);
+                        } else if ([name caseInsensitiveCompare:@"Content-Disposition"] == NSOrderedSame) {
+                            NSString *contentDisposition = GCDWebServerNormalizeHeaderValue(value);
+
+                            if ([GCDWebServerTruncateHeaderValue(contentDisposition) isEqualToString:@"form-data"]) {
+                                _controlName = GCDWebServerExtractHeaderValueParameter(contentDisposition, @"name");
+                                _fileName = GCDWebServerExtractHeaderValueParameter(contentDisposition, @"filename");
+                            } else if ([GCDWebServerTruncateHeaderValue(contentDisposition) isEqualToString:@"file"]) {
+                                _controlName = _defaultcontrolName;
+                                _fileName = GCDWebServerExtractHeaderValueParameter(contentDisposition, @"filename");
+                            }
+                        }
+                    } else {
+                        GWS_DNOT_REACHED();
+                    }
+                }
+
+                if (_contentType == nil) {
+                    _contentType = @"text/plain";
+                }
+            } else {
+                GWS_LOG_ERROR(@"Failed decoding headers in part of 'multipart/form-data'");
+                GWS_DNOT_REACHED();
+            }
+
+            if (_controlName) {
+                if ([GCDWebServerTruncateHeaderValue(_contentType) isEqualToString:@"multipart/mixed"]) {
+                    NSString *boundary = GCDWebServerExtractHeaderValueParameter(_contentType, @"boundary");
+                    _subParser = [[GCDWebServerMIMEStreamParser alloc] initWithBoundary:boundary defaultControlName:_controlName arguments:_arguments files:_files];
+
+                    if (_subParser == nil) {
+                        GWS_DNOT_REACHED();
+                        success = NO;
+                    }
+                } else if (_fileName) {
+                    NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+                    _tmpFile = open([path fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+
+                    if (_tmpFile > 0) {
+                        _tmpPath = [path copy];
+                    } else {
+                        GWS_DNOT_REACHED();
+                        success = NO;
+                    }
+                }
+            } else {
                 GWS_DNOT_REACHED();
                 success = NO;
-              }
-            } else {
-              GWS_DNOT_REACHED();
-              success = NO;
             }
-            _tmpPath = nil;
-          } else {
-            NSData* data = [[NSData alloc] initWithBytes:(void*)dataBytes length:dataLength];
-            GCDWebServerMultiPartArgument* argument = [[GCDWebServerMultiPartArgument alloc] initWithControlName:_controlName contentType:_contentType data:data];
-            [_arguments addObject:argument];
-          }
-        }
 
-        if (subRange1.location != NSNotFound) {
-          [_data replaceBytesInRange:NSMakeRange(0, subRange1.location + subRange1.length) withBytes:NULL length:0];
-          _state = kParserState_Headers;
-          success = [self _parseData];
-        } else {
-          _state = kParserState_End;
+            [_data replaceBytesInRange:NSMakeRange(0, range.location + range.length) withBytes:NULL length:0];
+            _state = kParserState_Content;
         }
-      }
-    } else {
-      NSUInteger margin = 2 * _boundary.length;
-      if (_data.length > margin) {
-        NSUInteger length = _data.length - margin;
-        if (_subParser) {
-          if ([_subParser appendBytes:_data.bytes length:length]) {
-            [_data replaceBytesInRange:NSMakeRange(0, length) withBytes:NULL length:0];
-          } else {
-            GWS_DNOT_REACHED();
-            success = NO;
-          }
-        } else if (_tmpPath) {
-          ssize_t result = write(_tmpFile, _data.bytes, length);
-          if (result == (ssize_t)length) {
-            [_data replaceBytesInRange:NSMakeRange(0, length) withBytes:NULL length:0];
-          } else {
-            GWS_DNOT_REACHED();
-            success = NO;
-          }
-        }
-      }
     }
-  }
 
-  return success;
+    if ((_state == kParserState_Start) || (_state == kParserState_Content)) {
+        NSRange range = [_data rangeOfData:_boundary options:0 range:NSMakeRange(0, _data.length)];
+
+        if (range.location != NSNotFound) {
+            NSRange subRange = NSMakeRange(range.location + range.length, _data.length - range.location - range.length);
+            NSRange subRange1 = [_data rangeOfData:_newlineData options:NSDataSearchAnchored range:subRange];
+            NSRange subRange2 = [_data rangeOfData:_dashNewlineData options:NSDataSearchAnchored range:subRange];
+
+            if ((subRange1.location != NSNotFound) || (subRange2.location != NSNotFound)) {
+                if (_state == kParserState_Content) {
+                    const void *dataBytes = _data.bytes;
+                    NSUInteger dataLength = range.location - 2;
+
+                    if (_subParser) {
+                        if (![_subParser appendBytes:dataBytes length:(dataLength + 2)] || ![_subParser isAtEnd]) {
+                            GWS_DNOT_REACHED();
+                            success = NO;
+                        }
+
+                        _subParser = nil;
+                    } else if (_tmpPath) {
+                        ssize_t result = write(_tmpFile, dataBytes, dataLength);
+
+                        if (result == (ssize_t)dataLength) {
+                            if (close(_tmpFile) == 0) {
+                                _tmpFile = 0;
+                                GCDWebServerMultiPartFile *file = [[GCDWebServerMultiPartFile alloc] initWithControlName:_controlName contentType:_contentType fileName:_fileName temporaryPath:_tmpPath];
+                                [_files addObject:file];
+                            } else {
+                                GWS_DNOT_REACHED();
+                                success = NO;
+                            }
+                        } else {
+                            GWS_DNOT_REACHED();
+                            success = NO;
+                        }
+
+                        _tmpPath = nil;
+                    } else {
+                        NSData *data = [[NSData alloc] initWithBytes:(void *)dataBytes length:dataLength];
+                        GCDWebServerMultiPartArgument *argument = [[GCDWebServerMultiPartArgument alloc] initWithControlName:_controlName contentType:_contentType data:data];
+                        [_arguments addObject:argument];
+                    }
+                }
+
+                if (subRange1.location != NSNotFound) {
+                    [_data replaceBytesInRange:NSMakeRange(0, subRange1.location + subRange1.length) withBytes:NULL length:0];
+                    _state = kParserState_Headers;
+                    success = [self _parseData];
+                } else {
+                    _state = kParserState_End;
+                }
+            }
+        } else {
+            NSUInteger margin = 2 * _boundary.length;
+
+            if (_data.length > margin) {
+                NSUInteger length = _data.length - margin;
+
+                if (_subParser) {
+                    if ([_subParser appendBytes:_data.bytes length:length]) {
+                        [_data replaceBytesInRange:NSMakeRange(0, length) withBytes:NULL length:0];
+                    } else {
+                        GWS_DNOT_REACHED();
+                        success = NO;
+                    }
+                } else if (_tmpPath) {
+                    ssize_t result = write(_tmpFile, _data.bytes, length);
+
+                    if (result == (ssize_t)length) {
+                        [_data replaceBytesInRange:NSMakeRange(0, length) withBytes:NULL length:0];
+                    } else {
+                        GWS_DNOT_REACHED();
+                        success = NO;
+                    }
+                }
+            }
+        }
+    }
+
+    return success;
 }
 
-- (BOOL)appendBytes:(const void*)bytes length:(NSUInteger)length {
-  [_data appendBytes:bytes length:length];
-  return [self _parseData];
+- (BOOL)appendBytes:(const void *)bytes length:(NSUInteger)length {
+    [_data appendBytes:bytes length:length];
+    return [self _parseData];
 }
 
 - (BOOL)isAtEnd {
-  return (_state == kParserState_End);
+    return (_state == kParserState_End);
 }
 
 @end
 
 @interface GCDWebServerMultiPartFormRequest ()
-@property(nonatomic) NSMutableArray<GCDWebServerMultiPartArgument*>* arguments;
-@property(nonatomic) NSMutableArray<GCDWebServerMultiPartFile*>* files;
+@property (nonatomic) NSMutableArray<GCDWebServerMultiPartArgument *> *arguments;
+@property (nonatomic) NSMutableArray<GCDWebServerMultiPartFile *> *files;
 @end
 
 @implementation GCDWebServerMultiPartFormRequest {
-  GCDWebServerMIMEStreamParser* _parser;
+    GCDWebServerMIMEStreamParser *_parser;
 }
 
-+ (NSString*)mimeType {
-  return @"multipart/form-data";
++ (NSString *)mimeType {
+    return @"multipart/form-data";
 }
 
-- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary<NSString*, NSString*>*)headers path:(NSString*)path query:(NSDictionary<NSString*, NSString*>*)query {
-  if ((self = [super initWithMethod:method url:url headers:headers path:path query:query])) {
-    _arguments = [[NSMutableArray alloc] init];
-    _files = [[NSMutableArray alloc] init];
-  }
-  return self;
-}
-
-- (BOOL)open:(NSError**)error {
-  NSString* boundary = GCDWebServerExtractHeaderValueParameter(self.contentType, @"boundary");
-  _parser = [[GCDWebServerMIMEStreamParser alloc] initWithBoundary:boundary defaultControlName:nil arguments:_arguments files:_files];
-  if (_parser == nil) {
-    if (error) {
-      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Failed starting to parse multipart form data"}];
+- (instancetype)initWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary<NSString *, NSString *> *)headers path:(NSString *)path query:(NSDictionary<NSString *, NSString *> *)query {
+    if ((self = [super initWithMethod:method url:url headers:headers path:path query:query])) {
+        _arguments = [[NSMutableArray alloc] init];
+        _files = [[NSMutableArray alloc] init];
     }
-    return NO;
-  }
-  return YES;
+
+    return self;
 }
 
-- (BOOL)writeData:(NSData*)data error:(NSError**)error {
-  if (![_parser appendBytes:data.bytes length:data.length]) {
-    if (error) {
-      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Failed continuing to parse multipart form data"}];
+- (BOOL)open:(NSError **)error {
+    NSString *boundary = GCDWebServerExtractHeaderValueParameter(self.contentType, @"boundary");
+
+    _parser = [[GCDWebServerMIMEStreamParser alloc] initWithBoundary:boundary defaultControlName:nil arguments:_arguments files:_files];
+
+    if (_parser == nil) {
+        if (error) {
+            *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{ NSLocalizedDescriptionKey: @"Failed starting to parse multipart form data" }];
+        }
+
+        return NO;
     }
-    return NO;
-  }
-  return YES;
+
+    return YES;
 }
 
-- (BOOL)close:(NSError**)error {
-  BOOL atEnd = [_parser isAtEnd];
-  _parser = nil;
-  if (!atEnd) {
-    if (error) {
-      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Failed finishing to parse multipart form data"}];
+- (BOOL)writeData:(NSData *)data error:(NSError **)error {
+    if (![_parser appendBytes:data.bytes length:data.length]) {
+        if (error) {
+            *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{ NSLocalizedDescriptionKey: @"Failed continuing to parse multipart form data" }];
+        }
+
+        return NO;
     }
-    return NO;
-  }
-  return YES;
+
+    return YES;
 }
 
-- (GCDWebServerMultiPartArgument*)firstArgumentForControlName:(NSString*)name {
-  for (GCDWebServerMultiPartArgument* argument in _arguments) {
-    if ([argument.controlName isEqualToString:name]) {
-      return argument;
+- (BOOL)close:(NSError **)error {
+    BOOL atEnd = [_parser isAtEnd];
+
+    _parser = nil;
+
+    if (!atEnd) {
+        if (error) {
+            *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{ NSLocalizedDescriptionKey: @"Failed finishing to parse multipart form data" }];
+        }
+
+        return NO;
     }
-  }
-  return nil;
+
+    return YES;
 }
 
-- (GCDWebServerMultiPartFile*)firstFileForControlName:(NSString*)name {
-  for (GCDWebServerMultiPartFile* file in _files) {
-    if ([file.controlName isEqualToString:name]) {
-      return file;
+- (GCDWebServerMultiPartArgument *)firstArgumentForControlName:(NSString *)name {
+    for (GCDWebServerMultiPartArgument *argument in _arguments) {
+        if ([argument.controlName isEqualToString:name]) {
+            return argument;
+        }
     }
-  }
-  return nil;
+
+    return nil;
 }
 
-- (NSString*)description {
-  NSMutableString* description = [NSMutableString stringWithString:[super description]];
-  if (_arguments.count) {
-    [description appendString:@"\n"];
-    for (GCDWebServerMultiPartArgument* argument in _arguments) {
-      [description appendFormat:@"\n%@ (%@)\n", argument.controlName, argument.contentType];
-      [description appendString:GCDWebServerDescribeData(argument.data, argument.contentType)];
+- (GCDWebServerMultiPartFile *)firstFileForControlName:(NSString *)name {
+    for (GCDWebServerMultiPartFile *file in _files) {
+        if ([file.controlName isEqualToString:name]) {
+            return file;
+        }
     }
-  }
-  if (_files.count) {
-    [description appendString:@"\n"];
-    for (GCDWebServerMultiPartFile* file in _files) {
-      [description appendFormat:@"\n%@ (%@): %@\n{%@}", file.controlName, file.contentType, file.fileName, file.temporaryPath];
+
+    return nil;
+}
+
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithString:[super description]];
+
+    if (_arguments.count) {
+        [description appendString:@"\n"];
+
+        for (GCDWebServerMultiPartArgument *argument in _arguments) {
+            [description appendFormat:@"\n%@ (%@)\n", argument.controlName, argument.contentType];
+            [description appendString:GCDWebServerDescribeData(argument.data, argument.contentType)];
+        }
     }
-  }
-  return description;
+
+    if (_files.count) {
+        [description appendString:@"\n"];
+
+        for (GCDWebServerMultiPartFile *file in _files) {
+            [description appendFormat:@"\n%@ (%@): %@\n{%@}", file.controlName, file.contentType, file.fileName, file.temporaryPath];
+        }
+    }
+
+    return description;
 }
 
 @end

--- a/GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.h
+++ b/GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServerDataRequest.h"
@@ -42,13 +42,13 @@ NS_ASSUME_NONNULL_BEGIN
  *  The text encoding used to interpret the data is extracted from the
  *  "Content-Type" header or defaults to UTF-8.
  */
-@property(nonatomic, readonly) NSDictionary<NSString*, NSString*>* arguments;
+@property (nonatomic, readonly) NSDictionary<NSString *, NSString *> *arguments;
 
 /**
  *  Returns the MIME type for URL encoded forms
  *  i.e. "application/x-www-form-urlencoded".
  */
-+ (NSString*)mimeType;
++ (NSString *)mimeType;
 
 @end
 

--- a/GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -33,28 +33,31 @@
 
 @implementation GCDWebServerURLEncodedFormRequest
 
-+ (NSString*)mimeType {
-  return @"application/x-www-form-urlencoded";
++ (NSString *)mimeType {
+    return @"application/x-www-form-urlencoded";
 }
 
-- (BOOL)close:(NSError**)error {
-  if (![super close:error]) {
-    return NO;
-  }
+- (BOOL)close:(NSError **)error {
+    if (![super close:error]) {
+        return NO;
+    }
 
-  NSString* charset = GCDWebServerExtractHeaderValueParameter(self.contentType, @"charset");
-  NSString* string = [[NSString alloc] initWithData:self.data encoding:GCDWebServerStringEncodingFromCharset(charset)];
-  _arguments = GCDWebServerParseURLEncodedForm(string);
-  return YES;
+    NSString *charset = GCDWebServerExtractHeaderValueParameter(self.contentType, @"charset");
+    NSString *string = [[NSString alloc] initWithData:self.data encoding:GCDWebServerStringEncodingFromCharset(charset)];
+    _arguments = GCDWebServerParseURLEncodedForm(string);
+    return YES;
 }
 
-- (NSString*)description {
-  NSMutableString* description = [NSMutableString stringWithString:[super description]];
-  [description appendString:@"\n"];
-  for (NSString* argument in [[_arguments allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
-    [description appendFormat:@"\n%@ = %@", argument, [_arguments objectForKey:argument]];
-  }
-  return description;
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithString:[super description]];
+
+    [description appendString:@"\n"];
+
+    for (NSString *argument in [[_arguments allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+        [description appendFormat:@"\n%@ = %@", argument, [_arguments objectForKey:argument]];
+    }
+
+    return description;
 }
 
 @end

--- a/GCDWebServer/Responses/GCDWebServerDataResponse.h
+++ b/GCDWebServer/Responses/GCDWebServerDataResponse.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServerResponse.h"
@@ -34,17 +34,17 @@ NS_ASSUME_NONNULL_BEGIN
  *  of the HTTP response from memory.
  */
 @interface GCDWebServerDataResponse : GCDWebServerResponse
-@property(nonatomic, copy) NSString* contentType;  // Redeclare as non-null
+@property (nonatomic, copy) NSString *contentType;  // Redeclare as non-null
 
 /**
  *  Creates a response with data in memory and a given content type.
  */
-+ (instancetype)responseWithData:(NSData*)data contentType:(NSString*)type;
++ (instancetype)responseWithData:(NSData *)data contentType:(NSString *)type;
 
 /**
  *  This method is the designated initializer for the class.
  */
-- (instancetype)initWithData:(NSData*)data contentType:(NSString*)type;
+- (instancetype)initWithData:(NSData *)data contentType:(NSString *)type;
 
 @end
 
@@ -53,18 +53,18 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Creates a data response from text encoded using UTF-8.
  */
-+ (nullable instancetype)responseWithText:(NSString*)text;
++ (nullable instancetype)responseWithText:(NSString *)text;
 
 /**
  *  Creates a data response from HTML encoded using UTF-8.
  */
-+ (nullable instancetype)responseWithHTML:(NSString*)html;
++ (nullable instancetype)responseWithHTML:(NSString *)html;
 
 /**
  *  Creates a data response from an HTML template encoded using UTF-8.
  *  See -initWithHTMLTemplate:variables: for details.
  */
-+ (nullable instancetype)responseWithHTMLTemplate:(NSString*)path variables:(NSDictionary<NSString*, NSString*>*)variables;
++ (nullable instancetype)responseWithHTMLTemplate:(NSString *)path variables:(NSDictionary<NSString *, NSString *> *)variables;
 
 /**
  *  Creates a data response from a serialized JSON object and the default
@@ -76,17 +76,17 @@ NS_ASSUME_NONNULL_BEGIN
  *  Creates a data response from a serialized JSON object and a custom
  *  content type.
  */
-+ (nullable instancetype)responseWithJSONObject:(id)object contentType:(NSString*)type;
++ (nullable instancetype)responseWithJSONObject:(id)object contentType:(NSString *)type;
 
 /**
  *  Initializes a data response from text encoded using UTF-8.
  */
-- (nullable instancetype)initWithText:(NSString*)text;
+- (nullable instancetype)initWithText:(NSString *)text;
 
 /**
  *  Initializes a data response from HTML encoded using UTF-8.
  */
-- (nullable instancetype)initWithHTML:(NSString*)html;
+- (nullable instancetype)initWithHTML:(NSString *)html;
 
 /**
  *  Initializes a data response from an HTML template encoded using UTF-8.
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  All occurences of "%variable%" within the HTML template are replaced with
  *  their corresponding values.
  */
-- (nullable instancetype)initWithHTMLTemplate:(NSString*)path variables:(NSDictionary<NSString*, NSString*>*)variables;
+- (nullable instancetype)initWithHTMLTemplate:(NSString *)path variables:(NSDictionary<NSString *, NSString *> *)variables;
 
 /**
  *  Initializes a data response from a serialized JSON object and the default
@@ -106,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Initializes a data response from a serialized JSON object and a custom
  *  content type.
  */
-- (nullable instancetype)initWithJSONObject:(id)object contentType:(NSString*)type;
+- (nullable instancetype)initWithJSONObject:(id)object contentType:(NSString *)type;
 
 @end
 

--- a/GCDWebServer/Responses/GCDWebServerDataResponse.m
+++ b/GCDWebServer/Responses/GCDWebServerDataResponse.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -32,105 +32,116 @@
 #import "GCDWebServerPrivate.h"
 
 @implementation GCDWebServerDataResponse {
-  NSData* _data;
-  BOOL _done;
+    NSData *_data;
+    BOOL _done;
 }
 
 @dynamic contentType;
 
-+ (instancetype)responseWithData:(NSData*)data contentType:(NSString*)type {
-  return [(GCDWebServerDataResponse*)[[self class] alloc] initWithData:data contentType:type];
++ (instancetype)responseWithData:(NSData *)data contentType:(NSString *)type {
+    return [(GCDWebServerDataResponse *)[[self class] alloc] initWithData:data contentType:type];
 }
 
-- (instancetype)initWithData:(NSData*)data contentType:(NSString*)type {
-  if ((self = [super init])) {
-    _data = data;
+- (instancetype)initWithData:(NSData *)data contentType:(NSString *)type {
+    if ((self = [super init])) {
+        _data = data;
 
-    self.contentType = type;
-    self.contentLength = data.length;
-  }
-  return self;
+        self.contentType = type;
+        self.contentLength = data.length;
+    }
+
+    return self;
 }
 
-- (NSData*)readData:(NSError**)error {
-  NSData* data;
-  if (_done) {
-    data = [NSData data];
-  } else {
-    data = _data;
-    _done = YES;
-  }
-  return data;
+- (NSData *)readData:(NSError **)error {
+    NSData *data;
+
+    if (_done) {
+        data = [NSData data];
+    } else {
+        data = _data;
+        _done = YES;
+    }
+
+    return data;
 }
 
-- (NSString*)description {
-  NSMutableString* description = [NSMutableString stringWithString:[super description]];
-  [description appendString:@"\n\n"];
-  [description appendString:GCDWebServerDescribeData(_data, self.contentType)];
-  return description;
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithString:[super description]];
+
+    [description appendString:@"\n\n"];
+    [description appendString:GCDWebServerDescribeData(_data, self.contentType)];
+    return description;
 }
 
 @end
 
 @implementation GCDWebServerDataResponse (Extensions)
 
-+ (instancetype)responseWithText:(NSString*)text {
-  return [(GCDWebServerDataResponse*)[self alloc] initWithText:text];
++ (instancetype)responseWithText:(NSString *)text {
+    return [(GCDWebServerDataResponse *)[self alloc] initWithText:text];
 }
 
-+ (instancetype)responseWithHTML:(NSString*)html {
-  return [(GCDWebServerDataResponse*)[self alloc] initWithHTML:html];
++ (instancetype)responseWithHTML:(NSString *)html {
+    return [(GCDWebServerDataResponse *)[self alloc] initWithHTML:html];
 }
 
-+ (instancetype)responseWithHTMLTemplate:(NSString*)path variables:(NSDictionary<NSString*, NSString*>*)variables {
-  return [(GCDWebServerDataResponse*)[self alloc] initWithHTMLTemplate:path variables:variables];
++ (instancetype)responseWithHTMLTemplate:(NSString *)path variables:(NSDictionary<NSString *, NSString *> *)variables {
+    return [(GCDWebServerDataResponse *)[self alloc] initWithHTMLTemplate:path variables:variables];
 }
 
 + (instancetype)responseWithJSONObject:(id)object {
-  return [(GCDWebServerDataResponse*)[self alloc] initWithJSONObject:object];
+    return [(GCDWebServerDataResponse *)[self alloc] initWithJSONObject:object];
 }
 
-+ (instancetype)responseWithJSONObject:(id)object contentType:(NSString*)type {
-  return [(GCDWebServerDataResponse*)[self alloc] initWithJSONObject:object contentType:type];
++ (instancetype)responseWithJSONObject:(id)object contentType:(NSString *)type {
+    return [(GCDWebServerDataResponse *)[self alloc] initWithJSONObject:object contentType:type];
 }
 
-- (instancetype)initWithText:(NSString*)text {
-  NSData* data = [text dataUsingEncoding:NSUTF8StringEncoding];
-  if (data == nil) {
-    GWS_DNOT_REACHED();
-    return nil;
-  }
-  return [self initWithData:data contentType:@"text/plain; charset=utf-8"];
+- (instancetype)initWithText:(NSString *)text {
+    NSData *data = [text dataUsingEncoding:NSUTF8StringEncoding];
+
+    if (data == nil) {
+        GWS_DNOT_REACHED();
+        return nil;
+    }
+
+    return [self initWithData:data contentType:@"text/plain; charset=utf-8"];
 }
 
-- (instancetype)initWithHTML:(NSString*)html {
-  NSData* data = [html dataUsingEncoding:NSUTF8StringEncoding];
-  if (data == nil) {
-    GWS_DNOT_REACHED();
-    return nil;
-  }
-  return [self initWithData:data contentType:@"text/html; charset=utf-8"];
+- (instancetype)initWithHTML:(NSString *)html {
+    NSData *data = [html dataUsingEncoding:NSUTF8StringEncoding];
+
+    if (data == nil) {
+        GWS_DNOT_REACHED();
+        return nil;
+    }
+
+    return [self initWithData:data contentType:@"text/html; charset=utf-8"];
 }
 
-- (instancetype)initWithHTMLTemplate:(NSString*)path variables:(NSDictionary<NSString*, NSString*>*)variables {
-  NSMutableString* html = [[NSMutableString alloc] initWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
-  [variables enumerateKeysAndObjectsUsingBlock:^(NSString* key, NSString* value, BOOL* stop) {
-    [html replaceOccurrencesOfString:[NSString stringWithFormat:@"%%%@%%", key] withString:value options:0 range:NSMakeRange(0, html.length)];
-  }];
-  return [self initWithHTML:html];
+- (instancetype)initWithHTMLTemplate:(NSString *)path variables:(NSDictionary<NSString *, NSString *> *)variables {
+    NSMutableString *html = [[NSMutableString alloc] initWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
+
+    [variables enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
+                   [html replaceOccurrencesOfString:[NSString stringWithFormat:@"%%%@%%", key] withString:value options:0 range:NSMakeRange(0, html.length)];
+               }];
+    return [self initWithHTML:html];
 }
 
 - (instancetype)initWithJSONObject:(id)object {
-  return [self initWithJSONObject:object contentType:@"application/json"];
+    return [self initWithJSONObject:object contentType:@"application/json"];
 }
 
-- (instancetype)initWithJSONObject:(id)object contentType:(NSString*)type {
-  NSData* data = [NSJSONSerialization dataWithJSONObject:object options:0 error:NULL];
-  if (data == nil) {
-    GWS_DNOT_REACHED();
-    return nil;
-  }
-  return [self initWithData:data contentType:type];
+- (instancetype)initWithJSONObject:(id)object contentType:(NSString *)type {
+    NSData *data = [NSJSONSerialization dataWithJSONObject:object options:0 error:NULL];
+
+    if (data == nil) {
+        GWS_DNOT_REACHED();
+        return nil;
+    }
+
+    return [self initWithData:data contentType:type];
 }
 
 @end

--- a/GCDWebServer/Responses/GCDWebServerErrorResponse.h
+++ b/GCDWebServer/Responses/GCDWebServerErrorResponse.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServerDataResponse.h"
@@ -39,46 +39,46 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Creates a client error response with the corresponding HTTP status code.
  */
-+ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... NS_FORMAT_FUNCTION(2, 3);
++ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
 
 /**
  *  Creates a server error response with the corresponding HTTP status code.
  */
-+ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString*)format, ... NS_FORMAT_FUNCTION(2, 3);
++ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
 
 /**
  *  Creates a client error response with the corresponding HTTP status code
  *  and an underlying NSError.
  */
-+ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError*)underlyingError message:(NSString*)format, ... NS_FORMAT_FUNCTION(3, 4);
++ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError *)underlyingError message:(NSString *)format, ... NS_FORMAT_FUNCTION(3, 4);
 
 /**
  *  Creates a server error response with the corresponding HTTP status code
  *  and an underlying NSError.
  */
-+ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError*)underlyingError message:(NSString*)format, ... NS_FORMAT_FUNCTION(3, 4);
++ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError *)underlyingError message:(NSString *)format, ... NS_FORMAT_FUNCTION(3, 4);
 
 /**
  *  Initializes a client error response with the corresponding HTTP status code.
  */
-- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... NS_FORMAT_FUNCTION(2, 3);
+- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
 
 /**
  *  Initializes a server error response with the corresponding HTTP status code.
  */
-- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString*)format, ... NS_FORMAT_FUNCTION(2, 3);
+- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
 
 /**
  *  Initializes a client error response with the corresponding HTTP status code
  *  and an underlying NSError.
  */
-- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError*)underlyingError message:(NSString*)format, ... NS_FORMAT_FUNCTION(3, 4);
+- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError *)underlyingError message:(NSString *)format, ... NS_FORMAT_FUNCTION(3, 4);
 
 /**
  *  Initializes a server error response with the corresponding HTTP status code
  *  and an underlying NSError.
  */
-- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError*)underlyingError message:(NSString*)format, ... NS_FORMAT_FUNCTION(3, 4);
+- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError *)underlyingError message:(NSString *)format, ... NS_FORMAT_FUNCTION(3, 4);
 
 @end
 

--- a/GCDWebServer/Responses/GCDWebServerErrorResponse.m
+++ b/GCDWebServer/Responses/GCDWebServerErrorResponse.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -33,92 +33,94 @@
 
 @implementation GCDWebServerErrorResponse
 
-+ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... {
-  GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
-  va_list arguments;
-  va_start(arguments, format);
-  GCDWebServerErrorResponse* response = [(GCDWebServerErrorResponse*)[self alloc] initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
-  va_end(arguments);
-  return response;
++ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString *)format, ... {
+    GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
+    va_list arguments;
+    va_start(arguments, format);
+    GCDWebServerErrorResponse *response = [(GCDWebServerErrorResponse *)[self alloc] initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
+    va_end(arguments);
+    return response;
 }
 
-+ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString*)format, ... {
-  GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
-  va_list arguments;
-  va_start(arguments, format);
-  GCDWebServerErrorResponse* response = [(GCDWebServerErrorResponse*)[self alloc] initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
-  va_end(arguments);
-  return response;
++ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString *)format, ... {
+    GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
+    va_list arguments;
+    va_start(arguments, format);
+    GCDWebServerErrorResponse *response = [(GCDWebServerErrorResponse *)[self alloc] initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
+    va_end(arguments);
+    return response;
 }
 
-+ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(NSError*)underlyingError message:(NSString*)format, ... {
-  GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
-  va_list arguments;
-  va_start(arguments, format);
-  GCDWebServerErrorResponse* response = [(GCDWebServerErrorResponse*)[self alloc] initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
-  va_end(arguments);
-  return response;
++ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(NSError *)underlyingError message:(NSString *)format, ... {
+    GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
+    va_list arguments;
+    va_start(arguments, format);
+    GCDWebServerErrorResponse *response = [(GCDWebServerErrorResponse *)[self alloc] initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
+    va_end(arguments);
+    return response;
 }
 
-+ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(NSError*)underlyingError message:(NSString*)format, ... {
-  GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
-  va_list arguments;
-  va_start(arguments, format);
-  GCDWebServerErrorResponse* response = [(GCDWebServerErrorResponse*)[self alloc] initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
-  va_end(arguments);
-  return response;
++ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(NSError *)underlyingError message:(NSString *)format, ... {
+    GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
+    va_list arguments;
+    va_start(arguments, format);
+    GCDWebServerErrorResponse *response = [(GCDWebServerErrorResponse *)[self alloc] initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
+    va_end(arguments);
+    return response;
 }
 
-static inline NSString* _EscapeHTMLString(NSString* string) {
-  return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"&quot;"];
+static inline NSString * _EscapeHTMLString(NSString *string) {
+    return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"&quot;"];
 }
 
-- (instancetype)initWithStatusCode:(NSInteger)statusCode underlyingError:(NSError*)underlyingError messageFormat:(NSString*)format arguments:(va_list)arguments {
-  NSString* message = [[NSString alloc] initWithFormat:format arguments:arguments];
-  NSString* title = [NSString stringWithFormat:@"HTTP Error %i", (int)statusCode];
-  NSString* error = underlyingError ? [NSString stringWithFormat:@"[%@] %@ (%li)", underlyingError.domain, _EscapeHTMLString(underlyingError.localizedDescription), (long)underlyingError.code] : @"";
-  NSString* html = [NSString stringWithFormat:@"<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>%@</title></head><body><h1>%@: %@</h1><h3>%@</h3></body></html>",
-                                              title, title, _EscapeHTMLString(message), error];
-  if ((self = [self initWithHTML:html])) {
-    self.statusCode = statusCode;
-  }
-  return self;
+- (instancetype)initWithStatusCode:(NSInteger)statusCode underlyingError:(NSError *)underlyingError messageFormat:(NSString *)format arguments:(va_list)arguments {
+    NSString *message = [[NSString alloc] initWithFormat:format arguments:arguments];
+    NSString *title = [NSString stringWithFormat:@"HTTP Error %i", (int)statusCode];
+    NSString *error = underlyingError ? [NSString stringWithFormat:@"[%@] %@ (%li)", underlyingError.domain, _EscapeHTMLString(underlyingError.localizedDescription), (long)underlyingError.code] : @"";
+    NSString *html = [NSString stringWithFormat:@"<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>%@</title></head><body><h1>%@: %@</h1><h3>%@</h3></body></html>",
+                      title, title, _EscapeHTMLString(message), error];
+
+    if ((self = [self initWithHTML:html])) {
+        self.statusCode = statusCode;
+    }
+
+    return self;
 }
 
-- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... {
-  GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
-  va_list arguments;
-  va_start(arguments, format);
-  self = [self initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
-  va_end(arguments);
-  return self;
+- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString *)format, ... {
+    GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
+    va_list arguments;
+    va_start(arguments, format);
+    self = [self initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
+    va_end(arguments);
+    return self;
 }
 
-- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString*)format, ... {
-  GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
-  va_list arguments;
-  va_start(arguments, format);
-  self = [self initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
-  va_end(arguments);
-  return self;
+- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString *)format, ... {
+    GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
+    va_list arguments;
+    va_start(arguments, format);
+    self = [self initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
+    va_end(arguments);
+    return self;
 }
 
-- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(NSError*)underlyingError message:(NSString*)format, ... {
-  GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
-  va_list arguments;
-  va_start(arguments, format);
-  self = [self initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
-  va_end(arguments);
-  return self;
+- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(NSError *)underlyingError message:(NSString *)format, ... {
+    GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
+    va_list arguments;
+    va_start(arguments, format);
+    self = [self initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
+    va_end(arguments);
+    return self;
 }
 
-- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(NSError*)underlyingError message:(NSString*)format, ... {
-  GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
-  va_list arguments;
-  va_start(arguments, format);
-  self = [self initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
-  va_end(arguments);
-  return self;
+- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(NSError *)underlyingError message:(NSString *)format, ... {
+    GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
+    va_list arguments;
+    va_start(arguments, format);
+    self = [self initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
+    va_end(arguments);
+    return self;
 }
 
 @end

--- a/GCDWebServer/Responses/GCDWebServerFileResponse.h
+++ b/GCDWebServer/Responses/GCDWebServerFileResponse.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServerResponse.h"
@@ -38,20 +38,20 @@ NS_ASSUME_NONNULL_BEGIN
  *  metadata.
  */
 @interface GCDWebServerFileResponse : GCDWebServerResponse
-@property(nonatomic, copy) NSString* contentType;  // Redeclare as non-null
-@property(nonatomic) NSDate* lastModifiedDate;  // Redeclare as non-null
-@property(nonatomic, copy) NSString* eTag;  // Redeclare as non-null
+@property (nonatomic, copy) NSString *contentType;  // Redeclare as non-null
+@property (nonatomic) NSDate *lastModifiedDate;  // Redeclare as non-null
+@property (nonatomic, copy) NSString *eTag;  // Redeclare as non-null
 
 /**
  *  Creates a response with the contents of a file.
  */
-+ (nullable instancetype)responseWithFile:(NSString*)path;
++ (nullable instancetype)responseWithFile:(NSString *)path;
 
 /**
  *  Creates a response like +responseWithFile: and sets the "Content-Disposition"
  *  HTTP header for a download if the "attachment" argument is YES.
  */
-+ (nullable instancetype)responseWithFile:(NSString*)path isAttachment:(BOOL)attachment;
++ (nullable instancetype)responseWithFile:(NSString *)path isAttachment:(BOOL)attachment;
 
 /**
  *  Creates a response like +responseWithFile: but restricts the file contents
@@ -59,26 +59,26 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  See -initWithFile:byteRange: for details.
  */
-+ (nullable instancetype)responseWithFile:(NSString*)path byteRange:(NSRange)range;
++ (nullable instancetype)responseWithFile:(NSString *)path byteRange:(NSRange)range;
 
 /**
  *  Creates a response like +responseWithFile:byteRange: and sets the
  *  "Content-Disposition" HTTP header for a download if the "attachment"
  *  argument is YES.
  */
-+ (nullable instancetype)responseWithFile:(NSString*)path byteRange:(NSRange)range isAttachment:(BOOL)attachment;
++ (nullable instancetype)responseWithFile:(NSString *)path byteRange:(NSRange)range isAttachment:(BOOL)attachment;
 
 /**
  *  Initializes a response with the contents of a file.
  */
-- (nullable instancetype)initWithFile:(NSString*)path;
+- (nullable instancetype)initWithFile:(NSString *)path;
 
 /**
  *  Initializes a response like +responseWithFile: and sets the
  *  "Content-Disposition" HTTP header for a download if the "attachment"
  *  argument is YES.
  */
-- (nullable instancetype)initWithFile:(NSString*)path isAttachment:(BOOL)attachment;
+- (nullable instancetype)initWithFile:(NSString *)path isAttachment:(BOOL)attachment;
 
 /**
  *  Initializes a response like -initWithFile: but restricts the file contents
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  This argument would typically be set to the value of the byteRange property
  *  of the current GCDWebServerRequest.
  */
-- (nullable instancetype)initWithFile:(NSString*)path byteRange:(NSRange)range;
+- (nullable instancetype)initWithFile:(NSString *)path byteRange:(NSRange)range;
 
 /**
  *  This method is the designated initializer for the class.
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  file extensions without the period, and the values must be the corresponding
  *  MIME types.
  */
-- (nullable instancetype)initWithFile:(NSString*)path byteRange:(NSRange)range isAttachment:(BOOL)attachment mimeTypeOverrides:(nullable NSDictionary<NSString*, NSString*>*)overrides;
+- (nullable instancetype)initWithFile:(NSString *)path byteRange:(NSRange)range isAttachment:(BOOL)attachment mimeTypeOverrides:(nullable NSDictionary<NSString *, NSString *> *)overrides;
 
 @end
 

--- a/GCDWebServer/Responses/GCDWebServerFileResponse.m
+++ b/GCDWebServer/Responses/GCDWebServerFileResponse.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -36,150 +36,169 @@
 #define kFileReadBufferSize (32 * 1024)
 
 @implementation GCDWebServerFileResponse {
-  NSString* _path;
-  NSUInteger _offset;
-  NSUInteger _size;
-  int _file;
+    NSString *_path;
+    NSUInteger _offset;
+    NSUInteger _size;
+    int _file;
 }
 
 @dynamic contentType, lastModifiedDate, eTag;
 
-+ (instancetype)responseWithFile:(NSString*)path {
-  return [(GCDWebServerFileResponse*)[[self class] alloc] initWithFile:path];
++ (instancetype)responseWithFile:(NSString *)path {
+    return [(GCDWebServerFileResponse *)[[self class] alloc] initWithFile:path];
 }
 
-+ (instancetype)responseWithFile:(NSString*)path isAttachment:(BOOL)attachment {
-  return [(GCDWebServerFileResponse*)[[self class] alloc] initWithFile:path isAttachment:attachment];
++ (instancetype)responseWithFile:(NSString *)path isAttachment:(BOOL)attachment {
+    return [(GCDWebServerFileResponse *)[[self class] alloc] initWithFile:path isAttachment:attachment];
 }
 
-+ (instancetype)responseWithFile:(NSString*)path byteRange:(NSRange)range {
-  return [(GCDWebServerFileResponse*)[[self class] alloc] initWithFile:path byteRange:range];
++ (instancetype)responseWithFile:(NSString *)path byteRange:(NSRange)range {
+    return [(GCDWebServerFileResponse *)[[self class] alloc] initWithFile:path byteRange:range];
 }
 
-+ (instancetype)responseWithFile:(NSString*)path byteRange:(NSRange)range isAttachment:(BOOL)attachment {
-  return [(GCDWebServerFileResponse*)[[self class] alloc] initWithFile:path byteRange:range isAttachment:attachment mimeTypeOverrides:nil];
++ (instancetype)responseWithFile:(NSString *)path byteRange:(NSRange)range isAttachment:(BOOL)attachment {
+    return [(GCDWebServerFileResponse *)[[self class] alloc] initWithFile:path byteRange:range isAttachment:attachment mimeTypeOverrides:nil];
 }
 
-- (instancetype)initWithFile:(NSString*)path {
-  return [self initWithFile:path byteRange:NSMakeRange(NSUIntegerMax, 0) isAttachment:NO mimeTypeOverrides:nil];
+- (instancetype)initWithFile:(NSString *)path {
+    return [self initWithFile:path byteRange:NSMakeRange(NSUIntegerMax, 0) isAttachment:NO mimeTypeOverrides:nil];
 }
 
-- (instancetype)initWithFile:(NSString*)path isAttachment:(BOOL)attachment {
-  return [self initWithFile:path byteRange:NSMakeRange(NSUIntegerMax, 0) isAttachment:attachment mimeTypeOverrides:nil];
+- (instancetype)initWithFile:(NSString *)path isAttachment:(BOOL)attachment {
+    return [self initWithFile:path byteRange:NSMakeRange(NSUIntegerMax, 0) isAttachment:attachment mimeTypeOverrides:nil];
 }
 
-- (instancetype)initWithFile:(NSString*)path byteRange:(NSRange)range {
-  return [self initWithFile:path byteRange:range isAttachment:NO mimeTypeOverrides:nil];
+- (instancetype)initWithFile:(NSString *)path byteRange:(NSRange)range {
+    return [self initWithFile:path byteRange:range isAttachment:NO mimeTypeOverrides:nil];
 }
 
-static inline NSDate* _NSDateFromTimeSpec(const struct timespec* t) {
-  return [NSDate dateWithTimeIntervalSince1970:((NSTimeInterval)t->tv_sec + (NSTimeInterval)t->tv_nsec / 1000000000.0)];
+static inline NSDate * _NSDateFromTimeSpec(const struct timespec *t) {
+    return [NSDate dateWithTimeIntervalSince1970:((NSTimeInterval)t->tv_sec + (NSTimeInterval)t->tv_nsec / 1000000000.0)];
 }
 
-- (instancetype)initWithFile:(NSString*)path byteRange:(NSRange)range isAttachment:(BOOL)attachment mimeTypeOverrides:(NSDictionary<NSString*, NSString*>*)overrides {
-  struct stat info;
-  if (lstat([path fileSystemRepresentation], &info) || !(info.st_mode & S_IFREG)) {
-    GWS_DNOT_REACHED();
-    return nil;
-  }
-#ifndef __LP64__
-  if (info.st_size >= (off_t)4294967295) {  // In 32 bit mode, we can't handle files greater than 4 GiBs (don't use "NSUIntegerMax" here to avoid potential unsigned to signed conversion issues)
-    GWS_DNOT_REACHED();
-    return nil;
-  }
-#endif
-  NSUInteger fileSize = (NSUInteger)info.st_size;
+- (instancetype)initWithFile:(NSString *)path byteRange:(NSRange)range isAttachment:(BOOL)attachment mimeTypeOverrides:(NSDictionary<NSString *, NSString *> *)overrides {
+    struct stat info;
 
-  BOOL hasByteRange = GCDWebServerIsValidByteRange(range);
-  if (hasByteRange) {
-    if (range.location != NSUIntegerMax) {
-      range.location = MIN(range.location, fileSize);
-      range.length = MIN(range.length, fileSize - range.location);
-    } else {
-      range.length = MIN(range.length, fileSize);
-      range.location = fileSize - range.length;
-    }
-    if (range.length == 0) {
-      return nil;  // TODO: Return 416 status code and "Content-Range: bytes */{file length}" header
-    }
-  } else {
-    range.location = 0;
-    range.length = fileSize;
-  }
-
-  if ((self = [super init])) {
-    _path = [path copy];
-    _offset = range.location;
-    _size = range.length;
-    if (hasByteRange) {
-      [self setStatusCode:kGCDWebServerHTTPStatusCode_PartialContent];
-      [self setValue:[NSString stringWithFormat:@"bytes %lu-%lu/%lu", (unsigned long)_offset, (unsigned long)(_offset + _size - 1), (unsigned long)fileSize] forAdditionalHeader:@"Content-Range"];
-      GWS_LOG_DEBUG(@"Using content bytes range [%lu-%lu] for file \"%@\"", (unsigned long)_offset, (unsigned long)(_offset + _size - 1), path);
-    }
-
-    if (attachment) {
-      NSString* fileName = [path lastPathComponent];
-      NSData* data = [[fileName stringByReplacingOccurrencesOfString:@"\"" withString:@""] dataUsingEncoding:NSISOLatin1StringEncoding allowLossyConversion:YES];
-      NSString* lossyFileName = data ? [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding] : nil;
-      if (lossyFileName) {
-        NSString* value = [NSString stringWithFormat:@"attachment; filename=\"%@\"; filename*=UTF-8''%@", lossyFileName, GCDWebServerEscapeURLString(fileName)];
-        [self setValue:value forAdditionalHeader:@"Content-Disposition"];
-      } else {
+    if (lstat([path fileSystemRepresentation], &info) || !(info.st_mode & S_IFREG)) {
         GWS_DNOT_REACHED();
-      }
+        return nil;
     }
 
-    self.contentType = GCDWebServerGetMimeTypeForExtension([_path pathExtension], overrides);
-    self.contentLength = _size;
-    self.lastModifiedDate = _NSDateFromTimeSpec(&info.st_mtimespec);
-    self.eTag = [NSString stringWithFormat:@"%llu/%li/%li", info.st_ino, info.st_mtimespec.tv_sec, info.st_mtimespec.tv_nsec];
-  }
-  return self;
+#ifndef __LP64__
+
+    if (info.st_size >= (off_t)4294967295) { // In 32 bit mode, we can't handle files greater than 4 GiBs (don't use "NSUIntegerMax" here to avoid potential unsigned to signed conversion issues)
+        GWS_DNOT_REACHED();
+        return nil;
+    }
+
+#endif
+    NSUInteger fileSize = (NSUInteger)info.st_size;
+
+    BOOL hasByteRange = GCDWebServerIsValidByteRange(range);
+
+    if (hasByteRange) {
+        if (range.location != NSUIntegerMax) {
+            range.location = MIN(range.location, fileSize);
+            range.length = MIN(range.length, fileSize - range.location);
+        } else {
+            range.length = MIN(range.length, fileSize);
+            range.location = fileSize - range.length;
+        }
+
+        if (range.length == 0) {
+            return nil; // TODO: Return 416 status code and "Content-Range: bytes */{file length}" header
+        }
+    } else {
+        range.location = 0;
+        range.length = fileSize;
+    }
+
+    if ((self = [super init])) {
+        _path = [path copy];
+        _offset = range.location;
+        _size = range.length;
+
+        if (hasByteRange) {
+            [self setStatusCode:kGCDWebServerHTTPStatusCode_PartialContent];
+            [self setValue:[NSString stringWithFormat:@"bytes %lu-%lu/%lu", (unsigned long)_offset, (unsigned long)(_offset + _size - 1), (unsigned long)fileSize] forAdditionalHeader:@"Content-Range"];
+            GWS_LOG_DEBUG(@"Using content bytes range [%lu-%lu] for file \"%@\"", (unsigned long)_offset, (unsigned long)(_offset + _size - 1), path);
+        }
+
+        if (attachment) {
+            NSString *fileName = [path lastPathComponent];
+            NSData *data = [[fileName stringByReplacingOccurrencesOfString:@"\"" withString:@""] dataUsingEncoding:NSISOLatin1StringEncoding allowLossyConversion:YES];
+            NSString *lossyFileName = data ? [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding] : nil;
+
+            if (lossyFileName) {
+                NSString *value = [NSString stringWithFormat:@"attachment; filename=\"%@\"; filename*=UTF-8''%@", lossyFileName, GCDWebServerEscapeURLString(fileName)];
+                [self setValue:value forAdditionalHeader:@"Content-Disposition"];
+            } else {
+                GWS_DNOT_REACHED();
+            }
+        }
+
+        self.contentType = GCDWebServerGetMimeTypeForExtension([_path pathExtension], overrides);
+        self.contentLength = _size;
+        self.lastModifiedDate = _NSDateFromTimeSpec(&info.st_mtimespec);
+        self.eTag = [NSString stringWithFormat:@"%llu/%li/%li", info.st_ino, info.st_mtimespec.tv_sec, info.st_mtimespec.tv_nsec];
+    }
+
+    return self;
 }
 
-- (BOOL)open:(NSError**)error {
-  _file = open([_path fileSystemRepresentation], O_NOFOLLOW | O_RDONLY);
-  if (_file <= 0) {
-    if (error) {
-      *error = GCDWebServerMakePosixError(errno);
+- (BOOL)open:(NSError **)error {
+    _file = open([_path fileSystemRepresentation], O_NOFOLLOW | O_RDONLY);
+
+    if (_file <= 0) {
+        if (error) {
+            *error = GCDWebServerMakePosixError(errno);
+        }
+
+        return NO;
     }
-    return NO;
-  }
-  if (lseek(_file, _offset, SEEK_SET) != (off_t)_offset) {
-    if (error) {
-      *error = GCDWebServerMakePosixError(errno);
+
+    if (lseek(_file, _offset, SEEK_SET) != (off_t)_offset) {
+        if (error) {
+            *error = GCDWebServerMakePosixError(errno);
+        }
+
+        close(_file);
+        return NO;
     }
-    close(_file);
-    return NO;
-  }
-  return YES;
+
+    return YES;
 }
 
-- (NSData*)readData:(NSError**)error {
-  size_t length = MIN((NSUInteger)kFileReadBufferSize, _size);
-  NSMutableData* data = [[NSMutableData alloc] initWithLength:length];
-  ssize_t result = read(_file, data.mutableBytes, length);
-  if (result < 0) {
-    if (error) {
-      *error = GCDWebServerMakePosixError(errno);
+- (NSData *)readData:(NSError **)error {
+    size_t length = MIN((NSUInteger)kFileReadBufferSize, _size);
+    NSMutableData *data = [[NSMutableData alloc] initWithLength:length];
+    ssize_t result = read(_file, data.mutableBytes, length);
+
+    if (result < 0) {
+        if (error) {
+            *error = GCDWebServerMakePosixError(errno);
+        }
+
+        return nil;
     }
-    return nil;
-  }
-  if (result > 0) {
-    [data setLength:result];
-    _size -= result;
-  }
-  return data;
+
+    if (result > 0) {
+        [data setLength:result];
+        _size -= result;
+    }
+
+    return data;
 }
 
 - (void)close {
-  close(_file);
+    close(_file);
 }
 
-- (NSString*)description {
-  NSMutableString* description = [NSMutableString stringWithString:[super description]];
-  [description appendFormat:@"\n\n{%@}", _path];
-  return description;
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithString:[super description]];
+
+    [description appendFormat:@"\n\n{%@}", _path];
+    return description;
 }
 
 @end

--- a/GCDWebServer/Responses/GCDWebServerStreamedResponse.h
+++ b/GCDWebServer/Responses/GCDWebServerStreamedResponse.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServerResponse.h"
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  The block must return either a chunk of data, an empty NSData when done, or
  *  nil on error and set the "error" argument which is guaranteed to be non-NULL.
  */
-typedef NSData* _Nullable (^GCDWebServerStreamBlock)(NSError** error);
+typedef NSData * _Nullable (^GCDWebServerStreamBlock)(NSError **error);
 
 /**
  *  The GCDWebServerAsyncStreamBlock works like the GCDWebServerStreamBlock
@@ -53,27 +53,27 @@ typedef void (^GCDWebServerAsyncStreamBlock)(GCDWebServerBodyReaderCompletionBlo
  *  the body of the HTTP response using a GCD block.
  */
 @interface GCDWebServerStreamedResponse : GCDWebServerResponse
-@property(nonatomic, copy) NSString* contentType;  // Redeclare as non-null
+@property (nonatomic, copy) NSString *contentType;  // Redeclare as non-null
 
 /**
  *  Creates a response with streamed data and a given content type.
  */
-+ (instancetype)responseWithContentType:(NSString*)type streamBlock:(GCDWebServerStreamBlock)block;
++ (instancetype)responseWithContentType:(NSString *)type streamBlock:(GCDWebServerStreamBlock)block;
 
 /**
  *  Creates a response with async streamed data and a given content type.
  */
-+ (instancetype)responseWithContentType:(NSString*)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block;
++ (instancetype)responseWithContentType:(NSString *)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block;
 
 /**
  *  Initializes a response with streamed data and a given content type.
  */
-- (instancetype)initWithContentType:(NSString*)type streamBlock:(GCDWebServerStreamBlock)block;
+- (instancetype)initWithContentType:(NSString *)type streamBlock:(GCDWebServerStreamBlock)block;
 
 /**
  *  This method is the designated initializer for the class.
  */
-- (instancetype)initWithContentType:(NSString*)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block;
+- (instancetype)initWithContentType:(NSString *)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block;
 
 @end
 

--- a/GCDWebServer/Responses/GCDWebServerStreamedResponse.m
+++ b/GCDWebServer/Responses/GCDWebServerStreamedResponse.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -32,45 +32,47 @@
 #import "GCDWebServerPrivate.h"
 
 @implementation GCDWebServerStreamedResponse {
-  GCDWebServerAsyncStreamBlock _block;
+    GCDWebServerAsyncStreamBlock _block;
 }
 
 @dynamic contentType;
 
-+ (instancetype)responseWithContentType:(NSString*)type streamBlock:(GCDWebServerStreamBlock)block {
-  return [(GCDWebServerStreamedResponse*)[[self class] alloc] initWithContentType:type streamBlock:block];
++ (instancetype)responseWithContentType:(NSString *)type streamBlock:(GCDWebServerStreamBlock)block {
+    return [(GCDWebServerStreamedResponse *)[[self class] alloc] initWithContentType:type streamBlock:block];
 }
 
-+ (instancetype)responseWithContentType:(NSString*)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block {
-  return [(GCDWebServerStreamedResponse*)[[self class] alloc] initWithContentType:type asyncStreamBlock:block];
++ (instancetype)responseWithContentType:(NSString *)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block {
+    return [(GCDWebServerStreamedResponse *)[[self class] alloc] initWithContentType:type asyncStreamBlock:block];
 }
 
-- (instancetype)initWithContentType:(NSString*)type streamBlock:(GCDWebServerStreamBlock)block {
-  return [self initWithContentType:type
-                  asyncStreamBlock:^(GCDWebServerBodyReaderCompletionBlock completionBlock) {
-                    NSError* error = nil;
-                    NSData* data = block(&error);
-                    completionBlock(data, error);
-                  }];
+- (instancetype)initWithContentType:(NSString *)type streamBlock:(GCDWebServerStreamBlock)block {
+    return [self initWithContentType:type
+                    asyncStreamBlock:^(GCDWebServerBodyReaderCompletionBlock completionBlock) {
+                        NSError *error = nil;
+                        NSData *data = block(&error);
+                        completionBlock(data, error);
+                    }];
 }
 
-- (instancetype)initWithContentType:(NSString*)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block {
-  if ((self = [super init])) {
-    _block = [block copy];
+- (instancetype)initWithContentType:(NSString *)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block {
+    if ((self = [super init])) {
+        _block = [block copy];
 
-    self.contentType = type;
-  }
-  return self;
+        self.contentType = type;
+    }
+
+    return self;
 }
 
 - (void)asyncReadDataWithCompletion:(GCDWebServerBodyReaderCompletionBlock)block {
-  _block(block);
+    _block(block);
 }
 
-- (NSString*)description {
-  NSMutableString* description = [NSMutableString stringWithString:[super description]];
-  [description appendString:@"\n\n<STREAM>"];
-  return description;
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithString:[super description]];
+
+    [description appendString:@"\n\n<STREAM>"];
+    return description;
 }
 
 @end

--- a/GCDWebUploader/GCDWebUploader.h
+++ b/GCDWebUploader/GCDWebUploader.h
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import "GCDWebServer.h"
@@ -42,27 +42,27 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  This method is called whenever a file has been downloaded.
  */
-- (void)webUploader:(GCDWebUploader*)uploader didDownloadFileAtPath:(NSString*)path;
+- (void)webUploader:(GCDWebUploader *)uploader didDownloadFileAtPath:(NSString *)path;
 
 /**
  *  This method is called whenever a file has been uploaded.
  */
-- (void)webUploader:(GCDWebUploader*)uploader didUploadFileAtPath:(NSString*)path;
+- (void)webUploader:(GCDWebUploader *)uploader didUploadFileAtPath:(NSString *)path;
 
 /**
  *  This method is called whenever a file or directory has been moved.
  */
-- (void)webUploader:(GCDWebUploader*)uploader didMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+- (void)webUploader:(GCDWebUploader *)uploader didMoveItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath;
 
 /**
  *  This method is called whenever a file or directory has been deleted.
  */
-- (void)webUploader:(GCDWebUploader*)uploader didDeleteItemAtPath:(NSString*)path;
+- (void)webUploader:(GCDWebUploader *)uploader didDeleteItemAtPath:(NSString *)path;
 
 /**
  *  This method is called whenever a directory has been created.
  */
-- (void)webUploader:(GCDWebUploader*)uploader didCreateDirectoryAtPath:(NSString*)path;
+- (void)webUploader:(GCDWebUploader *)uploader didCreateDirectoryAtPath:(NSString *)path;
 
 @end
 
@@ -81,19 +81,19 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns the upload directory as specified when the uploader was initialized.
  */
-@property(nonatomic, readonly) NSString* uploadDirectory;
+@property (nonatomic, readonly) NSString *uploadDirectory;
 
 /**
  *  Sets the delegate for the uploader.
  */
-@property(nonatomic, weak, nullable) id<GCDWebUploaderDelegate> delegate;
+@property (nonatomic, weak, nullable) id<GCDWebUploaderDelegate> delegate;
 
 /**
  *  Sets which files are allowed to be operated on depending on their extension.
  *
  *  The default value is nil i.e. all file extensions are allowed.
  */
-@property(nonatomic, copy) NSArray<NSString*>* allowedFileExtensions;
+@property (nonatomic, copy) NSArray<NSString *> *allowedFileExtensions;
 
 /**
  *  Sets if files and directories whose name start with a period are allowed to
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The default value is NO.
  */
-@property(nonatomic) BOOL allowHiddenItems;
+@property (nonatomic) BOOL allowHiddenItems;
 
 /**
  *  Sets the title for the uploader web interface.
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning Any reserved HTML characters in the string value for this property
  *  must have been replaced by character entities e.g. "&" becomes "&amp;".
  */
-@property(nonatomic, copy) NSString* title;
+@property (nonatomic, copy) NSString *title;
 
 /**
  *  Sets the header for the uploader web interface.
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning Any reserved HTML characters in the string value for this property
  *  must have been replaced by character entities e.g. "&" becomes "&amp;".
  */
-@property(nonatomic, copy) NSString* header;
+@property (nonatomic, copy) NSString *header;
 
 /**
  *  Sets the prologue for the uploader web interface.
@@ -131,7 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning The string value for this property must be raw HTML
  *  e.g. "<p>Some text</p>"
  */
-@property(nonatomic, copy) NSString* prologue;
+@property (nonatomic, copy) NSString *prologue;
 
 /**
  *  Sets the epilogue for the uploader web interface.
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning The string value for this property must be raw HTML
  *  e.g. "<p>Some text</p>"
  */
-@property(nonatomic, copy) NSString* epilogue;
+@property (nonatomic, copy) NSString *epilogue;
 
 /**
  *  Sets the footer for the uploader web interface.
@@ -151,12 +151,12 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning Any reserved HTML characters in the string value for this property
  *  must have been replaced by character entities e.g. "&" becomes "&amp;".
  */
-@property(nonatomic, copy) NSString* footer;
+@property (nonatomic, copy) NSString *footer;
 
 /**
  *  This method is the designated initializer for the class.
  */
-- (instancetype)initWithUploadDirectory:(NSString*)path;
+- (instancetype)initWithUploadDirectory:(NSString *)path;
 
 @end
 
@@ -173,28 +173,28 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The default implementation returns YES.
  */
-- (BOOL)shouldUploadFileAtPath:(NSString*)path withTemporaryFile:(NSString*)tempPath;
+- (BOOL)shouldUploadFileAtPath:(NSString *)path withTemporaryFile:(NSString *)tempPath;
 
 /**
  *  This method is called to check if a file or directory is allowed to be moved.
  *
  *  The default implementation returns YES.
  */
-- (BOOL)shouldMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+- (BOOL)shouldMoveItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath;
 
 /**
  *  This method is called to check if a file or directory is allowed to be deleted.
  *
  *  The default implementation returns YES.
  */
-- (BOOL)shouldDeleteItemAtPath:(NSString*)path;
+- (BOOL)shouldDeleteItemAtPath:(NSString *)path;
 
 /**
  *  This method is called to check if a directory is allowed to be created.
  *
  *  The default implementation returns YES.
  */
-- (BOOL)shouldCreateDirectoryAtPath:(NSString*)path;
+- (BOOL)shouldCreateDirectoryAtPath:(NSString *)path;
 
 @end
 

--- a/GCDWebUploader/GCDWebUploader.m
+++ b/GCDWebUploader/GCDWebUploader.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #if !__has_feature(objc_arc)
@@ -50,12 +50,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface GCDWebUploader (Methods)
-- (nullable GCDWebServerResponse*)listDirectory:(GCDWebServerRequest*)request;
-- (nullable GCDWebServerResponse*)downloadFile:(GCDWebServerRequest*)request;
-- (nullable GCDWebServerResponse*)uploadFile:(GCDWebServerMultiPartFormRequest*)request;
-- (nullable GCDWebServerResponse*)moveItem:(GCDWebServerURLEncodedFormRequest*)request;
-- (nullable GCDWebServerResponse*)deleteItem:(GCDWebServerURLEncodedFormRequest*)request;
-- (nullable GCDWebServerResponse*)createDirectory:(GCDWebServerURLEncodedFormRequest*)request;
+- (nullable GCDWebServerResponse *)listDirectory:(GCDWebServerRequest *)request;
+- (nullable GCDWebServerResponse *)downloadFile:(GCDWebServerRequest *)request;
+- (nullable GCDWebServerResponse *)uploadFile:(GCDWebServerMultiPartFormRequest *)request;
+- (nullable GCDWebServerResponse *)moveItem:(GCDWebServerURLEncodedFormRequest *)request;
+- (nullable GCDWebServerResponse *)deleteItem:(GCDWebServerURLEncodedFormRequest *)request;
+- (nullable GCDWebServerResponse *)createDirectory:(GCDWebServerURLEncodedFormRequest *)request;
 @end
 
 NS_ASSUME_NONNULL_END
@@ -64,371 +64,422 @@ NS_ASSUME_NONNULL_END
 
 @dynamic delegate;
 
-- (instancetype)initWithUploadDirectory:(NSString*)path {
-  if ((self = [super init])) {
-    NSString* bundlePath = [[NSBundle bundleForClass:[GCDWebUploader class]] pathForResource:@"GCDWebUploader" ofType:@"bundle"];
-    if (bundlePath == nil) {
-      return nil;
+- (instancetype)initWithUploadDirectory:(NSString *)path {
+    if ((self = [super init])) {
+        NSString *bundlePath = [[NSBundle bundleForClass:[GCDWebUploader class]] pathForResource:@"GCDWebUploader" ofType:@"bundle"];
+
+        if (bundlePath == nil) {
+            return nil;
+        }
+
+        NSBundle *siteBundle = [NSBundle bundleWithPath:bundlePath];
+
+        if (siteBundle == nil) {
+            return nil;
+        }
+
+        _uploadDirectory = [path copy];
+        GCDWebUploader * __unsafe_unretained server = self;
+
+        // Resource files
+        [self addGETHandlerForBasePath:@"/" directoryPath:(NSString *)[siteBundle resourcePath] indexFilename:nil cacheAge:3600 allowRangeRequests:NO];
+
+        // Web page
+        [self addHandlerForMethod:@"GET"
+                             path:@"/"
+                     requestClass:[GCDWebServerRequest class]
+                     processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                         #if TARGET_OS_IPHONE
+                         NSString *device = [[UIDevice currentDevice] name];
+                         #else
+                         NSString *device = CFBridgingRelease(SCDynamicStoreCopyComputerName(NULL, NULL));
+                         #endif
+                         NSString *title = server.title;
+
+                         if (title == nil) {
+                             title = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+
+                             if (title == nil) {
+                                 title = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+                             }
+
+                         #if !TARGET_OS_IPHONE
+
+                             if (title == nil) {
+                                 title = [[NSProcessInfo processInfo] processName];
+                             }
+
+                         #endif
+                         }
+
+                         NSString *header = server.header;
+
+                         if (header == nil) {
+                             header = title;
+                         }
+
+                         NSString *prologue = server.prologue;
+
+                         if (prologue == nil) {
+                             prologue = [siteBundle localizedStringForKey:@"PROLOGUE" value:@"" table:nil];
+                         }
+
+                         NSString *epilogue = server.epilogue;
+
+                         if (epilogue == nil) {
+                             epilogue = [siteBundle localizedStringForKey:@"EPILOGUE" value:@"" table:nil];
+                         }
+
+                         NSString *footer = server.footer;
+
+                         if (footer == nil) {
+                             NSString *name = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+
+                             if (name == nil) {
+                                 name = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+                             }
+
+                             NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+                         #if !TARGET_OS_IPHONE
+
+                             if (!name && !version) {
+                                 name = @"OS X";
+                                 version = [[NSProcessInfo processInfo] operatingSystemVersionString];
+                             }
+
+                         #endif
+                             footer = [NSString stringWithFormat:[siteBundle localizedStringForKey:@"FOOTER_FORMAT" value:@"" table:nil], name, version];
+                         }
+
+                         return [GCDWebServerDataResponse responseWithHTMLTemplate:(NSString *)[siteBundle pathForResource:@"index" ofType:@"html"]
+                                                                         variables:@{
+                                     @"device": device,
+                                     @"title": title,
+                                     @"header": header,
+                                     @"prologue": prologue,
+                                     @"epilogue": epilogue,
+                                     @"footer": footer
+                                 }];
+                     }];
+
+        // File listing
+        [self addHandlerForMethod:@"GET"
+                             path:@"/list"
+                     requestClass:[GCDWebServerRequest class]
+                     processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                         return [server listDirectory:request];
+                     }];
+
+        // File download
+        [self addHandlerForMethod:@"GET"
+                             path:@"/download"
+                     requestClass:[GCDWebServerRequest class]
+                     processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                         return [server downloadFile:request];
+                     }];
+
+        // File upload
+        [self addHandlerForMethod:@"POST"
+                             path:@"/upload"
+                     requestClass:[GCDWebServerMultiPartFormRequest class]
+                     processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                         return [server uploadFile:(GCDWebServerMultiPartFormRequest *)request];
+                     }];
+
+        // File and folder moving
+        [self addHandlerForMethod:@"POST"
+                             path:@"/move"
+                     requestClass:[GCDWebServerURLEncodedFormRequest class]
+                     processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                         return [server moveItem:(GCDWebServerURLEncodedFormRequest *)request];
+                     }];
+
+        // File and folder deletion
+        [self addHandlerForMethod:@"POST"
+                             path:@"/delete"
+                     requestClass:[GCDWebServerURLEncodedFormRequest class]
+                     processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                         return [server deleteItem:(GCDWebServerURLEncodedFormRequest *)request];
+                     }];
+
+        // Directory creation
+        [self addHandlerForMethod:@"POST"
+                             path:@"/create"
+                     requestClass:[GCDWebServerURLEncodedFormRequest class]
+                     processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                         return [server createDirectory:(GCDWebServerURLEncodedFormRequest *)request];
+                     }];
     }
-    NSBundle* siteBundle = [NSBundle bundleWithPath:bundlePath];
-    if (siteBundle == nil) {
-      return nil;
-    }
-    _uploadDirectory = [path copy];
-    GCDWebUploader* __unsafe_unretained server = self;
 
-    // Resource files
-    [self addGETHandlerForBasePath:@"/" directoryPath:(NSString*)[siteBundle resourcePath] indexFilename:nil cacheAge:3600 allowRangeRequests:NO];
-
-    // Web page
-    [self addHandlerForMethod:@"GET"
-                         path:@"/"
-                 requestClass:[GCDWebServerRequest class]
-                 processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-
-#if TARGET_OS_IPHONE
-                   NSString* device = [[UIDevice currentDevice] name];
-#else
-          NSString* device = CFBridgingRelease(SCDynamicStoreCopyComputerName(NULL, NULL));
-#endif
-                   NSString* title = server.title;
-                   if (title == nil) {
-                     title = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-                     if (title == nil) {
-                       title = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
-                     }
-#if !TARGET_OS_IPHONE
-                     if (title == nil) {
-                       title = [[NSProcessInfo processInfo] processName];
-                     }
-#endif
-                   }
-                   NSString* header = server.header;
-                   if (header == nil) {
-                     header = title;
-                   }
-                   NSString* prologue = server.prologue;
-                   if (prologue == nil) {
-                     prologue = [siteBundle localizedStringForKey:@"PROLOGUE" value:@"" table:nil];
-                   }
-                   NSString* epilogue = server.epilogue;
-                   if (epilogue == nil) {
-                     epilogue = [siteBundle localizedStringForKey:@"EPILOGUE" value:@"" table:nil];
-                   }
-                   NSString* footer = server.footer;
-                   if (footer == nil) {
-                     NSString* name = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-                     if (name == nil) {
-                       name = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
-                     }
-                     NSString* version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-#if !TARGET_OS_IPHONE
-                     if (!name && !version) {
-                       name = @"OS X";
-                       version = [[NSProcessInfo processInfo] operatingSystemVersionString];
-                     }
-#endif
-                     footer = [NSString stringWithFormat:[siteBundle localizedStringForKey:@"FOOTER_FORMAT" value:@"" table:nil], name, version];
-                   }
-                   return [GCDWebServerDataResponse responseWithHTMLTemplate:(NSString*)[siteBundle pathForResource:@"index" ofType:@"html"]
-                                                                   variables:@{
-                                                                     @"device" : device,
-                                                                     @"title" : title,
-                                                                     @"header" : header,
-                                                                     @"prologue" : prologue,
-                                                                     @"epilogue" : epilogue,
-                                                                     @"footer" : footer
-                                                                   }];
-                 }];
-
-    // File listing
-    [self addHandlerForMethod:@"GET"
-                         path:@"/list"
-                 requestClass:[GCDWebServerRequest class]
-                 processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                   return [server listDirectory:request];
-                 }];
-
-    // File download
-    [self addHandlerForMethod:@"GET"
-                         path:@"/download"
-                 requestClass:[GCDWebServerRequest class]
-                 processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                   return [server downloadFile:request];
-                 }];
-
-    // File upload
-    [self addHandlerForMethod:@"POST"
-                         path:@"/upload"
-                 requestClass:[GCDWebServerMultiPartFormRequest class]
-                 processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                   return [server uploadFile:(GCDWebServerMultiPartFormRequest*)request];
-                 }];
-
-    // File and folder moving
-    [self addHandlerForMethod:@"POST"
-                         path:@"/move"
-                 requestClass:[GCDWebServerURLEncodedFormRequest class]
-                 processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                   return [server moveItem:(GCDWebServerURLEncodedFormRequest*)request];
-                 }];
-
-    // File and folder deletion
-    [self addHandlerForMethod:@"POST"
-                         path:@"/delete"
-                 requestClass:[GCDWebServerURLEncodedFormRequest class]
-                 processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                   return [server deleteItem:(GCDWebServerURLEncodedFormRequest*)request];
-                 }];
-
-    // Directory creation
-    [self addHandlerForMethod:@"POST"
-                         path:@"/create"
-                 requestClass:[GCDWebServerURLEncodedFormRequest class]
-                 processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                   return [server createDirectory:(GCDWebServerURLEncodedFormRequest*)request];
-                 }];
-  }
-  return self;
+    return self;
 }
 
 @end
 
 @implementation GCDWebUploader (Methods)
 
-- (BOOL)_checkFileExtension:(NSString*)fileName {
-  if (_allowedFileExtensions && ![_allowedFileExtensions containsObject:[[fileName pathExtension] lowercaseString]]) {
-    return NO;
-  }
-  return YES;
-}
-
-- (NSString*)_uniquePathForPath:(NSString*)path {
-  if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
-    NSString* directory = [path stringByDeletingLastPathComponent];
-    NSString* file = [path lastPathComponent];
-    NSString* base = [file stringByDeletingPathExtension];
-    NSString* extension = [file pathExtension];
-    int retries = 0;
-    do {
-      if (extension.length) {
-        path = [directory stringByAppendingPathComponent:(NSString*)[[base stringByAppendingFormat:@" (%i)", ++retries] stringByAppendingPathExtension:extension]];
-      } else {
-        path = [directory stringByAppendingPathComponent:[base stringByAppendingFormat:@" (%i)", ++retries]];
-      }
-    } while ([[NSFileManager defaultManager] fileExistsAtPath:path]);
-  }
-  return path;
-}
-
-- (GCDWebServerResponse*)listDirectory:(GCDWebServerRequest*)request {
-  NSString* relativePath = [[request query] objectForKey:@"path"];
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory = NO;
-  if (!absolutePath || ![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
-  }
-  if (!isDirectory) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"\"%@\" is not a directory", relativePath];
-  }
-
-  NSString* directoryName = [absolutePath lastPathComponent];
-  if (!_allowHiddenItems && [directoryName hasPrefix:@"."]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Listing directory name \"%@\" is not allowed", directoryName];
-  }
-
-  NSError* error = nil;
-  NSArray* contents = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:absolutePath error:&error] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
-  if (contents == nil) {
-    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed listing directory \"%@\"", relativePath];
-  }
-
-  NSMutableArray* array = [NSMutableArray array];
-  for (NSString* item in [contents sortedArrayUsingSelector:@selector(localizedStandardCompare:)]) {
-    if (_allowHiddenItems || ![item hasPrefix:@"."]) {
-      NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[absolutePath stringByAppendingPathComponent:item] error:NULL];
-      NSString* type = [attributes objectForKey:NSFileType];
-      if ([type isEqualToString:NSFileTypeRegular] && [self _checkFileExtension:item]) {
-        [array addObject:@{
-          @"path" : [relativePath stringByAppendingPathComponent:item],
-          @"name" : item,
-          @"size" : (NSNumber*)[attributes objectForKey:NSFileSize]
-        }];
-      } else if ([type isEqualToString:NSFileTypeDirectory]) {
-        [array addObject:@{
-          @"path" : [[relativePath stringByAppendingPathComponent:item] stringByAppendingString:@"/"],
-          @"name" : item
-        }];
-      }
+- (BOOL)_checkFileExtension:(NSString *)fileName {
+    if (_allowedFileExtensions && ![_allowedFileExtensions containsObject:[[fileName pathExtension] lowercaseString]]) {
+        return NO;
     }
-  }
-  return [GCDWebServerDataResponse responseWithJSONObject:array];
+
+    return YES;
 }
 
-- (GCDWebServerResponse*)downloadFile:(GCDWebServerRequest*)request {
-  NSString* relativePath = [[request query] objectForKey:@"path"];
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory = NO;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
-  }
-  if (isDirectory) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"\"%@\" is a directory", relativePath];
-  }
+- (NSString *)_uniquePathForPath:(NSString *)path {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+        NSString *directory = [path stringByDeletingLastPathComponent];
+        NSString *file = [path lastPathComponent];
+        NSString *base = [file stringByDeletingPathExtension];
+        NSString *extension = [file pathExtension];
+        int retries = 0;
+        do {
+            if (extension.length) {
+                path = [directory stringByAppendingPathComponent:(NSString *)[[base stringByAppendingFormat:@" (%i)", ++retries] stringByAppendingPathExtension:extension]];
+            } else {
+                path = [directory stringByAppendingPathComponent:[base stringByAppendingFormat:@" (%i)", ++retries]];
+            }
+        } while ([[NSFileManager defaultManager] fileExistsAtPath:path]);
+    }
 
-  NSString* fileName = [absolutePath lastPathComponent];
-  if (([fileName hasPrefix:@"."] && !_allowHiddenItems) || ![self _checkFileExtension:fileName]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Downlading file name \"%@\" is not allowed", fileName];
-  }
-
-  if ([self.delegate respondsToSelector:@selector(webUploader:didDownloadFileAtPath:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.delegate webUploader:self didDownloadFileAtPath:absolutePath];
-    });
-  }
-  return [GCDWebServerFileResponse responseWithFile:absolutePath isAttachment:YES];
+    return path;
 }
 
-- (GCDWebServerResponse*)uploadFile:(GCDWebServerMultiPartFormRequest*)request {
-  NSRange range = [[request.headers objectForKey:@"Accept"] rangeOfString:@"application/json" options:NSCaseInsensitiveSearch];
-  NSString* contentType = (range.location != NSNotFound ? @"application/json" : @"text/plain; charset=utf-8");  // Required when using iFrame transport (see https://github.com/blueimp/jQuery-File-Upload/wiki/Setup)
+- (GCDWebServerResponse *)listDirectory:(GCDWebServerRequest *)request {
+    NSString *relativePath = [[request query] objectForKey:@"path"];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory = NO;
 
-  GCDWebServerMultiPartFile* file = [request firstFileForControlName:@"files[]"];
-  if ((!_allowHiddenItems && [file.fileName hasPrefix:@"."]) || ![self _checkFileExtension:file.fileName]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploaded file name \"%@\" is not allowed", file.fileName];
-  }
-  NSString* relativePath = [[request firstArgumentForControlName:@"path"] string];
-  NSString* absolutePath = [self _uniquePathForPath:[[_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)] stringByAppendingPathComponent:file.fileName]];
+    if (!absolutePath || ![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+    }
 
-  if (![self shouldUploadFileAtPath:absolutePath withTemporaryFile:file.temporaryPath]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file \"%@\" to \"%@\" is not permitted", file.fileName, relativePath];
-  }
+    if (!isDirectory) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"\"%@\" is not a directory", relativePath];
+    }
 
-  NSError* error = nil;
-  if (![[NSFileManager defaultManager] moveItemAtPath:file.temporaryPath toPath:absolutePath error:&error]) {
-    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
-  }
+    NSString *directoryName = [absolutePath lastPathComponent];
 
-  if ([self.delegate respondsToSelector:@selector(webUploader:didUploadFileAtPath:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.delegate webUploader:self didUploadFileAtPath:absolutePath];
-    });
-  }
-  return [GCDWebServerDataResponse responseWithJSONObject:@{} contentType:contentType];
+    if (!_allowHiddenItems && [directoryName hasPrefix:@"."]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Listing directory name \"%@\" is not allowed", directoryName];
+    }
+
+    NSError *error = nil;
+    NSArray *contents = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:absolutePath error:&error] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
+
+    if (contents == nil) {
+        return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed listing directory \"%@\"", relativePath];
+    }
+
+    NSMutableArray *array = [NSMutableArray array];
+
+    for (NSString *item in [contents sortedArrayUsingSelector:@selector(localizedStandardCompare:)]) {
+        if (_allowHiddenItems || ![item hasPrefix:@"."]) {
+            NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[absolutePath stringByAppendingPathComponent:item] error:NULL];
+            NSString *type = [attributes objectForKey:NSFileType];
+
+            if ([type isEqualToString:NSFileTypeRegular] && [self _checkFileExtension:item]) {
+                [array addObject:@{
+                     @"path": [relativePath stringByAppendingPathComponent:item],
+                     @"name": item,
+                     @"size": (NSNumber *)[attributes objectForKey:NSFileSize]
+                 }];
+            } else if ([type isEqualToString:NSFileTypeDirectory]) {
+                [array addObject:@{
+                     @"path": [[relativePath stringByAppendingPathComponent:item] stringByAppendingString:@"/"],
+                     @"name": item
+                 }];
+            }
+        }
+    }
+
+    return [GCDWebServerDataResponse responseWithJSONObject:array];
 }
 
-- (GCDWebServerResponse*)moveItem:(GCDWebServerURLEncodedFormRequest*)request {
-  NSString* oldRelativePath = [request.arguments objectForKey:@"oldPath"];
-  NSString* oldAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(oldRelativePath)];
-  BOOL isDirectory = NO;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:oldAbsolutePath isDirectory:&isDirectory]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", oldRelativePath];
-  }
+- (GCDWebServerResponse *)downloadFile:(GCDWebServerRequest *)request {
+    NSString *relativePath = [[request query] objectForKey:@"path"];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory = NO;
 
-  NSString* oldItemName = [oldAbsolutePath lastPathComponent];
-  if ((!_allowHiddenItems && [oldItemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:oldItemName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Moving from item name \"%@\" is not allowed", oldItemName];
-  }
+    if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+    }
 
-  NSString* newRelativePath = [request.arguments objectForKey:@"newPath"];
-  NSString* newAbsolutePath = [self _uniquePathForPath:[_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(newRelativePath)]];
+    if (isDirectory) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"\"%@\" is a directory", relativePath];
+    }
 
-  NSString* newItemName = [newAbsolutePath lastPathComponent];
-  if ((!_allowHiddenItems && [newItemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:newItemName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Moving to item name \"%@\" is not allowed", newItemName];
-  }
+    NSString *fileName = [absolutePath lastPathComponent];
 
-  if (![self shouldMoveItemFromPath:oldAbsolutePath toPath:newAbsolutePath]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Moving \"%@\" to \"%@\" is not permitted", oldRelativePath, newRelativePath];
-  }
+    if (([fileName hasPrefix:@"."] && !_allowHiddenItems) || ![self _checkFileExtension:fileName]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Downlading file name \"%@\" is not allowed", fileName];
+    }
 
-  NSError* error = nil;
-  if (![[NSFileManager defaultManager] moveItemAtPath:oldAbsolutePath toPath:newAbsolutePath error:&error]) {
-    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving \"%@\" to \"%@\"", oldRelativePath, newRelativePath];
-  }
+    if ([self.delegate respondsToSelector:@selector(webUploader:didDownloadFileAtPath:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate webUploader:self didDownloadFileAtPath:absolutePath];
+        });
+    }
 
-  if ([self.delegate respondsToSelector:@selector(webUploader:didMoveItemFromPath:toPath:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.delegate webUploader:self didMoveItemFromPath:oldAbsolutePath toPath:newAbsolutePath];
-    });
-  }
-  return [GCDWebServerDataResponse responseWithJSONObject:@{}];
+    return [GCDWebServerFileResponse responseWithFile:absolutePath isAttachment:YES];
 }
 
-- (GCDWebServerResponse*)deleteItem:(GCDWebServerURLEncodedFormRequest*)request {
-  NSString* relativePath = [request.arguments objectForKey:@"path"];
-  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
-  BOOL isDirectory = NO;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
-  }
+- (GCDWebServerResponse *)uploadFile:(GCDWebServerMultiPartFormRequest *)request {
+    NSRange range = [[request.headers objectForKey:@"Accept"] rangeOfString:@"application/json" options:NSCaseInsensitiveSearch];
+    NSString *contentType = (range.location != NSNotFound ? @"application/json" : @"text/plain; charset=utf-8"); // Required when using iFrame transport (see https://github.com/blueimp/jQuery-File-Upload/wiki/Setup)
 
-  NSString* itemName = [absolutePath lastPathComponent];
-  if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting item name \"%@\" is not allowed", itemName];
-  }
+    GCDWebServerMultiPartFile *file = [request firstFileForControlName:@"files[]"];
 
-  if (![self shouldDeleteItemAtPath:absolutePath]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not permitted", relativePath];
-  }
+    if ((!_allowHiddenItems && [file.fileName hasPrefix:@"."]) || ![self _checkFileExtension:file.fileName]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploaded file name \"%@\" is not allowed", file.fileName];
+    }
 
-  NSError* error = nil;
-  if (![[NSFileManager defaultManager] removeItemAtPath:absolutePath error:&error]) {
-    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed deleting \"%@\"", relativePath];
-  }
+    NSString *relativePath = [[request firstArgumentForControlName:@"path"] string];
+    NSString *absolutePath = [self _uniquePathForPath:[[_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)] stringByAppendingPathComponent:file.fileName]];
 
-  if ([self.delegate respondsToSelector:@selector(webUploader:didDeleteItemAtPath:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.delegate webUploader:self didDeleteItemAtPath:absolutePath];
-    });
-  }
-  return [GCDWebServerDataResponse responseWithJSONObject:@{}];
+    if (![self shouldUploadFileAtPath:absolutePath withTemporaryFile:file.temporaryPath]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file \"%@\" to \"%@\" is not permitted", file.fileName, relativePath];
+    }
+
+    NSError *error = nil;
+
+    if (![[NSFileManager defaultManager] moveItemAtPath:file.temporaryPath toPath:absolutePath error:&error]) {
+        return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
+    }
+
+    if ([self.delegate respondsToSelector:@selector(webUploader:didUploadFileAtPath:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate webUploader:self didUploadFileAtPath:absolutePath];
+        });
+    }
+
+    return [GCDWebServerDataResponse responseWithJSONObject:@{} contentType:contentType];
 }
 
-- (GCDWebServerResponse*)createDirectory:(GCDWebServerURLEncodedFormRequest*)request {
-  NSString* relativePath = [request.arguments objectForKey:@"path"];
-  NSString* absolutePath = [self _uniquePathForPath:[_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)]];
+- (GCDWebServerResponse *)moveItem:(GCDWebServerURLEncodedFormRequest *)request {
+    NSString *oldRelativePath = [request.arguments objectForKey:@"oldPath"];
+    NSString *oldAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(oldRelativePath)];
+    BOOL isDirectory = NO;
 
-  NSString* directoryName = [absolutePath lastPathComponent];
-  if (!_allowHiddenItems && [directoryName hasPrefix:@"."]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory name \"%@\" is not allowed", directoryName];
-  }
+    if (![[NSFileManager defaultManager] fileExistsAtPath:oldAbsolutePath isDirectory:&isDirectory]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", oldRelativePath];
+    }
 
-  if (![self shouldCreateDirectoryAtPath:absolutePath]) {
-    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory \"%@\" is not permitted", relativePath];
-  }
+    NSString *oldItemName = [oldAbsolutePath lastPathComponent];
 
-  NSError* error = nil;
-  if (![[NSFileManager defaultManager] createDirectoryAtPath:absolutePath withIntermediateDirectories:NO attributes:nil error:&error]) {
-    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed creating directory \"%@\"", relativePath];
-  }
+    if ((!_allowHiddenItems && [oldItemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:oldItemName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Moving from item name \"%@\" is not allowed", oldItemName];
+    }
 
-  if ([self.delegate respondsToSelector:@selector(webUploader:didCreateDirectoryAtPath:)]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.delegate webUploader:self didCreateDirectoryAtPath:absolutePath];
-    });
-  }
-  return [GCDWebServerDataResponse responseWithJSONObject:@{}];
+    NSString *newRelativePath = [request.arguments objectForKey:@"newPath"];
+    NSString *newAbsolutePath = [self _uniquePathForPath:[_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(newRelativePath)]];
+
+    NSString *newItemName = [newAbsolutePath lastPathComponent];
+
+    if ((!_allowHiddenItems && [newItemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:newItemName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Moving to item name \"%@\" is not allowed", newItemName];
+    }
+
+    if (![self shouldMoveItemFromPath:oldAbsolutePath toPath:newAbsolutePath]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Moving \"%@\" to \"%@\" is not permitted", oldRelativePath, newRelativePath];
+    }
+
+    NSError *error = nil;
+
+    if (![[NSFileManager defaultManager] moveItemAtPath:oldAbsolutePath toPath:newAbsolutePath error:&error]) {
+        return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving \"%@\" to \"%@\"", oldRelativePath, newRelativePath];
+    }
+
+    if ([self.delegate respondsToSelector:@selector(webUploader:didMoveItemFromPath:toPath:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate webUploader:self didMoveItemFromPath:oldAbsolutePath toPath:newAbsolutePath];
+        });
+    }
+
+    return [GCDWebServerDataResponse responseWithJSONObject:@{}];
+}
+
+- (GCDWebServerResponse *)deleteItem:(GCDWebServerURLEncodedFormRequest *)request {
+    NSString *relativePath = [request.arguments objectForKey:@"path"];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+    BOOL isDirectory = NO;
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+    }
+
+    NSString *itemName = [absolutePath lastPathComponent];
+
+    if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting item name \"%@\" is not allowed", itemName];
+    }
+
+    if (![self shouldDeleteItemAtPath:absolutePath]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not permitted", relativePath];
+    }
+
+    NSError *error = nil;
+
+    if (![[NSFileManager defaultManager] removeItemAtPath:absolutePath error:&error]) {
+        return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed deleting \"%@\"", relativePath];
+    }
+
+    if ([self.delegate respondsToSelector:@selector(webUploader:didDeleteItemAtPath:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate webUploader:self didDeleteItemAtPath:absolutePath];
+        });
+    }
+
+    return [GCDWebServerDataResponse responseWithJSONObject:@{}];
+}
+
+- (GCDWebServerResponse *)createDirectory:(GCDWebServerURLEncodedFormRequest *)request {
+    NSString *relativePath = [request.arguments objectForKey:@"path"];
+    NSString *absolutePath = [self _uniquePathForPath:[_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)]];
+
+    NSString *directoryName = [absolutePath lastPathComponent];
+
+    if (!_allowHiddenItems && [directoryName hasPrefix:@"."]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory name \"%@\" is not allowed", directoryName];
+    }
+
+    if (![self shouldCreateDirectoryAtPath:absolutePath]) {
+        return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory \"%@\" is not permitted", relativePath];
+    }
+
+    NSError *error = nil;
+
+    if (![[NSFileManager defaultManager] createDirectoryAtPath:absolutePath withIntermediateDirectories:NO attributes:nil error:&error]) {
+        return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed creating directory \"%@\"", relativePath];
+    }
+
+    if ([self.delegate respondsToSelector:@selector(webUploader:didCreateDirectoryAtPath:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate webUploader:self didCreateDirectoryAtPath:absolutePath];
+        });
+    }
+
+    return [GCDWebServerDataResponse responseWithJSONObject:@{}];
 }
 
 @end
 
 @implementation GCDWebUploader (Subclassing)
 
-- (BOOL)shouldUploadFileAtPath:(NSString*)path withTemporaryFile:(NSString*)tempPath {
-  return YES;
+- (BOOL)shouldUploadFileAtPath:(NSString *)path withTemporaryFile:(NSString *)tempPath {
+    return YES;
 }
 
-- (BOOL)shouldMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath {
-  return YES;
+- (BOOL)shouldMoveItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath {
+    return YES;
 }
 
-- (BOOL)shouldDeleteItemAtPath:(NSString*)path {
-  return YES;
+- (BOOL)shouldDeleteItemAtPath:(NSString *)path {
+    return YES;
 }
 
-- (BOOL)shouldCreateDirectoryAtPath:(NSString*)path {
-  return YES;
+- (BOOL)shouldCreateDirectoryAtPath:(NSString *)path {
+    return YES;
 }
 
 @end

--- a/Mac/main.m
+++ b/Mac/main.m
@@ -1,28 +1,28 @@
 /*
- Copyright (c) 2012-2019, Pierre-Olivier Latour
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+   Copyright (c) 2012-2019, Pierre-Olivier Latour
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+   notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
  * The name of Pierre-Olivier Latour may not be used to endorse
- or promote products derived from this software without specific
- prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   or promote products derived from this software without specific
+   prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #import <libgen.h>
@@ -45,14 +45,14 @@
 #endif
 
 typedef enum {
-  kMode_WebServer = 0,
-  kMode_HTMLPage,
-  kMode_HTMLForm,
-  kMode_HTMLFileUpload,
-  kMode_WebDAV,
-  kMode_WebUploader,
-  kMode_StreamingResponse,
-  kMode_AsyncResponse
+    kMode_WebServer = 0,
+    kMode_HTMLPage,
+    kMode_HTMLForm,
+    kMode_HTMLFileUpload,
+    kMode_WebDAV,
+    kMode_WebUploader,
+    kMode_StreamingResponse,
+    kMode_AsyncResponse
 } Mode;
 
 @interface Delegate : NSObject <GCDWebServerDelegate, GCDWebDAVServerDelegate, GCDWebUploaderDelegate>
@@ -61,178 +61,181 @@ typedef enum {
 @implementation Delegate
 
 - (void)_logDelegateCall:(SEL)selector {
-  fprintf(stdout, "<DELEGATE METHOD \"%s\" CALLED>\n", [NSStringFromSelector(selector) UTF8String]);
+    fprintf(stdout, "<DELEGATE METHOD \"%s\" CALLED>\n", [NSStringFromSelector(selector) UTF8String]);
 }
 
-- (void)webServerDidStart:(GCDWebServer*)server {
-  [self _logDelegateCall:_cmd];
+- (void)webServerDidStart:(GCDWebServer *)server {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webServerDidCompleteBonjourRegistration:(GCDWebServer*)server {
-  [self _logDelegateCall:_cmd];
+- (void)webServerDidCompleteBonjourRegistration:(GCDWebServer *)server {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webServerDidUpdateNATPortMapping:(GCDWebServer*)server {
-  [self _logDelegateCall:_cmd];
+- (void)webServerDidUpdateNATPortMapping:(GCDWebServer *)server {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webServerDidConnect:(GCDWebServer*)server {
-  [self _logDelegateCall:_cmd];
+- (void)webServerDidConnect:(GCDWebServer *)server {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webServerDidDisconnect:(GCDWebServer*)server {
-  [self _logDelegateCall:_cmd];
+- (void)webServerDidDisconnect:(GCDWebServer *)server {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webServerDidStop:(GCDWebServer*)server {
-  [self _logDelegateCall:_cmd];
+- (void)webServerDidStop:(GCDWebServer *)server {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)davServer:(GCDWebDAVServer*)server didDownloadFileAtPath:(NSString*)path {
-  [self _logDelegateCall:_cmd];
+- (void)davServer:(GCDWebDAVServer *)server didDownloadFileAtPath:(NSString *)path {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)davServer:(GCDWebDAVServer*)server didUploadFileAtPath:(NSString*)path {
-  [self _logDelegateCall:_cmd];
+- (void)davServer:(GCDWebDAVServer *)server didUploadFileAtPath:(NSString *)path {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)davServer:(GCDWebDAVServer*)server didMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath {
-  [self _logDelegateCall:_cmd];
+- (void)davServer:(GCDWebDAVServer *)server didMoveItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)davServer:(GCDWebDAVServer*)server didCopyItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath {
-  [self _logDelegateCall:_cmd];
+- (void)davServer:(GCDWebDAVServer *)server didCopyItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)davServer:(GCDWebDAVServer*)server didDeleteItemAtPath:(NSString*)path {
-  [self _logDelegateCall:_cmd];
+- (void)davServer:(GCDWebDAVServer *)server didDeleteItemAtPath:(NSString *)path {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)davServer:(GCDWebDAVServer*)server didCreateDirectoryAtPath:(NSString*)path {
-  [self _logDelegateCall:_cmd];
+- (void)davServer:(GCDWebDAVServer *)server didCreateDirectoryAtPath:(NSString *)path {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webUploader:(GCDWebUploader*)uploader didDownloadFileAtPath:(NSString*)path {
-  [self _logDelegateCall:_cmd];
+- (void)webUploader:(GCDWebUploader *)uploader didDownloadFileAtPath:(NSString *)path {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webUploader:(GCDWebUploader*)uploader didUploadFileAtPath:(NSString*)path {
-  [self _logDelegateCall:_cmd];
+- (void)webUploader:(GCDWebUploader *)uploader didUploadFileAtPath:(NSString *)path {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webUploader:(GCDWebUploader*)uploader didMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath {
-  [self _logDelegateCall:_cmd];
+- (void)webUploader:(GCDWebUploader *)uploader didMoveItemFromPath:(NSString *)fromPath toPath:(NSString *)toPath {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webUploader:(GCDWebUploader*)uploader didDeleteItemAtPath:(NSString*)path {
-  [self _logDelegateCall:_cmd];
+- (void)webUploader:(GCDWebUploader *)uploader didDeleteItemAtPath:(NSString *)path {
+    [self _logDelegateCall:_cmd];
 }
 
-- (void)webUploader:(GCDWebUploader*)uploader didCreateDirectoryAtPath:(NSString*)path {
-  [self _logDelegateCall:_cmd];
+- (void)webUploader:(GCDWebUploader *)uploader didCreateDirectoryAtPath:(NSString *)path {
+    [self _logDelegateCall:_cmd];
 }
 
 @end
 
-int main(int argc, const char* argv[]) {
-  int result = -1;
-  @autoreleasepool {
-    Mode mode = kMode_WebServer;
-    BOOL recording = NO;
-    NSString* rootDirectory = NSHomeDirectory();
-    NSString* testDirectory = nil;
-    NSString* authenticationMethod = nil;
-    NSString* authenticationRealm = nil;
-    NSString* authenticationUser = nil;
-    NSString* authenticationPassword = nil;
-    BOOL bindToLocalhost = NO;
-    BOOL requestNATPortMapping = NO;
+int main(int argc, const char *argv[]) {
+    int result = -1;
 
-    if (argc == 1) {
-      fprintf(stdout, "Usage: %s [-mode webServer | htmlPage | htmlForm | htmlFileUpload | webDAV | webUploader | streamingResponse | asyncResponse] [-record] [-root directory] [-tests directory] [-authenticationMethod Basic | Digest] [-authenticationRealm realm] [-authenticationUser user] [-authenticationPassword password] [--localhost]\n\n", basename((char*)argv[0]));
-    } else {
-      for (int i = 1; i < argc; ++i) {
-        if (argv[i][0] != '-') {
-          continue;
+    @autoreleasepool {
+        Mode mode = kMode_WebServer;
+        BOOL recording = NO;
+        NSString *rootDirectory = NSHomeDirectory();
+        NSString *testDirectory = nil;
+        NSString *authenticationMethod = nil;
+        NSString *authenticationRealm = nil;
+        NSString *authenticationUser = nil;
+        NSString *authenticationPassword = nil;
+        BOOL bindToLocalhost = NO;
+        BOOL requestNATPortMapping = NO;
+
+        if (argc == 1) {
+            fprintf(stdout, "Usage: %s [-mode webServer | htmlPage | htmlForm | htmlFileUpload | webDAV | webUploader | streamingResponse | asyncResponse] [-record] [-root directory] [-tests directory] [-authenticationMethod Basic | Digest] [-authenticationRealm realm] [-authenticationUser user] [-authenticationPassword password] [--localhost]\n\n", basename((char *)argv[0]));
+        } else {
+            for (int i = 1; i < argc; ++i) {
+                if (argv[i][0] != '-') {
+                    continue;
+                }
+
+                if (!strcmp(argv[i], "-mode") && (i + 1 < argc)) {
+                    ++i;
+
+                    if (!strcmp(argv[i], "webServer")) {
+                        mode = kMode_WebServer;
+                    } else if (!strcmp(argv[i], "htmlPage")) {
+                        mode = kMode_HTMLPage;
+                    } else if (!strcmp(argv[i], "htmlForm")) {
+                        mode = kMode_HTMLForm;
+                    } else if (!strcmp(argv[i], "htmlFileUpload")) {
+                        mode = kMode_HTMLFileUpload;
+                    } else if (!strcmp(argv[i], "webDAV")) {
+                        mode = kMode_WebDAV;
+                    } else if (!strcmp(argv[i], "webUploader")) {
+                        mode = kMode_WebUploader;
+                    } else if (!strcmp(argv[i], "streamingResponse")) {
+                        mode = kMode_StreamingResponse;
+                    } else if (!strcmp(argv[i], "asyncResponse")) {
+                        mode = kMode_AsyncResponse;
+                    }
+                } else if (!strcmp(argv[i], "-record")) {
+                    recording = YES;
+                } else if (!strcmp(argv[i], "-root") && (i + 1 < argc)) {
+                    ++i;
+                    rootDirectory = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:argv[i] length:strlen(argv[i])];
+                } else if (!strcmp(argv[i], "-tests") && (i + 1 < argc)) {
+                    ++i;
+                    testDirectory = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:argv[i] length:strlen(argv[i])];
+                } else if (!strcmp(argv[i], "-authenticationMethod") && (i + 1 < argc)) {
+                    ++i;
+                    authenticationMethod = [NSString stringWithUTF8String:argv[i]];
+                } else if (!strcmp(argv[i], "-authenticationRealm") && (i + 1 < argc)) {
+                    ++i;
+                    authenticationRealm = [NSString stringWithUTF8String:argv[i]];
+                } else if (!strcmp(argv[i], "-authenticationUser") && (i + 1 < argc)) {
+                    ++i;
+                    authenticationUser = [NSString stringWithUTF8String:argv[i]];
+                } else if (!strcmp(argv[i], "-authenticationPassword") && (i + 1 < argc)) {
+                    ++i;
+                    authenticationPassword = [NSString stringWithUTF8String:argv[i]];
+                } else if (!strcmp(argv[i], "--localhost")) {
+                    bindToLocalhost = YES;
+                } else if (!strcmp(argv[i], "--nat")) {
+                    requestNATPortMapping = YES;
+                }
+            }
         }
-        if (!strcmp(argv[i], "-mode") && (i + 1 < argc)) {
-          ++i;
-          if (!strcmp(argv[i], "webServer")) {
-            mode = kMode_WebServer;
-          } else if (!strcmp(argv[i], "htmlPage")) {
-            mode = kMode_HTMLPage;
-          } else if (!strcmp(argv[i], "htmlForm")) {
-            mode = kMode_HTMLForm;
-          } else if (!strcmp(argv[i], "htmlFileUpload")) {
-            mode = kMode_HTMLFileUpload;
-          } else if (!strcmp(argv[i], "webDAV")) {
-            mode = kMode_WebDAV;
-          } else if (!strcmp(argv[i], "webUploader")) {
-            mode = kMode_WebUploader;
-          } else if (!strcmp(argv[i], "streamingResponse")) {
-            mode = kMode_StreamingResponse;
-          } else if (!strcmp(argv[i], "asyncResponse")) {
-            mode = kMode_AsyncResponse;
-          }
-        } else if (!strcmp(argv[i], "-record")) {
-          recording = YES;
-        } else if (!strcmp(argv[i], "-root") && (i + 1 < argc)) {
-          ++i;
-          rootDirectory = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:argv[i] length:strlen(argv[i])];
-        } else if (!strcmp(argv[i], "-tests") && (i + 1 < argc)) {
-          ++i;
-          testDirectory = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:argv[i] length:strlen(argv[i])];
-        } else if (!strcmp(argv[i], "-authenticationMethod") && (i + 1 < argc)) {
-          ++i;
-          authenticationMethod = [NSString stringWithUTF8String:argv[i]];
-        } else if (!strcmp(argv[i], "-authenticationRealm") && (i + 1 < argc)) {
-          ++i;
-          authenticationRealm = [NSString stringWithUTF8String:argv[i]];
-        } else if (!strcmp(argv[i], "-authenticationUser") && (i + 1 < argc)) {
-          ++i;
-          authenticationUser = [NSString stringWithUTF8String:argv[i]];
-        } else if (!strcmp(argv[i], "-authenticationPassword") && (i + 1 < argc)) {
-          ++i;
-          authenticationPassword = [NSString stringWithUTF8String:argv[i]];
-        } else if (!strcmp(argv[i], "--localhost")) {
-          bindToLocalhost = YES;
-        } else if (!strcmp(argv[i], "--nat")) {
-          requestNATPortMapping = YES;
-        }
-      }
-    }
 
-    GCDWebServer* webServer = nil;
-    switch (mode) {
-      // Simply serve contents of home directory
-      case kMode_WebServer: {
-        fprintf(stdout, "Running in Web Server mode from \"%s\"\n", [rootDirectory UTF8String]);
-        webServer = [[GCDWebServer alloc] init];
-        [webServer addGETHandlerForBasePath:@"/" directoryPath:rootDirectory indexFilename:nil cacheAge:0 allowRangeRequests:YES];
-        break;
-      }
+        GCDWebServer *webServer = nil;
+        switch (mode) {
+            // Simply serve contents of home directory
+            case kMode_WebServer: {
+                fprintf(stdout, "Running in Web Server mode from \"%s\"\n", [rootDirectory UTF8String]);
+                webServer = [[GCDWebServer alloc] init];
+                [webServer addGETHandlerForBasePath:@"/" directoryPath:rootDirectory indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+                break;
+            }
 
-      // Renders a HTML page
-      case kMode_HTMLPage: {
-        fprintf(stdout, "Running in HTML Page mode\n");
-        webServer = [[GCDWebServer alloc] init];
-        [webServer addDefaultHandlerForMethod:@"GET"
-                                 requestClass:[GCDWebServerRequest class]
-                                 processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                                   return [GCDWebServerDataResponse responseWithHTML:@"<html><body><p>Hello World</p></body></html>"];
-                                 }];
-        break;
-      }
+            // Renders a HTML page
+            case kMode_HTMLPage: {
+                fprintf(stdout, "Running in HTML Page mode\n");
+                webServer = [[GCDWebServer alloc] init];
+                [webServer addDefaultHandlerForMethod:@"GET"
+                                         requestClass:[GCDWebServerRequest class]
+                                         processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                             return [GCDWebServerDataResponse responseWithHTML:@"<html><body><p>Hello World</p></body></html>"];
+                                         }];
+                break;
+            }
 
-      // Implements an HTML form
-      case kMode_HTMLForm: {
-        fprintf(stdout, "Running in HTML Form mode\n");
-        webServer = [[GCDWebServer alloc] init];
-        [webServer addHandlerForMethod:@"GET"
-                                  path:@"/"
-                          requestClass:[GCDWebServerRequest class]
-                          processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                            NSString* html = @" \
+            // Implements an HTML form
+            case kMode_HTMLForm: {
+                fprintf(stdout, "Running in HTML Form mode\n");
+                webServer = [[GCDWebServer alloc] init];
+                [webServer addHandlerForMethod:@"GET"
+                                          path:@"/"
+                                  requestClass:[GCDWebServerRequest class]
+                                  processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                      NSString *html = @" \
             <html><body> \
               <form name=\"input\" action=\"/\" method=\"post\" enctype=\"application/x-www-form-urlencoded\"> \
               Value: <input type=\"text\" name=\"value\"> \
@@ -240,174 +243,185 @@ int main(int argc, const char* argv[]) {
               </form> \
             </body></html> \
           ";
-                            return [GCDWebServerDataResponse responseWithHTML:html];
-                          }];
-        [webServer addHandlerForMethod:@"POST"
-                                  path:@"/"
-                          requestClass:[GCDWebServerURLEncodedFormRequest class]
-                          processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                            NSString* value = [[(GCDWebServerURLEncodedFormRequest*)request arguments] objectForKey:@"value"];
-                            NSString* html = [NSString stringWithFormat:@"<html><body><p>%@</p></body></html>", value];
-                            return [GCDWebServerDataResponse responseWithHTML:html];
-                          }];
-        break;
-      }
+                                      return [GCDWebServerDataResponse responseWithHTML:html];
+                                  }];
+                [webServer addHandlerForMethod:@"POST"
+                                          path:@"/"
+                                  requestClass:[GCDWebServerURLEncodedFormRequest class]
+                                  processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                      NSString *value = [[(GCDWebServerURLEncodedFormRequest *)request arguments] objectForKey:@"value"];
+                                      NSString *html = [NSString stringWithFormat:@"<html><body><p>%@</p></body></html>", value];
+                                      return [GCDWebServerDataResponse responseWithHTML:html];
+                                  }];
+                break;
+            }
 
-      // Implements HTML file upload
-      case kMode_HTMLFileUpload: {
-        fprintf(stdout, "Running in HTML File Upload mode\n");
-        webServer = [[GCDWebServer alloc] init];
-        NSString* formHTML = @" \
+            // Implements HTML file upload
+            case kMode_HTMLFileUpload: {
+                fprintf(stdout, "Running in HTML File Upload mode\n");
+                webServer = [[GCDWebServer alloc] init];
+                NSString *formHTML = @" \
           <form name=\"input\" action=\"/\" method=\"post\" enctype=\"multipart/form-data\"> \
           <input type=\"hidden\" name=\"secret\" value=\"42\"> \
           <input type=\"file\" name=\"files\" multiple><br/> \
           <input type=\"submit\" value=\"Submit\"> \
           </form> \
         ";
-        [webServer addHandlerForMethod:@"GET"
-                                  path:@"/"
-                          requestClass:[GCDWebServerRequest class]
-                          processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                            NSString* html = [NSString stringWithFormat:@"<html><body>%@</body></html>", formHTML];
-                            return [GCDWebServerDataResponse responseWithHTML:html];
-                          }];
-        [webServer addHandlerForMethod:@"POST"
-                                  path:@"/"
-                          requestClass:[GCDWebServerMultiPartFormRequest class]
-                          processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                            NSMutableString* string = [NSMutableString string];
-                            for (GCDWebServerMultiPartArgument* argument in [(GCDWebServerMultiPartFormRequest*)request arguments]) {
-                              [string appendFormat:@"%@ = %@<br>", argument.controlName, argument.string];
-                            }
-                            for (GCDWebServerMultiPartFile* file in [(GCDWebServerMultiPartFormRequest*)request files]) {
-                              NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:file.temporaryPath error:NULL];
-                              [string appendFormat:@"%@ = &quot;%@&quot; (%@ | %llu %@)<br>", file.controlName, file.fileName, file.mimeType,
-                                                   attributes.fileSize >= 1000 ? attributes.fileSize / 1000 : attributes.fileSize,
-                                                   attributes.fileSize >= 1000 ? @"KB" : @"Bytes"];
-                            };
-                            NSString* html = [NSString stringWithFormat:@"<html><body><p>%@</p><hr>%@</body></html>", string, formHTML];
-                            return [GCDWebServerDataResponse responseWithHTML:html];
-                          }];
-        break;
-      }
+                [webServer addHandlerForMethod:@"GET"
+                                          path:@"/"
+                                  requestClass:[GCDWebServerRequest class]
+                                  processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                      NSString *html = [NSString stringWithFormat:@"<html><body>%@</body></html>", formHTML];
+                                      return [GCDWebServerDataResponse responseWithHTML:html];
+                                  }];
+                [webServer addHandlerForMethod:@"POST"
+                                          path:@"/"
+                                  requestClass:[GCDWebServerMultiPartFormRequest class]
+                                  processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                      NSMutableString *string = [NSMutableString string];
 
-      // Serve home directory through WebDAV
-      case kMode_WebDAV: {
-        fprintf(stdout, "Running in WebDAV mode from \"%s\"\n", [rootDirectory UTF8String]);
-        webServer = [[GCDWebDAVServer alloc] initWithUploadDirectory:rootDirectory];
-        break;
-      }
+                                      for (GCDWebServerMultiPartArgument *argument in [(GCDWebServerMultiPartFormRequest *)request arguments]) {
+                                          [string appendFormat:@"%@ = %@<br>", argument.controlName, argument.string];
+                                      }
 
-      // Serve home directory through web uploader
-      case kMode_WebUploader: {
-        fprintf(stdout, "Running in Web Uploader mode from \"%s\"\n", [rootDirectory UTF8String]);
-        webServer = [[GCDWebUploader alloc] initWithUploadDirectory:rootDirectory];
-        break;
-      }
+                                      for (GCDWebServerMultiPartFile *file in [(GCDWebServerMultiPartFormRequest *)request files]) {
+                                          NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:file.temporaryPath error:NULL];
+                                          [string appendFormat:@"%@ = &quot;%@&quot; (%@ | %llu %@)<br>", file.controlName, file.fileName, file.mimeType,
+                                           attributes.fileSize >= 1000 ? attributes.fileSize / 1000 : attributes.fileSize,
+                                           attributes.fileSize >= 1000 ? @"KB" : @"Bytes"];
+                                      }
 
-      // Test streaming responses
-      case kMode_StreamingResponse: {
-        fprintf(stdout, "Running in Streaming Response mode\n");
-        webServer = [[GCDWebServer alloc] init];
-        [webServer addHandlerForMethod:@"GET"
-                                  path:@"/sync"
-                          requestClass:[GCDWebServerRequest class]
-                          processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                            __block int countDown = 10;
-                            return [GCDWebServerStreamedResponse responseWithContentType:@"text/plain"
-                                                                             streamBlock:^NSData*(NSError** error) {
-                                                                               usleep(100 * 1000);
-                                                                               if (countDown) {
-                                                                                 return [[NSString stringWithFormat:@"%i\n", countDown--] dataUsingEncoding:NSUTF8StringEncoding];
-                                                                               } else {
-                                                                                 return [NSData data];
-                                                                               }
-                                                                             }];
-                          }];
-        [webServer addHandlerForMethod:@"GET"
-                                  path:@"/async"
-                          requestClass:[GCDWebServerRequest class]
-                          processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
-                            __block int countDown = 10;
-                            return [GCDWebServerStreamedResponse responseWithContentType:@"text/plain"
-                                                                        asyncStreamBlock:^(GCDWebServerBodyReaderCompletionBlock completionBlock) {
-                                                                          dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                                                                            NSData* data = countDown ? [[NSString stringWithFormat:@"%i\n", countDown--] dataUsingEncoding:NSUTF8StringEncoding] : [NSData data];
-                                                                            completionBlock(data, nil);
-                                                                          });
-                                                                        }];
-                          }];
-        break;
-      }
+                                      NSString *html = [NSString stringWithFormat:@"<html><body><p>%@</p><hr>%@</body></html>", string, formHTML];
+                                      return [GCDWebServerDataResponse responseWithHTML:html];
+                                  }];
+                break;
+            }
 
-      // Test async responses
-      case kMode_AsyncResponse: {
-        fprintf(stdout, "Running in Async Response mode\n");
-        webServer = [[GCDWebServer alloc] init];
-        [webServer addHandlerForMethod:@"GET"
-                                  path:@"/async"
-                          requestClass:[GCDWebServerRequest class]
-                     asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock) {
-                       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                         GCDWebServerDataResponse* response = [GCDWebServerDataResponse responseWithData:(NSData*)[@"Hello World!" dataUsingEncoding:NSUTF8StringEncoding] contentType:@"text/plain"];
-                         completionBlock(response);
-                       });
-                     }];
-        [webServer addHandlerForMethod:@"GET"
-                                  path:@"/async2"
-                          requestClass:[GCDWebServerRequest class]
-                     asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock handlerCompletionBlock) {
-                       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                         __block int countDown = 10;
-                         GCDWebServerStreamedResponse* response = [GCDWebServerStreamedResponse responseWithContentType:@"text/plain"
-                                                                                                       asyncStreamBlock:^(GCDWebServerBodyReaderCompletionBlock readerCompletionBlock) {
-                                                                                                         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                                                                                                           NSData* data = countDown ? [[NSString stringWithFormat:@"%i\n", countDown--] dataUsingEncoding:NSUTF8StringEncoding] : [NSData data];
-                                                                                                           readerCompletionBlock(data, nil);
-                                                                                                         });
-                                                                                                       }];
-                         handlerCompletionBlock(response);
-                       });
-                     }];
-        break;
-      }
-    }
+            // Serve home directory through WebDAV
+            case kMode_WebDAV: {
+                fprintf(stdout, "Running in WebDAV mode from \"%s\"\n", [rootDirectory UTF8String]);
+                webServer = [[GCDWebDAVServer alloc] initWithUploadDirectory:rootDirectory];
+                break;
+            }
 
-    if (webServer) {
-      Delegate* delegate = [[Delegate alloc] init];
-      if (testDirectory) {
+            // Serve home directory through web uploader
+            case kMode_WebUploader: {
+                fprintf(stdout, "Running in Web Uploader mode from \"%s\"\n", [rootDirectory UTF8String]);
+                webServer = [[GCDWebUploader alloc] initWithUploadDirectory:rootDirectory];
+                break;
+            }
+
+            // Test streaming responses
+            case kMode_StreamingResponse: {
+                fprintf(stdout, "Running in Streaming Response mode\n");
+                webServer = [[GCDWebServer alloc] init];
+                [webServer addHandlerForMethod:@"GET"
+                                          path:@"/sync"
+                                  requestClass:[GCDWebServerRequest class]
+                                  processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                      __block int countDown = 10;
+                                      return [GCDWebServerStreamedResponse responseWithContentType:@"text/plain"
+                                                                                       streamBlock:^NSData *(NSError **error) {
+                                                                                           usleep(100 * 1000);
+
+                                                                                           if (countDown) {
+                                                                                           return [[NSString stringWithFormat:@"%i\n", countDown--] dataUsingEncoding:NSUTF8StringEncoding];
+                                                                                           } else {
+                                                                                           return [NSData data];
+                                                                                           }
+                                                                      }];
+                                  }];
+                [webServer addHandlerForMethod:@"GET"
+                                          path:@"/async"
+                                  requestClass:[GCDWebServerRequest class]
+                                  processBlock:^GCDWebServerResponse *(GCDWebServerRequest *request) {
+                                      __block int countDown = 10;
+                                      return [GCDWebServerStreamedResponse responseWithContentType:@"text/plain"
+                                                                                  asyncStreamBlock:^(GCDWebServerBodyReaderCompletionBlock completionBlock) {
+                                                                                      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                                                                                        NSData *data = countDown ? [[NSString stringWithFormat:@"%i\n", countDown--] dataUsingEncoding:NSUTF8StringEncoding] : [NSData data];
+                                                                                        completionBlock(data, nil);
+                                                                                      });
+                                                                 }];
+                                  }];
+                break;
+            }
+
+            // Test async responses
+            case kMode_AsyncResponse: {
+                fprintf(stdout, "Running in Async Response mode\n");
+                webServer = [[GCDWebServer alloc] init];
+                [webServer addHandlerForMethod:@"GET"
+                                          path:@"/async"
+                                  requestClass:[GCDWebServerRequest class]
+                             asyncProcessBlock:^(GCDWebServerRequest *request, GCDWebServerCompletionBlock completionBlock) {
+                                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                                                    GCDWebServerDataResponse *response = [GCDWebServerDataResponse responseWithData:(NSData *)[@"Hello World!" dataUsingEncoding:NSUTF8StringEncoding] contentType:@"text/plain"];
+                                                    completionBlock(response);
+                                                });
+                             }];
+                [webServer addHandlerForMethod:@"GET"
+                                          path:@"/async2"
+                                  requestClass:[GCDWebServerRequest class]
+                             asyncProcessBlock:^(GCDWebServerRequest *request, GCDWebServerCompletionBlock handlerCompletionBlock) {
+                                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                                                    __block int countDown = 10;
+                                                    GCDWebServerStreamedResponse *response = [GCDWebServerStreamedResponse responseWithContentType:@"text/plain"
+                                                                                                                                  asyncStreamBlock:^(GCDWebServerBodyReaderCompletionBlock readerCompletionBlock) {
+                                                                                                                                      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                                                                                                                                             NSData *data = countDown ? [[NSString stringWithFormat:@"%i\n", countDown--] dataUsingEncoding:NSUTF8StringEncoding] : [NSData data];
+                                                                                                                                             readerCompletionBlock(data, nil);
+                                                                                                                                         });
+                                                                                                                      }];
+                                                    handlerCompletionBlock(response);
+                                                });
+                             }];
+                break;
+            }
+        }
+
+        if (webServer) {
+            Delegate *delegate = [[Delegate alloc] init];
+
+            if (testDirectory) {
 #if DEBUG
-        webServer.delegate = delegate;
+                webServer.delegate = delegate;
 #endif
-        fprintf(stdout, "<RUNNING TESTS FROM \"%s\">\n\n", [testDirectory UTF8String]);
-        result = (int)[webServer runTestsWithOptions:@{GCDWebServerOption_Port : @8080} inDirectory:testDirectory];
-      } else {
-        webServer.delegate = delegate;
-        if (recording) {
-          fprintf(stdout, "<RECORDING ENABLED>\n");
-          webServer.recordingEnabled = YES;
+                fprintf(stdout, "<RUNNING TESTS FROM \"%s\">\n\n", [testDirectory UTF8String]);
+                result = (int)[webServer runTestsWithOptions:@{ GCDWebServerOption_Port: @8080 } inDirectory:testDirectory];
+            } else {
+                webServer.delegate = delegate;
+
+                if (recording) {
+                    fprintf(stdout, "<RECORDING ENABLED>\n");
+                    webServer.recordingEnabled = YES;
+                }
+
+                fprintf(stdout, "\n");
+                NSMutableDictionary *options = [NSMutableDictionary dictionary];
+                [options setObject:@8080 forKey:GCDWebServerOption_Port];
+                [options setObject:@(requestNATPortMapping) forKey:GCDWebServerOption_RequestNATPortMapping];
+                [options setObject:@(bindToLocalhost) forKey:GCDWebServerOption_BindToLocalhost];
+                [options setObject:@"" forKey:GCDWebServerOption_BonjourName];
+
+                if (authenticationUser && authenticationPassword) {
+                    [options setValue:authenticationRealm forKey:GCDWebServerOption_AuthenticationRealm];
+                    [options setObject:@{ authenticationUser: authenticationPassword } forKey:GCDWebServerOption_AuthenticationAccounts];
+
+                    if ([authenticationMethod isEqualToString:@"Basic"]) {
+                        [options setObject:GCDWebServerAuthenticationMethod_Basic forKey:GCDWebServerOption_AuthenticationMethod];
+                    } else if ([authenticationMethod isEqualToString:@"Digest"]) {
+                        [options setObject:GCDWebServerAuthenticationMethod_DigestAccess forKey:GCDWebServerOption_AuthenticationMethod];
+                    }
+                }
+
+                if ([webServer runWithOptions:options error:NULL]) {
+                    result = 0;
+                }
+            }
+
+            webServer.delegate = nil;
         }
-        fprintf(stdout, "\n");
-        NSMutableDictionary* options = [NSMutableDictionary dictionary];
-        [options setObject:@8080 forKey:GCDWebServerOption_Port];
-        [options setObject:@(requestNATPortMapping) forKey:GCDWebServerOption_RequestNATPortMapping];
-        [options setObject:@(bindToLocalhost) forKey:GCDWebServerOption_BindToLocalhost];
-        [options setObject:@"" forKey:GCDWebServerOption_BonjourName];
-        if (authenticationUser && authenticationPassword) {
-          [options setValue:authenticationRealm forKey:GCDWebServerOption_AuthenticationRealm];
-          [options setObject:@{authenticationUser : authenticationPassword} forKey:GCDWebServerOption_AuthenticationAccounts];
-          if ([authenticationMethod isEqualToString:@"Basic"]) {
-            [options setObject:GCDWebServerAuthenticationMethod_Basic forKey:GCDWebServerOption_AuthenticationMethod];
-          } else if ([authenticationMethod isEqualToString:@"Digest"]) {
-            [options setObject:GCDWebServerAuthenticationMethod_DigestAccess forKey:GCDWebServerOption_AuthenticationMethod];
-          }
-        }
-        if ([webServer runWithOptions:options error:NULL]) {
-          result = 0;
-        }
-      }
-      webServer.delegate = nil;
     }
-  }
-  return result;
+    return result;
 }

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,0 +1,487 @@
+#
+# Uncrustify Configuration File
+# File Created With UncrustifyX 0.2 (140)
+#
+ 
+# Alignment
+# ---------
+ 
+## Alignment
+ 
+# Align obj-c declaration params on colon
+align_oc_decl_colon                     = true          # boolean (false/true)
+ 
+# Align on tabstop
+align_on_tabstop                        = false         # boolean (false/true)
+ 
+# Align variable definitions
+align_func_params                       = true          # boolean (false/true)
+ 
+# Align with tabs
+align_with_tabs                         = false         # boolean (false/true)
+ 
+# Keep non-indenting tabs
+align_keep_tabs                         = false         # boolean (false/true)
+
+# Align macros wrapped with backslash and newline
+align_nl_cont                           = true          # boolean (false/true)
+ 
+## Alignment Span
+ 
+# Alignment span for #define bodies
+align_pp_define_span                    = 8             # number
+ 
+# Alignment span for equals in enums
+align_enum_equ_span                     = 4             # number
+ 
+# Alignment span for obj-c message colons
+align_oc_msg_colon_span                 = 20            # number
+ 
+# Alignment span for obj-c message spec
+align_oc_msg_spec_span                  = 0             # number
+ 
+# Alignment span for single-line typedefs
+align_typedef_span                      = 5             # number
+ 
+# Alignment span for struct initializer values
+align_struct_init_span                  = 4             # number
+ 
+# Alignment span for trailing comments
+align_right_cmt_span                    = 8             # number
+ 
+## Alignment Style
+ 
+# Alignment style for star in variable definitions
+align_var_def_star_style                = 1             # number
+ 
+## Gap
+ 
+# Minimum gap between type and synonym of typedef
+align_typedef_gap                       = 3             # number
+ 
+# Minimum gap for trailing comment
+align_right_cmt_gap                     = 8             # number
+ 
+## Other
+ 
+# Always align with first parameter in obj-c message
+align_oc_msg_colon_first                = true          # boolean (false/true)
+ 
+# Blank Lines
+# -----------
+ 
+## Newline Count After
+ 
+# Newline count after function body
+nl_after_func_body                      = 2             # number
+ 
+# Newline count after single-line function body
+nl_after_func_body_one_liner            = 2             # number
+ 
+# Newline count after variable definition block
+nl_func_var_def_blk                     = 1             # number
+ 
+## Other
+ 
+# Remove blank lines after open brace
+eat_blanks_after_open_brace             = true          # boolean (false/true)
+ 
+# Remove blank lines before close brace
+eat_blanks_before_close_brace           = true          # boolean (false/true)
+ 
+# Code-Modifying
+# --------------
+ 
+## Braces
+ 
+# Braces around statments that span N newlines
+mod_full_brace_nl                       = 3             # number
+ 
+# Braces on single-line do statement
+mod_full_brace_do                       = ignore        # string (add/force/ignore/remove)
+ 
+# Braces on single-line else statement
+mod_full_brace_if                       = force        # string (add/force/ignore/remove)
+ 
+# Braces on single-line for statement
+mod_full_brace_for                      = add           # string (add/force/ignore/remove)
+ 
+# Braces on single-line while statement
+mod_full_brace_while                    = remove        # string (add/force/ignore/remove)
+ 
+## Comments
+ 
+# Add comment after ifdef/else statement of size
+mod_add_long_ifdef_else_comment         = 20            # number
+ 
+# Add comment after ifdef/endif statement of size
+mod_add_long_ifdef_endif_comment        = 20            # number
+ 
+## Parentheses
+ 
+# Remove unnecessary parentheses on return statement
+mod_paren_on_return                     = ignore        # string (add/force/ignore/remove)
+ 
+## Semicolons
+ 
+# Remove superflous semicolons
+mod_remove_extra_semicolon              = true          # boolean (false/true)
+ 
+# Comments
+# --------
+ 
+## Empty Lines
+ 
+# Empty first line for multi-line C comments
+cmt_c_nl_start                          = true          # boolean (false/true)
+ 
+# Empty first line for multi-line C++ comments
+cmt_cpp_nl_start                        = true          # boolean (false/true)
+ 
+## Other
+ 
+# Stars on multi-line comments
+cmt_star_cont                           = false         # boolean (false/true)
+ 
+# General
+# -------
+ 
+## Other
+ 
+# Newline character
+newlines                                = lf            # string (auto/cr/crlf/lf)
+ 
+# Output tab size
+output_tab_size                         = 4             # number
+ 
+# Indentation
+# -----------
+ 
+## Indentation
+ 
+# Indent obj-c block
+indent_oc_block                         = true          # boolean (false/true)
+ 
+## Indentation Size
+ 
+# Indentation column size
+indent_columns                          = 4             # number
+ 
+# Indentation size between case and switch
+indent_switch_case                      = 4             # number
+ 
+# Indentation size for obj-c blocks in a message parameter
+indent_oc_block_msg                     = 4             # number
+ 
+# Indentation size for obj-c message subsequent parameters
+indent_oc_msg_colon                     = 4             # number
+ 
+## Other
+ 
+# Align continued statements at equals
+indent_align_assign                     = false         # boolean (false/true)
+ 
+# Indent goto labels
+indent_label                            = 2             # number
+ 
+# Indent with tabs
+indent_with_tabs                        = 0             # number
+ 
+# Newlines
+# --------
+ 
+## Merging
+ 
+# Change unbraced if statements into one-liner
+nl_create_if_one_liner                  = true          # boolean (false/true)
+ 
+## Newline After
+ 
+# Newline after brace open
+nl_after_brace_open                     = true         # boolean (false/true)
+ 
+# Newline after for
+nl_after_for                            = force         # string (add/force/ignore/remove)
+ 
+# Newline after if
+nl_after_if                             = force         # string (add/force/ignore/remove)
+ 
+# Newline after macro multi-line definition
+nl_multi_line_define                    = true          # boolean (false/true)
+ 
+# Newline after return
+nl_after_return                         = true          # boolean (false/true)
+ 
+## Newline Before
+ 
+# Newline before case statement
+nl_before_case                          = true          # boolean (false/true)
+ 
+# Newline before for
+nl_before_for                           = force         # string (add/force/ignore/remove)
+ 
+# Newline before if
+nl_before_if                            = force         # string (add/force/ignore/remove)
+ 
+# Newline before while
+nl_before_while                         = force         # string (add/force/ignore/remove)
+ 
+## Newline Between
+ 
+# Newline between case colon and open brace
+nl_case_colon_brace                     = remove        # string (add/force/ignore/remove)
+ 
+# Newline between catch and open brace
+nl_catch_brace                          = remove        # string (add/force/ignore/remove)
+ 
+# Newline between close brace and catch
+nl_brace_catch                          = remove        # string (add/force/ignore/remove)
+ 
+# Newline between close brace and else
+nl_brace_else                           = remove        # string (add/force/ignore/remove)
+ 
+# Newline between close brace and finally
+nl_brace_finally                        = remove        # string (add/force/ignore/remove)
+ 
+# Newline between close brace and while
+nl_brace_while                          = remove        # string (add/force/ignore/remove)
+ 
+# Newline between close parenthesis and open brace in multi line conditional
+nl_multi_line_cond                      = false         # boolean (false/true)
+ 
+# Newline between do and open brace
+nl_do_brace                             = remove        # string (add/force/ignore/remove)
+ 
+# Newline between else and open brace
+nl_else_brace                           = remove        # string (add/force/ignore/remove)
+ 
+# Newline between else if and open brace
+nl_elseif_brace                         = remove        # string (add/force/ignore/remove)
+ 
+# Newline between enum and open brace
+nl_enum_brace                           = remove        # string (add/force/ignore/remove)
+ 
+# Newline between finally and open brace
+nl_finally_brace                        = remove        # string (add/force/ignore/remove)
+ 
+# Newline between for and open brace
+nl_for_brace                            = remove        # string (add/force/ignore/remove)
+ 
+# Newline between function call and open brace
+nl_fcall_brace                          = remove        # string (add/force/ignore/remove)
+ 
+# Newline between function signature and open brace
+nl_fdef_brace                           = remove        # string (add/force/ignore/remove)
+ 
+# Newline between if and open brace
+nl_if_brace                             = remove        # string (add/force/ignore/remove)
+ 
+# Newline between struct and open brace
+nl_struct_brace                         = remove        # string (add/force/ignore/remove)
+ 
+# Newline between switch and open brace
+nl_switch_brace                         = remove        # string (add/force/ignore/remove)
+ 
+# Newline between try and open brace
+nl_try_brace                            = remove        # string (add/force/ignore/remove)
+ 
+# Newline between union and open brace
+nl_union_brace                          = remove        # string (add/force/ignore/remove)
+ 
+# Newline between while and open brace
+nl_while_brace                          = remove        # string (add/force/ignore/remove)
+ 
+## Other
+ 
+# Don't split one-line obj-c messages
+nl_oc_msg_leave_one_liner               = true          # boolean (false/true)
+ 
+# Newlines at end of file
+nl_end_of_file                          = add           # string (add/force/ignore/remove)
+ 
+# Place obj-c message parameters on new lines
+nl_oc_msg_args                          = true          # boolean (false/true)
+
+# Whether to alter newlines in '#define' macros
+nl_define_macro                         = true          # boolean (false/true)
+ 
+# Spacing
+# -------
+ 
+## Space After
+ 
+# Space after C++ comment opening
+sp_cmt_cpp_start                        = ignore        # string (add/force/ignore/remove)
+ 
+# Space after cast
+sp_after_cast                           = remove        # string (add/force/ignore/remove)
+ 
+# Space after class colon
+sp_after_class_colon                    = force         # string (add/force/ignore/remove)
+ 
+# Space after comma
+sp_after_comma                          = add           # string (add/force/ignore/remove)
+ 
+# Space after condition close parenthesis
+sp_after_sparen                         = force         # string (add/force/ignore/remove)
+ 
+# Space after obj-c block caret
+sp_after_oc_block_caret                 = remove        # string (add/force/ignore/remove)
+ 
+# Space after obj-c colon
+sp_after_oc_colon                       = remove        # string (add/force/ignore/remove)
+ 
+# Space after obj-c dictionary colon
+sp_after_oc_dict_colon                  = add           # string (add/force/ignore/remove)
+ 
+# Space after obj-c message colon
+sp_after_send_oc_colon                  = remove        # string (add/force/ignore/remove)
+ 
+# Space after obj-c property
+sp_after_oc_property                    = add           # string (add/force/ignore/remove)
+ 
+# Space after obj-c return type
+sp_after_oc_return_type                 = remove        # string (add/force/ignore/remove)
+ 
+# Space after obj-c scope
+sp_after_oc_scope                       = force         # string (add/force/ignore/remove)
+ 
+# Space after obj-c type
+sp_after_oc_type                        = remove        # string (add/force/ignore/remove)
+ 
+# Space after pointer star
+sp_after_ptr_star                       = remove        # string (add/force/ignore/remove)
+ 
+# Space after pointer star followed by function
+sp_after_ptr_star_func                  = force         # string (add/force/ignore/remove)
+ 
+## Space Around
+ 
+# Space around arithmetic operators
+sp_arith                                = add           # string (add/force/ignore/remove)
+ 
+# Space around assignment operator
+sp_assign                               = add           # string (add/force/ignore/remove)
+ 
+# Space around boolean operators
+sp_bool                                 = add           # string (add/force/ignore/remove)
+ 
+# Space around compare operators
+sp_compare                              = add           # string (add/force/ignore/remove)
+ 
+# Space around ternary condition colon
+sp_cond_colon                           = force         # string (add/force/ignore/remove)
+ 
+# Space around ternary condition question mark
+sp_cond_question                        = force         # string (add/force/ignore/remove)
+ 
+## Space Before
+ 
+# Space before case colon
+sp_before_case_colon                    = remove        # string (add/force/ignore/remove)
+ 
+# Space before class colon
+sp_before_class_colon                   = force         # string (add/force/ignore/remove)
+ 
+# Space before if/for/switch/while open parenthesis
+sp_before_sparen                        = force         # string (add/force/ignore/remove)
+ 
+# Space before obj-c block caret
+sp_before_oc_block_caret                = ignore        # string (add/force/ignore/remove)
+ 
+# Space before obj-c colon
+sp_before_oc_colon                      = remove        # string (add/force/ignore/remove)
+ 
+# Space before obj-c dictionary colon
+sp_before_oc_dict_colon                 = remove        # string (add/force/ignore/remove)
+ 
+# Space before obj-c message colon
+sp_before_send_oc_colon                 = remove        # string (add/force/ignore/remove)
+ 
+# Space before pointer star
+sp_before_ptr_star                      = force         # string (add/force/ignore/remove)
+ 
+# Space before pointer star followed by function
+sp_before_ptr_star_func                 = force         # string (add/force/ignore/remove)
+ 
+# Space before unnamed pointer star
+sp_before_unnamed_ptr_star              = ignore        # string (add/force/ignore/remove)
+ 
+## Space Between
+ 
+# Space between @selector and open parenthesis
+sp_after_oc_at_sel                      = remove        # string (add/force/ignore/remove)
+ 
+# Space between catch and open brace
+sp_catch_brace                          = add           # string (add/force/ignore/remove)
+ 
+# Space between catch and open parenthesis
+sp_catch_paren                          = add           # string (add/force/ignore/remove)
+ 
+# Space between close brace and else
+sp_brace_else                           = force         # string (add/force/ignore/remove)
+ 
+# Space between close parenthesis and open brace
+sp_paren_brace                          = force         # string (add/force/ignore/remove)
+ 
+# Space between closing brace and catch
+sp_brace_catch                          = add           # string (add/force/ignore/remove)
+ 
+# Space between closing brace and finally
+sp_brace_finally                        = add           # string (add/force/ignore/remove)
+ 
+# Space between closing parenthesis and open brace
+sp_fparen_brace                         = force         # string (add/force/ignore/remove)
+ 
+# Space between else and open brace
+sp_else_brace                           = force         # string (add/force/ignore/remove)
+ 
+# Space between finally and open brace
+sp_finally_brace                        = add           # string (add/force/ignore/remove)
+ 
+# Space between function name and open parenthesis
+sp_func_call_paren                      = remove        # string (add/force/ignore/remove)
+ 
+# Space between function name and open parenthesis in declaration
+sp_func_proto_paren                     = remove        # string (add/force/ignore/remove)
+ 
+# Space between function name and open parenthesis in function definition
+sp_func_def_paren                       = remove        # string (add/force/ignore/remove)
+ 
+# Space between pointer stars
+sp_between_ptr_star                     = remove        # string (add/force/ignore/remove)
+ 
+# Space between sizeof and open parenthesis
+sp_sizeof_paren                         = remove        # string (add/force/ignore/remove)
+ 
+# Space between try and open brace
+sp_try_brace                            = add           # string (add/force/ignore/remove)
+ 
+## Space Inside
+ 
+# Space inside @selector() parens
+sp_inside_oc_at_sel_parens              = remove        # string (add/force/ignore/remove)
+ 
+# Space inside braces
+sp_inside_braces                        = add           # string (add/force/ignore/remove)
+ 
+# Space inside cast parentheses
+sp_inside_paren_cast                    = remove        # string (add/force/ignore/remove)
+ 
+# Space inside enum braces
+sp_inside_braces_enum                   = add           # string (add/force/ignore/remove)
+ 
+# Space inside function parentheses
+sp_inside_fparen                        = remove        # string (add/force/ignore/remove)
+ 
+# Space inside if-condition parentheses
+sp_inside_sparen                        = remove        # string (add/force/ignore/remove)
+ 
+# Space inside parentheses
+sp_inside_paren                         = remove        # string (add/force/ignore/remove)
+ 
+# Space inside parentheses in function type
+sp_inside_tparen                        = remove        # string (add/force/ignore/remove)
+ 
+# Space inside struct/union braces
+sp_inside_braces_struct                 = add           # string (add/force/ignore/remove)


### PR DESCRIPTION
The code formatting of this library is pretty unconventional compared to the universally standard of Objective-C. Namely 2 spaces instead of 4 for tabs.

I added the uncrustify config from CocoaLumberjack and ran it on all of the source files, cleaning the code up and making it a lot more standardised now.