### PR TITLE
Validated the Host header against an allow-list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,12 +119,37 @@ mutated requests under ASan+UBSan produced zero memory errors, and request smugg
 structurally impossible (one request per connection, `Connection: Close`, leftover bytes
 never read) — verified live by pipelining.
 
-**Still open, deliberately deferred:** there is no `Host` validation anywhere, and the
-uploader's CSRF check compares `Origin` against `Host` — both attacker-controlled after DNS
-rebinding — so any website can drive the whole API once a DNS TTL flips. WebDAV has no
-origin check at all. The fix is a Host allowlist in the connection layer (IP literals,
-`localhost`, `<bonjourName>.local`, plus an option), which will reject setups that work
-today; that compatibility call is why it is not in this pass.
+### Host validation (DNS rebinding)
+
+Every request's `Host` is checked against an allow-list in
+`-[GCDWebServerConnection _rejectIfHostNotAllowed]`; anything else gets 421. Accepted with
+no configuration: any IP address literal, `localhost`, this machine's own host name, and the
+Bonjour name being advertised. `GCDWebServerOption_AllowedHostNames` adds more, and an entry
+may pin its own port.
+
+**Why nothing else would do.** Once a page on `evil.example` repoints its DNS here, the
+browser considers itself same-origin: CORS permits the read, an `Origin` comparison passes,
+and a CSRF token can simply be fetched from the page and replayed. The only thing that still
+differs is the *name* the browser sends in `Host` — and an attacker cannot make a browser put
+a raw IP literal there while scripting from a domain. That asymmetry is the entire defence,
+which is why IP literals are accepted by *shape* rather than by matching our own addresses.
+Do not "improve" this by resolving the Host and comparing against local interfaces: the
+attacker controls that DNS, so it resolves to us and the check evaporates.
+
+This also repairs rather than duplicates the uploader's CSRF check. That check compares
+`Origin` against `Host`, which was sound logic over an untrusted input; now that `Host` is
+validated first, the comparison means something again.
+
+It lives in the connection layer, ahead of `-preflightRequest:` (a subclassing point that
+must not be able to switch it off), so WebDAV and host-app handlers inherit it — WebDAV has
+no origin check of its own and would otherwise be the most exposed surface.
+
+A request with no `Host` at all is allowed: HTTP/1.0 and many native clients omit it, and
+rebinding requires a browser, which never does. Rejections log the offending name, the path,
+the peer and the full accepted set, deliberately loudly — this is the check most likely to
+surprise a deployment nobody anticipated, and a quiet refusal would present as "the server
+just doesn't work". Covered by `testHostValidationRefusesRebindingButAllowsRealNames`,
+`testHostValidationCoversWebDAV` and `testHostValidationHonoursConfiguredNames`.
 
 ### Third audit pass: remote DoS, lifecycle, and parsing fixes
 

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1586,6 +1586,96 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
                              @"input must not be truncated at the first NUL");
 }
 
