### PR TITLE
Fix issues found in deep security & correctness scan

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -111,6 +111,15 @@ static NSData* SSEData(NSString* string) {
     XCTAssertEqualObjects(received, (@[ @"1", @"2", @"3", @"4" ]));
 }
 
+// Parking a reader signals the client is alive, so it resets the idle-heartbeat
+// counter the owner uses to reap connections that have stopped reading.
+- (void)testSSEChannelParkingResetsIdleHeartbeats {
+    GCDWebUploaderSSEChannel* channel = [[GCDWebUploaderSSEChannel alloc] initWithCapacity:100];
+    channel.idleHeartbeats = 5;
+    [channel parkReader:^(NSData* data) {}];
+    XCTAssertEqual(channel.idleHeartbeats, (NSUInteger)0);
+}
+
 // When the buffer overflows (e.g. a dead connection), the oldest messages are
 // dropped so memory stays bounded.
 - (void)testSSEChannelDropsOldestBeyondCapacity {

--- a/Sources/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
+++ b/Sources/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
@@ -31,6 +31,14 @@ var _path = null;
 var _pendingReloads = [];
 var _reloadingDisabled = 0;
 
+// Escape server-provided strings (file/folder names, device name) before they are
+// concatenated into HTML, to prevent stored XSS via crafted names.
+function _escapeHTML(s) {
+  return String(s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
 function formatFileSize(bytes) {
   if (bytes >= 1000000000) {
     return (bytes / 1000000000).toFixed(2) + ' GB';
@@ -83,19 +91,19 @@ function _reload(path) {
     if (path != _path) {
       $("#path").empty();
       if (path == "/") {
-        $("#path").append('<li class="active">' + _device + '</li>');
+        $("#path").append('<li class="active">' + _escapeHTML(_device) + '</li>');
       } else {
-        $("#path").append('<li data-path="/"><a>' + _device + '</a></li>');
+        $("#path").append('<li data-path="/"><a>' + _escapeHTML(_device) + '</a></li>');
         var components = path.split("/").slice(1, -1);
         for (var i = 0; i < components.length - 1; ++i) {
           var subpath = "/" + components.slice(0, i + 1).join("/") + "/";
-          $("#path").append('<li data-path="' + subpath + '"><a>' + components[i] + '</a></li>');
+          $("#path").append('<li data-path="' + _escapeHTML(subpath) + '"><a>' + _escapeHTML(components[i]) + '</a></li>');
         }
         $("#path > li").click(function(event) {
           _reload($(this).data("path"));
           event.preventDefault();
         });
-        $("#path").append('<li class="active">' + components[components.length - 1] + '</li>');
+        $("#path").append('<li class="active">' + _escapeHTML(components[components.length - 1]) + '</li>');
       }
       _path = path;
 
@@ -353,7 +361,11 @@ $(document).ready(function() {
       if (data.type === 'external') {
         eventDir = eventPath;
       } else {
-        eventDir = eventPath.substring(0, eventPath.lastIndexOf('/') + 1) || '/';
+        // Strip a trailing slash first: folder create/delete events carry the
+        // folder's own path (e.g. "/Docs/New/"), and we want its PARENT dir so
+        // clients viewing "/Docs/" reload.
+        var p = eventPath.replace(/\/+$/, '');
+        eventDir = p.substring(0, p.lastIndexOf('/') + 1) || '/';
       }
 
       // Reload only if the changed directory IS the currently-viewed directory.
@@ -362,12 +374,19 @@ $(document).ready(function() {
       // of the current folder doesn't trigger a spurious reload.)
       var newDir = null;
       if (data.newPath) {
-        newDir = data.newPath.substring(0, data.newPath.lastIndexOf('/') + 1) || '/';
+        var np = data.newPath.replace(/\/+$/, '');
+        newDir = np.substring(0, np.lastIndexOf('/') + 1) || '/';
       }
       if (eventDir === _path || newDir === _path) {
         _reload(_path);
       }
     });
+
+    eventSource.onopen = function() {
+      // Re-sync on every (re)connect so any change missed while disconnected
+      // is picked up instead of leaving a stale listing.
+      _reload(_path);
+    };
 
     eventSource.onerror = function() {
       console.log('SSE connection error, will auto-reconnect');

--- a/Sources/GCDWebUploader/GCDWebUploader.m
+++ b/Sources/GCDWebUploader/GCDWebUploader.m
@@ -89,6 +89,7 @@
 }
 
 - (void)parkReader:(void (^)(NSData* data))reader {
+    _idleHeartbeats = 0;  // The client came back to read: it is alive.
     if (_buffer.count > 0) {
         NSData* data = _buffer.firstObject;
         [_buffer removeObjectAtIndex:0];
@@ -154,9 +155,9 @@ NS_ASSUME_NONNULL_END
         _filePresenterQueue = [[NSOperationQueue alloc] init];
         _filePresenterQueue.maxConcurrentOperationCount = 1;
         [self _startHeartbeatTimer];
-        if (_serverSentEventsEnabled) {
-            [self _registerFilePresenter];
-        }
+        // The NSFilePresenter is registered on -start and removed on -stop (see
+        // -_updateFilePresenterRegistration) so we only participate in system file
+        // coordination while actually serving, not for the object's whole lifetime.
         GCDWebUploader *const __unsafe_unretained server = self;
 
         // Resource files. cacheAge:0 sends "Cache-Control: no-cache" so browsers
@@ -306,7 +307,12 @@ NS_ASSUME_NONNULL_END
                          // reader and asking for the next (its streaming API is a ping-pong).
                          GCDWebUploaderSSEChannel *channel = [[GCDWebUploaderSSEChannel alloc] init];
                          dispatch_async(server->_sseQueue, ^{
-                             [server->_sseChannels addObject:channel];
+                             // Re-check on the SSE queue: SSE may have been disabled between the
+                             // check above and now, in which case don't register a channel that
+                             // would never be serviced or reaped.
+                             if (server->_serverSentEventsEnabled) {
+                                 [server->_sseChannels addObject:channel];
+                             }
                          });
                          GCDWebServerStreamedResponse *response =
                              [GCDWebServerStreamedResponse responseWithContentType:@"text/event-stream"
@@ -360,19 +366,47 @@ NS_ASSUME_NONNULL_END
     }
 }
 
+// The file presenter should be registered only while the server is actually
+// running AND SSE is enabled. Centralised here and driven from -start/-stop and
+// the SSE toggle. Idempotent (the register/unregister helpers are guarded).
+- (void)_updateFilePresenterRegistration {
+    if (self.isRunning && _serverSentEventsEnabled) {
+        [self _registerFilePresenter];
+    } else {
+        [self _unregisterFilePresenter];
+    }
+}
+
 - (void)setServerSentEventsEnabled:(BOOL)enabled {
     if (_serverSentEventsEnabled == enabled) {
         return;
     }
     _serverSentEventsEnabled = enabled;
-    if (enabled) {
-        [self _registerFilePresenter];
-    } else {
-        [self _unregisterFilePresenter];
+    [self _updateFilePresenterRegistration];
+    if (!enabled) {
         dispatch_async(_sseQueue, ^{
             [self->_sseChannels removeAllObjects];
         });
     }
+}
+
+- (BOOL)startWithOptions:(NSDictionary<NSString *, id> *)options error:(NSError **)error {
+    BOOL started = [super startWithOptions:options error:error];
+    if (started) {
+        [self _updateFilePresenterRegistration];
+    }
+    return started;
+}
+
+- (void)stop {
+    [super stop];
+    // No longer serving: stop observing the file system and drop any lingering SSE
+    // connections instead of leaving the presenter registered and the machinery
+    // running for the rest of the object's lifetime.
+    [self _updateFilePresenterRegistration];
+    dispatch_async(_sseQueue, ^{
+        [self->_sseChannels removeAllObjects];
+    });
 }
 
 #pragma mark - NSFilePresenter
@@ -416,14 +450,22 @@ NS_ASSUME_NONNULL_END
         [_pendingChangedPaths addObject:changedDirectory];
     }
 
-    // Coalesce rapid changes with a short timer
+    // Coalesce rapid changes with a short timer. Use the block-based API capturing
+    // a weak reference so the scheduled timer never retains self — a target:self
+    // timer would keep self alive (and, under continuous file activity, perpetually
+    // renew that retain), preventing deterministic teardown.
+    __weak GCDWebUploader *weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self->_changeCoalescingTimer invalidate];
-        self->_changeCoalescingTimer = [NSTimer scheduledTimerWithTimeInterval:0.1
-                                                                        target:self
-                                                                      selector:@selector(_flushPendingChanges)
-                                                                      userInfo:nil
-                                                                       repeats:NO];
+        GCDWebUploader *strongSelf = weakSelf;
+        if (strongSelf == nil) {
+            return;
+        }
+        [strongSelf->_changeCoalescingTimer invalidate];
+        strongSelf->_changeCoalescingTimer = [NSTimer scheduledTimerWithTimeInterval:0.1
+                                                                              repeats:NO
+                                                                                block:^(NSTimer *timer) {
+            [weakSelf _flushPendingChanges];
+        }];
     });
 }
 
@@ -449,8 +491,17 @@ NS_ASSUME_NONNULL_END
     }
     NSMutableArray<GCDWebUploaderSSEChannel *> *live = [NSMutableArray arrayWithCapacity:_sseChannels.count];
     for (GCDWebUploaderSSEChannel *channel in _sseChannels) {
-        if (!channel.hasParkedReader && channel.bufferedCount > 0) {
-            continue;  // Never came back to read what we last sent it: reap.
+        if (channel.hasParkedReader) {
+            channel.idleHeartbeats = 0;  // A reader is waiting: alive.
+        } else {
+            // No reader waiting since we last serviced it. A live client re-parks
+            // within milliseconds of each delivery, so tolerate a single transient
+            // miss (e.g. a socket write completing across a heartbeat boundary) and
+            // only reap after two consecutive idle heartbeats.
+            channel.idleHeartbeats += 1;
+            if (channel.idleHeartbeats >= 2) {
+                continue;  // Stopped reading: reap.
+            }
         }
         [live addObject:channel];
     }
@@ -602,12 +653,19 @@ NS_ASSUME_NONNULL_END
 
     GCDWebServerMultiPartFile *const file = [request firstFileForControlName:@"files[]"];
 
-    if ((!_allowHiddenItems && [file.fileName hasPrefix:@"."]) || ![self _checkFileExtension:file.fileName]) {
+    // The multipart "filename" is fully attacker-controlled and may contain path
+    // separators or "..", which -stringByAppendingPathComponent: does NOT resolve,
+    // so an unsanitized name lets a move escape the upload directory. Reduce it to
+    // a single leaf component and reject the traversal specials.
+    NSString *const fileName = [file.fileName lastPathComponent];
+
+    if ((fileName.length == 0) || [fileName isEqualToString:@"."] || [fileName isEqualToString:@".."] ||
+        (!_allowHiddenItems && [fileName hasPrefix:@"."]) || ![self _checkFileExtension:fileName]) {
         return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploaded file name \"%@\" is not allowed", file.fileName];
     }
 
     NSString *const relativePath = [[request firstArgumentForControlName:@"path"] string];
-    NSString *const desiredPath = [[_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)] stringByAppendingPathComponent:file.fileName];
+    NSString *const desiredPath = [[_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)] stringByAppendingPathComponent:fileName];
 
     // Resolving a unique name and moving the uploaded file into place must be
     // atomic against concurrent requests, otherwise two uploads of the same

--- a/Sources/GCDWebUploader/GCDWebUploaderSSEChannel.h
+++ b/Sources/GCDWebUploader/GCDWebUploaderSSEChannel.h
@@ -66,6 +66,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) NSUInteger bufferedCount;
 
+/**
+ *  Consecutive heartbeats observed by the owner during which no reader parked.
+ *  Used to reap connections that have stopped reading without misjudging a live
+ *  client that is momentarily mid-write. Reset to 0 whenever a reader parks.
+ */
+@property (nonatomic) NSUInteger idleHeartbeats;
+
 - (instancetype)init;  // Uses a sensible default capacity.
 - (instancetype)initWithCapacity:(NSUInteger)capacity NS_DESIGNATED_INITIALIZER;
 


### PR DESCRIPTION
Security (both pre-existing, confirmed by reproduction):
- Upload path traversal: the multipart filename was appended unsanitized, so a crafted "filename" like "../evil.txt" wrote OUTSIDE the upload directory (stringByAppendingPathComponent: doesn't resolve "..", moveItemAtPath: lets the kernel climb out). Reduce it to its leaf (lastPathComponent) and reject "."/".."/empty. Reproduced writing outside the dir before, blocked after.
- Stored XSS: the breadcrumb builder concatenated raw server-provided path components (and the device name) into .append(), so a folder named "<img onerror=…>" executed JS when browsed. Escape via a new _escapeHTML.

SSE correctness:
- Folder create/delete never live-reloaded *observing* clients: the event path for a directory carries a trailing slash, so the client computed the folder itself as the changed dir instead of its parent. Strip the trailing slash.
- Reap heuristic could drop a live-but-mid-write connection (no parked reader + buffered data at a heartbeat) and orphan it with no reconnect. Reap only after two consecutive idle heartbeats, tracked via a per-channel idleHeartbeats counter reset whenever a reader parks.
- EventSource now re-syncs (reloads) on (re)connect so changes missed during a disconnect are picked up.

Lifecycle:
- The SSE machinery (NSFilePresenter + heartbeat) lived for the object's whole lifetime and was torn down only in dealloc, which a target:self coalescing NSTimer could delay indefinitely under file activity. Register the file presenter only while running AND SSE-enabled (driven from -start/-stop and the toggle), and use a block-based weak-capturing timer so it never retains self.
- Toggling SSE off mid-connect could leave a "zombie" channel: re-check the enabled flag on the SSE queue before registering a new channel.

Verified: traversal blocked (reproduction), XSS payload escaped and folder-reload logic correct (node), SSE end-to-end delivery + reconnect-refresh intact, channel tests incl. new idleHeartbeats reset, Mac/iOS/tvOS build clean (9 XCTests pass).