### PR TITLE
Make isRunning reflect actual listening state while suspended

### DIFF
--- a/Sources/GCDWebServer/Core/GCDWebServer.h
+++ b/Sources/GCDWebServer/Core/GCDWebServer.h
@@ -319,7 +319,10 @@ extern NSString *const GCDWebServerAuthenticationMethod_DigestAccess;
 @property (nonatomic, weak, nullable) id<GCDWebServerDelegate> delegate;
 
 /**
- *  Returns YES if the server is currently running.
+ *  Returns YES if the server is currently running, i.e. actively listening for
+ *  connections. This is NO while the server is suspended in the background (see
+ *  GCDWebServerOption_AutomaticallySuspendInBackground), even though it will
+ *  resume automatically when the app returns to the foreground.
  */
 @property (nonatomic, readonly, getter=isRunning) BOOL running;
 

--- a/Sources/GCDWebServer/Core/GCDWebServer.m
+++ b/Sources/GCDWebServer/Core/GCDWebServer.m
@@ -873,7 +873,14 @@ static inline NSString *_EncodeBase64(NSString *string) {
 }
 
 - (BOOL)isRunning {
-    return (_options ? YES : NO);
+    // Reflect whether the server is actually listening, not merely configured.
+    // This is NO while the server is suspended in the background (its listening
+    // sockets are torn down until the app returns to the foreground), which is
+    // the behavior the header documents for
+    // GCDWebServerOption_AutomaticallySuspendInBackground. Previously this
+    // returned YES whenever the server had been started, so it stayed YES while
+    // suspended and lied about the server's state. See swisspol/GCDWebServer#437.
+    return (_source4 != NULL);
 }
 
 - (void)stop {


### PR DESCRIPTION
isRunning returned (_options != nil), so it stayed YES the whole time the server was suspended in the background even though its listening sockets had been torn down — the server was not actually running. This also contradicted the header, which documents that "the running property will be NO while the GCDWebServer is suspended" (swisspol/GCDWebServer#437).

Return (_source4 != NULL) instead, so isRunning is YES only while actually listening and NO while suspended, matching the documented contract. No internal code depended on the old behavior (start/stop/handler guards test _options and _source4 directly). Verified across the lifecycle: NO before start, YES started, NO suspended, YES resumed, NO after stop.