+#pragma mark - Host validation (DNS rebinding)
+
+// A page on evil.example that repoints its DNS at this server is, to the browser, genuinely
+// same-origin: CORS, Origin comparison and CSRF tokens are all satisfied. The one thing that
+// still differs is the name the browser puts in Host, which is why this check exists and why
+// nothing else substitutes for it.
+- (void)testHostValidationRefusesRebindingButAllowsRealNames {
+    GCDWebServer* server = [[GCDWebServer alloc] init];
+    [server addDefaultHandlerForMethod:@"GET"
+                          requestClass:[GCDWebServerRequest class]
+                          processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                              return [GCDWebServerDataResponse responseWithText:@"served"];
+                          }];
+    NSDictionary* options = @{GCDWebServerOption_Port : @0, GCDWebServerOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* (^get)(NSString*) = ^(NSString* host) {
+        return SendRawRequest(server.port, [NSString stringWithFormat:@"GET / HTTP/1.1\r\nHost: %@\r\n\r\n", host]);
+    };
+
+    // Names and literals this server genuinely answers to.
+    for (NSString* host in @[ @"localhost", @"LOCALHOST", @"127.0.0.1", @"192.168.1.42", @"[::1]" ]) {
+        XCTAssertTrue([get(host) containsString:@"served"], @"legitimate host \"%@\" was refused", host);
+    }
+    XCTAssertTrue([get([NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port]) containsString:@"served"], @"matching port was refused");
+
+    // The rebinding case, and near-misses around it.
+    for (NSString* host in @[ @"evil.example", @"localhost.evil.com", @"attacker.localhost.evil.com" ]) {
+        XCTAssertTrue([get(host) containsString:@"421"], @"host \"%@\" should have been refused", host);
+    }
+    XCTAssertTrue([get([NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port + 1]) containsString:@"421"], @"a mismatched port should be refused");
+
+    // No Host at all is allowed: HTTP/1.0 and native clients omit it, and rebinding needs a
+    // browser, which never does.
+    XCTAssertTrue([SendRawRequest(server.port, @"GET / HTTP/1.0\r\n\r\n") containsString:@"served"], @"a request with no Host should be allowed");
+
+    [server stop];
+}
+
+// The check lives in the connection layer precisely so WebDAV inherits it — WebDAV has no
+// origin check of its own, so an uploader-only fix would leave the more capable API exposed.
+- (void)testHostValidationCoversWebDAV {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    XCTAssertTrue([@"secret" writeToFile:[dir stringByAppendingPathComponent:@"a.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    GCDWebDAVServer* server = [[GCDWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{GCDWebServerOption_Port : @0, GCDWebServerOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* rebound = SendRawRequest(server.port, @"GET /a.txt HTTP/1.1\r\nHost: evil.example\r\n\r\n");
+    XCTAssertTrue([rebound containsString:@"421"], @"WebDAV did not inherit host validation: %@", rebound);
+    XCTAssertFalse([rebound containsString:@"secret"], @"WebDAV served file contents to a rebound host");
+
+    NSString* legitimate = SendRawRequest(server.port, @"GET /a.txt HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([legitimate containsString:@"secret"], @"host validation broke a legitimate WebDAV read: %@", legitimate);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// The escape hatch for anyone reached under another name — a reverse proxy, a custom DNS
+// entry. Entries may pin their own port.
+- (void)testHostValidationHonoursConfiguredNames {
+    GCDWebServer* server = [[GCDWebServer alloc] init];
+    [server addDefaultHandlerForMethod:@"GET"
+                          requestClass:[GCDWebServerRequest class]
+                          processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                              return [GCDWebServerDataResponse responseWithText:@"served"];
+                          }];
+    NSDictionary* options = @{
+        GCDWebServerOption_Port : @0,
+        GCDWebServerOption_BindToLocalhost : @YES,
+        GCDWebServerOption_AllowedHostNames : @[ @"files.example", @"pinned.example:8080" ]
+    };
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* (^get)(NSString*) = ^(NSString* host) {
+        return SendRawRequest(server.port, [NSString stringWithFormat:@"GET / HTTP/1.1\r\nHost: %@\r\n\r\n", host]);
+    };
+
+    XCTAssertTrue([get(@"files.example") containsString:@"served"]);
+    XCTAssertTrue([get(@"FILES.EXAMPLE") containsString:@"served"], @"configured names should match case-insensitively");
+    XCTAssertTrue([get(@"pinned.example:8080") containsString:@"served"], @"an entry may pin its own port");
+    XCTAssertTrue([get(@"other.example") containsString:@"421"], @"an unconfigured name should still be refused");
+    XCTAssertTrue([get(@"localhost") containsString:@"served"], @"the defaults should survive adding names");
+
+    [server stop];
+}
+
 #pragma mark - gzip response encoding
 
 // A gzip-encoded response body must decompress back to exactly what the handler produced.

--- a/Sources/GCDWebServer/Core/GCDWebServer.h
+++ b/Sources/GCDWebServer/Core/GCDWebServer.h
@@ -135,6 +135,33 @@ extern NSString *const GCDWebServerOption_RequestNATPortMapping;
 extern NSString *const GCDWebServerOption_BindToLocalhost;
 
 /**
+ *  Additional host names this server will answer to, beyond the ones it accepts
+ *  automatically (NSArray of NSString).
+ *
+ *  Every request's "Host" header is checked against an allow-list, and anything
+ *  else is refused with 421. This is what stops DNS rebinding: a browser sends the
+ *  *name* the page was loaded from, so a page on evil.example that has repointed
+ *  its DNS at this server still sends "Host: evil.example" — and an attacker
+ *  cannot make a browser send a raw IP address in Host while scripting from a
+ *  domain. Without this check, every same-origin protection (CORS, Origin
+ *  comparison, CSRF tokens) is bypassed, because after rebinding the attacker
+ *  genuinely *is* same-origin.
+ *
+ *  Accepted without configuration: any IP address literal, "localhost", this
+ *  machine's own host name, and the Bonjour name being advertised. Supply this
+ *  option only if the server is reached under some other name — behind a reverse
+ *  proxy, or via a custom DNS entry. Entries are compared case-insensitively and
+ *  may include a port ("files.example:8080"); without one, any port matches.
+ *
+ *  A request carrying no "Host" header at all is allowed: HTTP/1.0 and many
+ *  non-browser clients omit it, and rebinding requires a browser, which never does.
+ *
+ *  Rejections are logged with the offending name and the full accepted set, so an
+ *  unanticipated deployment reports itself rather than failing mysteriously.
+ */
+extern NSString *const GCDWebServerOption_AllowedHostNames;
+
+/**
  *  The maximum number of incoming HTTP requests that can be queued waiting to
  *  be handled before new ones are dropped (NSNumber / NSUInteger).
  *

--- a/Sources/GCDWebServer/Core/GCDWebServer.m
+++ b/Sources/GCDWebServer/Core/GCDWebServer.m
@@ -60,6 +60,7 @@ NSString *const GCDWebServerOption_BonjourType = @"BonjourType";
 NSString *const GCDWebServerOption_BonjourTXTData = @"BonjourTXTData";
 NSString *const GCDWebServerOption_RequestNATPortMapping = @"RequestNATPortMapping";
 NSString *const GCDWebServerOption_BindToLocalhost = @"BindToLocalhost";
+NSString *const GCDWebServerOption_AllowedHostNames = @"AllowedHostNames";
 NSString *const GCDWebServerOption_MaxPendingConnections = @"MaxPendingConnections";
 NSString *const GCDWebServerOption_ServerName = @"ServerName";
 NSString *const GCDWebServerOption_AuthenticationMethod = @"AuthenticationMethod";
@@ -196,6 +197,7 @@ static void _ExecuteMainThreadRunLoopSources(void) {
     CFRunLoopTimerRef _disconnectTimer;  // Accessed on main thread only
 
     NSDictionary<NSString *, id> *_options;
+    NSSet<NSString *> *_allowedHostNames;
     NSMutableDictionary<NSString *, NSString *> *_authenticationBasicAccounts;
     NSMutableDictionary<NSString *, NSString *> *_authenticationDigestAccounts;
     Class _connectionClass;
@@ -526,6 +528,7 @@ static NSString *_ValidateOptions(NSDictionary<NSString *, id> *options) {
         GCDWebServerOption_BonjourTXTData: [NSDictionary class],
         GCDWebServerOption_RequestNATPortMapping: [NSNumber class],
         GCDWebServerOption_BindToLocalhost: [NSNumber class],
+        GCDWebServerOption_AllowedHostNames: [NSArray class],
         GCDWebServerOption_MaxPendingConnections: [NSNumber class],
         GCDWebServerOption_ServerName: [NSString class],
         GCDWebServerOption_AuthenticationMethod: [NSString class],
@@ -814,6 +817,35 @@ static inline NSString *_EncodeBase64(NSString *string) {
     NSString *const bonjourName = _GetOption(_options, GCDWebServerOption_BonjourName, nil);
     NSString *const bonjourType = _GetOption(_options, GCDWebServerOption_BonjourType, @"_http._tcp");
 
+    // Names this server answers to. Anything else in a request's "Host" is refused: see
+    // GCDWebServerOption_AllowedHostNames for why that is the only defence against DNS
+    // rebinding. IP literals are not listed because they are recognised by shape rather
+    // than by value — the interface set can change under us, and a browser cannot be made
+    // to put a literal in Host while scripting from a domain, so any literal is safe.
+    NSMutableSet<NSString *> *const allowedHostNames = [[NSMutableSet alloc] init];
+    [allowedHostNames addObject:@"localhost"];
+    NSString *const advertisedName = (bonjourName.length ? bonjourName : _serverName);
+
+    if (advertisedName.length) {
+        [allowedHostNames addObject:[[advertisedName stringByAppendingString:@".local"] lowercaseString]];
+    }
+
+    NSString *const machineName = [[NSProcessInfo processInfo] hostName];  // Typically "<device>.local"
+
+    if (machineName.length) {
+        // A trailing dot makes an mDNS name fully qualified; browsers send it without.
+        [allowedHostNames addObject:[[machineName hasSuffix:@"."] ? [machineName substringToIndex:(machineName.length - 1)] : machineName lowercaseString]];
+    }
+
+    for (NSString *name in (NSArray *)_GetOption(_options, GCDWebServerOption_AllowedHostNames, @[])) {
+        if ([name isKindOfClass:[NSString class]] && name.length) {
+            [allowedHostNames addObject:[name lowercaseString]];
+        }
+    }
+
+    _allowedHostNames = allowedHostNames;
+    GWS_LOG_INFO(@"%@ will answer to host names %@ (and any IP address literal) on port %i", [self class], [[allowedHostNames allObjects] componentsJoinedByString:@", "], (int)_port);
+
     if (bonjourName) {
         _registrationService = CFNetServiceCreate(kCFAllocatorDefault, CFSTR("local."), (__bridge CFStringRef)bonjourType, (__bridge CFStringRef)(bonjourName.length ? bonjourName : _serverName), (SInt32)_port);
 
@@ -971,6 +1003,7 @@ static inline NSString *_EncodeBase64(NSString *string) {
     _bindToLocalhost = NO;
 
     _serverName = nil;
+    _allowedHostNames = nil;
     _authenticationRealm = nil;
     _authenticationBasicAccounts = nil;
     _authenticationDigestAccounts = nil;

--- a/Sources/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/Sources/GCDWebServer/Core/GCDWebServerConnection.m
@@ -29,7 +29,9 @@
 #error GCDWebServer requires ARC
 #endif
 
+#import <arpa/inet.h>
 #import <netdb.h>
+#import <netinet/in.h>
 #import <sys/socket.h>
 #import <TargetConditionals.h>
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
@@ -93,6 +95,7 @@ NS_ASSUME_NONNULL_END
     NSString *_authenticationRealm;
     NSDictionary<NSString *, NSString *> *_authenticationBasicAccounts;
     NSDictionary<NSString *, NSString *> *_authenticationDigestAccounts;
+    NSSet<NSString *> *_allowedHostNames;
     BOOL _shouldAutomaticallyMapHEADToGET;
 
     CFHTTPMessageRef _requestMessage;
@@ -164,9 +167,135 @@ NS_ASSUME_NONNULL_END
     CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Date"), (__bridge CFStringRef)GCDWebServerFormatRFC822([NSDate date]));
 }
 
+// A textual IP address needs no allow-list entry. The interface set can change under us, so
+// enumerating our own addresses would be both racy and incomplete — and the whole check
+// rests on the fact that a browser cannot be made to put a literal in "Host" while
+// scripting from a domain, so a literal can never be a rebound name.
+static BOOL _IsIPAddressLiteral(NSString *host) {
+    if (host.length == 0) {
+        return NO;
+    }
+
+    const char *const value = host.UTF8String;
+    struct in_addr address4;
+    struct in6_addr address6;
+    return (inet_pton(AF_INET, value, &address4) == 1) || (inet_pton(AF_INET6, value, &address6) == 1);
+}
+
+// The port this connection was actually accepted on. Taken from the connection's own local
+// address rather than the server's mutable _port ivar, which -_stop clears from another
+// thread while connections are still live.
+static uint16_t _LocalPortFromAddress(NSData *localAddressData) {
+    const struct sockaddr *const address = localAddressData.bytes;
+
+    if (address == NULL) {
+        return 0;
+    }
+
+    if (address->sa_family == AF_INET) {
+        return ntohs(((const struct sockaddr_in *)address)->sin_port);
+    }
+
+    if (address->sa_family == AF_INET6) {
+        return ntohs(((const struct sockaddr_in6 *)address)->sin6_port);
+    }
+
+    return 0;
+}
+
+// Refuse a request whose "Host" names something this server does not answer to. This is the
+// only defence against DNS rebinding: once a page on evil.example repoints its DNS here, the
+// browser treats it as same-origin, so CORS, Origin comparison and CSRF tokens are all
+// satisfied — but the browser still sends the name the page was loaded from. See
+// GCDWebServerOption_AllowedHostNames.
+- (GCDWebServerResponse *)_rejectIfHostNotAllowed {
+    NSString *const hostHeader = _request.headers[@"Host"];
+
+    // No "Host" at all: HTTP/1.0 and plenty of native clients omit it, and rebinding needs
+    // a browser, which never does. There is nothing here that could have been rebound.
+    if (hostHeader.length == 0) {
+        return nil;
+    }
+
+    NSString *const normalized = [hostHeader lowercaseString];
+
+    // An allow-list entry may pin a port ("files.example:8080"), so try the value verbatim
+    // before splitting it.
+    if ([_allowedHostNames containsObject:normalized]) {
+        return nil;
+    }
+
+    NSString *name = normalized;
+    NSString *portText = nil;
+
+    if ([name hasPrefix:@"["]) {  // Bracketed IPv6 literal, optionally followed by a port
+        NSRange closing = [name rangeOfString:@"]"];
+
+        if (closing.location == NSNotFound) {
+            return [self _misdirectedResponseForHost:hostHeader];
+        }
+
+        NSString *const remainder = [name substringFromIndex:(closing.location + 1)];
+
+        if (remainder.length && ![remainder hasPrefix:@":"]) {
+            return [self _misdirectedResponseForHost:hostHeader];
+        }
+
+        portText = remainder.length ? [remainder substringFromIndex:1] : nil;
+        name = [name substringWithRange:NSMakeRange(1, closing.location - 1)];
+    } else {
+        NSRange colon = [name rangeOfString:@":" options:NSBackwardsSearch];
+
+        if (colon.location != NSNotFound) {
+            portText = [name substringFromIndex:(colon.location + 1)];
+            name = [name substringToIndex:colon.location];
+        }
+    }
+
+    // A stated port must be the one this connection arrived on; omitting it is fine, since
+    // that is what a client reaching a default port sends.
+    if (portText.length) {
+        BOOL digitsOnly = (portText.length <= 5);
+
+        for (NSUInteger i = 0; digitsOnly && (i < portText.length); i++) {
+            unichar character = [portText characterAtIndex:i];
+            digitsOnly = ((character >= '0') && (character <= '9'));
+        }
+
+        if (!digitsOnly || ([portText integerValue] != (NSInteger)_LocalPortFromAddress(_localAddressData))) {
+            return [self _misdirectedResponseForHost:hostHeader];
+        }
+    }
+
+    if (_IsIPAddressLiteral(name) || [_allowedHostNames containsObject:name]) {
+        return nil;
+    }
+
+    return [self _misdirectedResponseForHost:hostHeader];
+}
+
+- (GCDWebServerResponse *)_misdirectedResponseForHost:(NSString *)hostHeader {
+    NSString *const accepted = [[[_allowedHostNames allObjects] sortedArrayUsingSelector:@selector(compare:)] componentsJoinedByString:@", "];
+    // Deliberately loud. This is the check most likely to surprise a deployment nobody
+    // anticipated, and a quiet refusal would present as "the server just doesn't work".
+    GWS_LOG_ERROR(@"Refusing \"%@ %@\" from %@: host \"%@\" is not one this server answers to (accepted: %@, plus any IP address literal). Set GCDWebServerOption_AllowedHostNames if this name is legitimate.",
+                  _request.method, _request.path, self.remoteAddressString, hostHeader, accepted);
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MisdirectedRequest
+                                                      message:@"Host \"%@\" is not served here. Accepted: %@, or any IP address. Set GCDWebServerOption_AllowedHostNames to add one.", hostHeader, accepted];
+}
+
 - (void)_startProcessingRequest {
     GWS_DCHECK(_responseMessage == NULL);
     _requestReceived = YES;  // Nothing further is read from the socket for this request
+
+    // Ahead of -preflightRequest: deliberately. That method is a documented subclassing
+    // point, and a subclass that does not call super must not be able to switch this off.
+    GCDWebServerResponse *const misdirectedResponse = [self _rejectIfHostNotAllowed];
+
+    if (misdirectedResponse) {
+        [self _finishProcessingRequest:misdirectedResponse];
+        return;
+    }
 
     GCDWebServerResponse *preflightResponse = [self preflightRequest:_request];
 
@@ -530,6 +659,7 @@ NS_ASSUME_NONNULL_END
         _authenticationRealm = server.authenticationRealm;
         _authenticationBasicAccounts = server.authenticationBasicAccounts;
         _authenticationDigestAccounts = server.authenticationDigestAccounts;
+        _allowedHostNames = server.allowedHostNames;
         _shouldAutomaticallyMapHEADToGET = server.shouldAutomaticallyMapHEADToGET;
         _localAddressData = localAddress;
         _remoteAddressData = remoteAddress;

--- a/Sources/GCDWebServer/Core/GCDWebServerHTTPStatusCodes.h
+++ b/Sources/GCDWebServer/Core/GCDWebServerHTTPStatusCodes.h
@@ -90,6 +90,7 @@ typedef NS_ENUM(NSInteger, GCDWebServerClientErrorHTTPStatusCode) {
     kGCDWebServerHTTPStatusCode_UnsupportedMediaType = 415,
     kGCDWebServerHTTPStatusCode_RequestedRangeNotSatisfiable = 416,
     kGCDWebServerHTTPStatusCode_ExpectationFailed = 417,
+    kGCDWebServerHTTPStatusCode_MisdirectedRequest = 421,
     kGCDWebServerHTTPStatusCode_UnprocessableEntity = 422,
     kGCDWebServerHTTPStatusCode_Locked = 423,
     kGCDWebServerHTTPStatusCode_FailedDependency = 424,

--- a/Sources/GCDWebServer/Core/GCDWebServerPrivate.h
+++ b/Sources/GCDWebServer/Core/GCDWebServerPrivate.h
@@ -214,6 +214,7 @@ extern NSString *GCDWebServerStringFromSockAddr(const struct sockaddr *addr, BOO
 @interface GCDWebServer ()
 @property (nonatomic, readonly) NSMutableArray<GCDWebServerHandler *> *handlers;
 @property (nonatomic, readonly, nullable) NSString *serverName;
+@property (nonatomic, readonly, nullable) NSSet<NSString *> *allowedHostNames;
 @property (nonatomic, readonly, nullable) NSString *authenticationRealm;
 @property (nonatomic, readonly, nullable) NSMutableDictionary<NSString *, NSString *> *authenticationBasicAccounts;
 @property (nonatomic, readonly, nullable) NSMutableDictionary<NSString *, NSString *> *authenticationDigestAccounts;

--- a/Sources/GCDWebUploader/GCDWebUploader.m
+++ b/Sources/GCDWebUploader/GCDWebUploader.m
@@ -1001,6 +1001,11 @@ static NSString *_OriginAuthority(NSString *value) {
 // always sends Origin), so reject those. Requests with no Origin/Referer at all — a
 // non-browser client such as curl or a native app — are allowed: they cannot be a
 // confused deputy. Returns a 403 response to reject, or nil to allow.
+//
+// Comparing against the client-supplied Host is only meaningful because the connection
+// layer has already validated it against an allow-list (see -_rejectIfHostNotAllowed). On
+// its own this check compares two attacker-controlled values and a DNS-rebound page passes
+// it trivially, so the two belong together.
 - (GCDWebServerResponse *)_rejectIfCrossOrigin:(GCDWebServerRequest *)request {
     NSString *const originHeader = request.headers[@"Origin"];
     NSString *const host = request.headers[@"Host"];


### PR DESCRIPTION
Closes the DNS rebinding hole. Once a page on evil.example repoints its DNS at this server the browser considers itself same-origin, so CORS permits the read, an Origin comparison passes, and a CSRF token can just be fetched from the page and replayed — a website the user merely visited could read, overwrite, rename and delete the entire share and tail /events for filenames. WebDAV was worse still, having no origin check at all.

Every request's Host is now checked in -_rejectIfHostNotAllowed and anything unrecognised gets 421. Accepted without configuration: any IP address literal, localhost, this machine's host name, and the Bonjour name being advertised. GCDWebServerOption_AllowedHostNames adds names for anyone reached under another — behind a reverse proxy, or via a custom DNS entry — and an entry may pin its port.

The defence rests on one asymmetry: an attacker cannot make a browser put a raw IP literal in Host while scripting from a domain. So literals are accepted by shape rather than by matching our own addresses, which would be racy as interfaces change and pointless anyway — resolving the Host and comparing would hand the check to the attacker, who controls that DNS.

This repairs rather than duplicates the uploader's CSRF check: comparing Origin against Host was sound logic over an untrusted input, and Host is now trustworthy. It sits in the connection layer ahead of -preflightRequest:, which is a documented subclassing point that must not be able to switch it off, so WebDAV and host-app handlers inherit it.

A request with no Host is allowed — HTTP/1.0 and many native clients omit it, and rebinding needs a browser, which never does. Rejections log the name, path, peer and the full accepted set, deliberately loudly: this is the check most likely to surprise a deployment nobody anticipated, and a quiet refusal would look like the server simply not working.