### PR TITLE
Serve uploader resources with no-cache so updates aren't served stale

### DIFF
--- a/Sources/GCDWebUploader/GCDWebUploader.m
+++ b/Sources/GCDWebUploader/GCDWebUploader.m
@@ -159,8 +159,12 @@ NS_ASSUME_NONNULL_END
         }
         GCDWebUploader *const __unsafe_unretained server = self;
 
-        // Resource files
-        [self addGETHandlerForBasePath:@"/" directoryPath:(NSString *)[siteBundle resourcePath] indexFilename:nil cacheAge:3600 allowRangeRequests:NO];
+        // Resource files. cacheAge:0 sends "Cache-Control: no-cache" so browsers
+        // revalidate (via ETag/Last-Modified) on every load instead of caching for
+        // an hour. Unchanged files still return a cheap 304, but after an app
+        // update the rebuilt bundle changes each file's ETag, so the new assets
+        // (e.g. index.js) are picked up immediately rather than served stale.
+        [self addGETHandlerForBasePath:@"/" directoryPath:(NSString *)[siteBundle resourcePath] indexFilename:nil cacheAge:0 allowRangeRequests:NO];
 
         // Web page
         [self addHandlerForMethod:@"GET"


### PR DESCRIPTION
The uploader served its bundled JS/CSS with cacheAge:3600, so browsers cached them for an hour. After an app update that changes those assets (e.g. the SSE index.js), returning users kept getting the old files until the cache expired — the problem reported upstream in swisspol/GCDWebServer#591.

Use cacheAge:0, which sends "Cache-Control: no-cache". Browsers then revalidate on every load using the ETag/Last-Modified the server already sends: unchanged files return a cheap 304, but after an app update the rebuilt bundle changes each file's ETag so the new assets are fetched immediately. Verified over raw HTTP: matching ETag -> 304, stale ETag -> 200.