### PR TITLE
Let CORS preflight through when authentication is enabled

### DIFF
--- a/Sources/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/Sources/GCDWebServer/Core/GCDWebServerConnection.m
@@ -769,6 +769,15 @@ static inline NSUInteger _ScanHexNumber(const void *bytes, NSUInteger size) {
     GWS_LOG_DEBUG(@"Connection on socket %i preflighting request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead);
     GCDWebServerResponse *response = nil;
 
+    // A CORS preflight (an OPTIONS request carrying "Access-Control-Request-Method")
+    // must not require credentials: browsers never send "Authorization" on preflight
+    // per the CORS spec, so enforcing auth here rejects it with 401 and breaks every
+    // subsequent cross-origin request. Let it through to the handler so the app can
+    // answer the preflight. See swisspol/GCDWebServer#479.
+    if ([request.method isEqualToString:@"OPTIONS"] && request.headers[@"Access-Control-Request-Method"]) {
+        return nil;
+    }
+
     if (_server.authenticationBasicAccounts) {
         __block BOOL authenticated = NO;
         NSString *const authorizationHeader = request.headers[@"Authorization"];


### PR DESCRIPTION
With Basic or Digest auth configured, the pre-handler auth gate returned 401 for any request without an Authorization header — including CORS preflight. Browsers never send credentials on a preflight (per the CORS spec), so the preflight was rejected and every cross-origin request failed (swisspol/GCDWebServer#479).

Exempt CORS preflight requests (OPTIONS carrying Access-Control-Request-Method) from the auth gate so the handler can answer them. Real requests are unaffected: verified that unauthenticated GET still returns 401, authenticated GET returns 200, and the preflight now reaches the handler (200) instead of 401.