### PR TITLE
Bounded in-memory request data across all connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,41 @@ mutated requests under ASan+UBSan produced zero memory errors, and request smugg
 structurally impossible (one request per connection, `Connection: Close`, leftover bytes
 never read) — verified live by pipelining.
 
+### Aggregate in-memory budget
+
+Every in-memory limit was per-request, and per-request limits do not compose: with
+`kGCDWebServerMaxConnections` concurrent requests the real ceiling was their product — about
+2 GB of chunked framing buffers, or 8 GB of inflated gzip output — many times what a phone
+survives. This was the same bug class fixed twice already (multipart bodies, then multipart
+part-headers); rather than wait for a third instance, the general case is now closed.
+
+`kGCDWebServerMaxTotalInMemoryLength` (64 MB) bounds the sum across all live connections.
+Every place that holds request data in memory takes a `GCDWebServerMemoryReservation` and
+resizes it as its buffer grows: data-request bodies, inflated gzip output, multipart argument
+parts, each multipart parser's working buffer, and the chunked framing buffer. Per-request
+limits still apply on top.
+
+The reservation is deliberately an **object**: the bytes are returned in `-dealloc`, so a
+connection that dies mid-body — dropped, reset, timed out — cannot leak budget and
+permanently shrink what the server can serve afterwards. Reservations that rise and fall
+(working buffers) shrink again as the parser drains them; a reservation that only grows
+(retained multipart arguments) is charged once against the shared budget object. Verified
+under load: 24 concurrent chunked bodies peaked at exactly the ceiling and never above it,
+and the reserved total returned to zero once they finished.
+
+`GCDWebServerSetMemoryLimitsForTesting` shrinks the limits so a bound can be proven without
+moving tens of megabytes. That fixed the long-standing flake in
+`testChunkedTransferRejectsUnterminatedSizeLine`, which used to push 16 MB through the server
+and lose the test runner in roughly half of full-suite runs; it now proves the same property
+against a 64 KB bound. Ten consecutive full-suite runs pass. Consult
+`GCDWebServerMaxInMemoryBodyLength()` / `GCDWebServerMaxDecompressedBodyLength()` rather than
+the `kGCDWebServer...` constants, so the overrides are honoured.
+
+Known imprecision: exhausting the budget surfaces as a 500, because the body-writer protocol
+reports failure as a plain BOOL and the connection maps any body-write failure to 500. A 503
+would be more honest; threading a status through that protocol was judged not worth
+destabilising the body-read path for.
+
 ### Host validation (DNS rebinding)
 
 Every request's `Host` is checked against an allow-list in

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -802,26 +802,31 @@ static NSString* MakeTempDirectory(void) {
     NSDictionary* options = @{GCDWebServerOption_Port : @0, GCDWebServerOption_BindToLocalhost : @YES, GCDWebServerOption_ConnectionIdleTimeout : @5.0};
     XCTAssertTrue([server startWithOptions:options error:NULL]);
 
+    // Shrink the bound so the property is proven with a few hundred kilobytes rather than
+    // by pushing 16 MB through the server. That volume was slow, and under the suite's
+    // AddressSanitizer build it was itself enough to lose the whole test runner — which
+    // reports as "0 failures" and silently takes the next test with it.
+    GCDWebServerSetMemoryLimitsForTesting(64 * 1024, 64 * 1024, 1024 * 1024);
+    [self addTeardownBlock:^{
+        GCDWebServerSetMemoryLimitsForTesting(0, 0, 0);
+    }];
+
     int fd = ConnectToLocalhostPort(server.port);
     XCTAssertGreaterThan(fd, 0);
     const char* head = "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/octet-stream\r\nTransfer-Encoding: chunked\r\n\r\n";
     XCTAssertEqual(send(fd, head, strlen(head), 0), (ssize_t)strlen(head));
 
-    // Stream ~20 MB of 'a' (all valid hex, no CRLF) so the chunk-size line can never
-    // complete, exceeding the 16 MB + framing-slack bound. Send on a background queue
-    // so the main thread can read the server's rejection response promptly (a blocking
-    // send of the whole blob would otherwise deadlock against the server that has
-    // stopped reading). A rejecting server produces an HTTP error response; a server
-    // that buffered without bound would send nothing and the read would just time out.
+    // Stream 'a' bytes (all valid hex, no CRLF) so the chunk-size line can never complete,
+    // exceeding the framing bound. Send on a background queue so the main thread can read
+    // the server's rejection promptly — a blocking send of the whole payload would deadlock
+    // against a server that has stopped reading. A rejecting server produces an HTTP error;
+    // a server that buffered without bound would send nothing and the read would time out.
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        // Stream from a small reusable buffer rather than allocating the whole 20 MB. The
-        // bytes on the wire are identical, but the test process no longer holds 20 MB
-        // alongside the ~16 MB the server is buffering — under AddressSanitizer that peak
-        // was enough to disturb neighbouring timing-sensitive tests in the same run.
-        char chunk[64 * 1024];
+        char chunk[16 * 1024];
         memset(chunk, 'a', sizeof(chunk));
+        NSUInteger toSend = 4 * (GCDWebServerMaxInMemoryBodyLength() + (64 * 1024));
 
-        for (int i = 0; i < (20 * 1024 * 1024) / (int)sizeof(chunk); i++) {
+        for (NSUInteger sent = 0; sent < toSend; sent += sizeof(chunk)) {
             if (send(fd, chunk, sizeof(chunk), 0) < 0) {
                 break;  // The server rejected and closed; the point is already proven
             }
@@ -1584,6 +1589,47 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     NSString* withNUL = [NSString stringWithFormat:@"abc%@def", [NSString stringWithCharacters:&nul length:1]];
     XCTAssertNotEqualObjects(GCDWebServerComputeMD5Digest(@"%@", withNUL), GCDWebServerComputeMD5Digest(@"%@", @"abc"),
                              @"input must not be truncated at the first NUL");
+}
+
+#pragma mark - Aggregate in-memory budget
+
+// Every in-memory limit is per-request, and per-request limits do not compose: with the
+// connection cap the real ceiling was their product — gigabytes, far past what a phone
+// survives. A process-wide budget bounds the sum, and a reservation returns its bytes when
+// it is deallocated so a connection dying mid-body cannot permanently shrink the budget.
+- (void)testTotalInMemoryBudgetIsBoundedAndReturned {
+    GCDWebServerSetMemoryLimitsForTesting(64 * 1024, 64 * 1024, 256 * 1024);
+    [self addTeardownBlock:^{
+        GCDWebServerSetMemoryLimitsForTesting(0, 0, 0);
+    }];
+    XCTAssertEqual(GCDWebServerReservedMemoryLength(), (NSUInteger)0, @"budget should start empty");
+
+    // The pool matters: the requests are autoreleased, so they are only deallocated — and
+    // their reservations only returned — once it drains.
+    NSUInteger accepted = 0;
+
+    @autoreleasepool {
+        // More concurrent bodies than the total budget can hold at once.
+        NSMutableArray<GCDWebServerDataRequest*>* requests = [NSMutableArray array];
+        NSMutableData* payload = [NSMutableData dataWithLength:(32 * 1024)];
+
+        for (int i = 0; i < 16; i++) {
+            GCDWebServerDataRequest* request = OpenBodyRequest([GCDWebServerDataRequest class], @{});
+            [requests addObject:request];
+            NSError* error = nil;
+
+            if ([request performWriteData:payload error:&error]) {
+                accepted += 1;
+            }
+        }
+
+        XCTAssertGreaterThan(accepted, (NSUInteger)0, @"the budget refused everything; it is too tight to be usable");
+        XCTAssertLessThan(accepted, (NSUInteger)16, @"the budget accepted every body; the aggregate ceiling is not enforced");
+        XCTAssertLessThanOrEqual(GCDWebServerReservedMemoryLength(), (NSUInteger)(256 * 1024), @"reserved memory exceeded the ceiling");
+    }
+
+    // Every holder is gone, so every byte must have come back.
+    XCTAssertEqual(GCDWebServerReservedMemoryLength(), (NSUInteger)0, @"reservations leaked after their holders were released");
 }
 
 #pragma mark - Host validation (DNS rebinding)

--- a/Sources/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/Sources/GCDWebServer/Core/GCDWebServerConnection.m
@@ -114,6 +114,7 @@ NS_ASSUME_NONNULL_END
     NSUInteger _headerPhaseTicks;  // Idle ticks elapsed before a request was matched; on _connectionQueue only
     BOOL _requestReceived;         // Set once the body is fully read and the handler runs; on _connectionQueue only
     NSTimeInterval _idleTimeout;   // Seconds between idle-timer ticks; 0 when idle timeouts are disabled
+    GCDWebServerMemoryReservation *_chunkReservation;  // This connection's chunked framing buffer
 
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__
     NSUInteger _connectionIndex;
@@ -456,6 +457,7 @@ static uint16_t _LocalPortFromAddress(NSData *localAddressData) {
         return;
     }
 
+    _chunkReservation = [[GCDWebServerMemoryReservation alloc] init];
     NSMutableData *const chunkData = [[NSMutableData alloc] initWithData:initialData];
     [self readNextBodyChunk:chunkData
             completionBlock:^(BOOL success) {
@@ -914,11 +916,11 @@ static inline NSUInteger _ScanHexNumber(const void *bytes, NSUInteger size) {
 
         if (length != NSNotFound) {
             if (length) {
-                if (length > kGCDWebServerMaxInMemoryBodyLength) {
+                if (length > GCDWebServerMaxInMemoryBodyLength()) {
                     // A single chunk is buffered whole in memory before being written, so
                     // cap its declared size. Legitimate chunked uploads use many smaller
                     // chunks; this only rejects a pathologically large single chunk.
-                    GWS_LOG_ERROR(@"Chunk size %lu exceeds the %i byte limit reading request body on socket %i", (unsigned long)length, (int)kGCDWebServerMaxInMemoryBodyLength, _socket);
+                    GWS_LOG_ERROR(@"Chunk size %lu exceeds the %lu byte limit reading request body on socket %i", (unsigned long)length, (unsigned long)GCDWebServerMaxInMemoryBodyLength(), _socket);
                     block(NO);
                     return;
                 }
@@ -969,8 +971,17 @@ static inline NSUInteger _ScanHexNumber(const void *bytes, NSUInteger size) {
     // bounds the buffer, so it would grow until the app is jetsam/OOM-killed (the idle
     // timeout never fires while bytes keep arriving). Bound it at one max-size chunk
     // plus framing slack: a legitimate in-flight chunk needs at most that much buffered.
-    if (chunkData.length > (NSUInteger)kGCDWebServerMaxInMemoryBodyLength + kHeadersMaxLength) {
+    if (chunkData.length > GCDWebServerMaxInMemoryBodyLength() + kHeadersMaxLength) {
         GWS_LOG_ERROR(@"Chunked transfer framing exceeds the buffer limit reading request body on socket %i", _socket);
+        block(NO);
+        return;
+    }
+
+    // That cap is per-connection, and per-connection caps do not compose: with the
+    // connection limit it allowed gigabytes in aggregate. Charge this buffer against the
+    // process-wide ceiling too, and give bytes back as the parser drains them.
+    if (![_chunkReservation reserveBytes:chunkData.length]) {
+        GWS_LOG_ERROR(@"Refusing chunked body on socket %i: the server is already holding its %lu byte in-memory limit across all connections", _socket, (unsigned long)kGCDWebServerMaxTotalInMemoryLength);
         block(NO);
         return;
     }

--- a/Sources/GCDWebServer/Core/GCDWebServerFunctions.m
+++ b/Sources/GCDWebServer/Core/GCDWebServerFunctions.m
@@ -40,10 +40,84 @@
 #endif
 #import <CommonCrypto/CommonDigest.h>
 #import <ifaddrs.h>
+#import <os/lock.h>
 #import <net/if.h>
 #import <netdb.h>
 
 #import "GCDWebServerPrivate.h"
+
+// Guards every field below. Contended only when a buffer grows, never per byte.
+static os_unfair_lock _memoryLock = OS_UNFAIR_LOCK_INIT;
+static NSUInteger _memoryReserved = 0;
+static NSUInteger _memoryCapacity = kGCDWebServerMaxTotalInMemoryLength;
+static NSUInteger _memoryPerRequestLimit = kGCDWebServerMaxInMemoryBodyLength;
+static NSUInteger _memoryDecompressedLimit = kGCDWebServerMaxDecompressedBodyLength;
+
+NSUInteger GCDWebServerMaxInMemoryBodyLength(void) {
+    os_unfair_lock_lock(&_memoryLock);
+    NSUInteger value = _memoryPerRequestLimit;
+    os_unfair_lock_unlock(&_memoryLock);
+    return value;
+}
+
+NSUInteger GCDWebServerMaxDecompressedBodyLength(void) {
+    os_unfair_lock_lock(&_memoryLock);
+    NSUInteger value = _memoryDecompressedLimit;
+    os_unfair_lock_unlock(&_memoryLock);
+    return value;
+}
+
+void GCDWebServerSetMemoryLimitsForTesting(NSUInteger perRequest, NSUInteger decompressed, NSUInteger total) {
+    os_unfair_lock_lock(&_memoryLock);
+    _memoryPerRequestLimit = perRequest ? perRequest : (NSUInteger)kGCDWebServerMaxInMemoryBodyLength;
+    _memoryDecompressedLimit = decompressed ? decompressed : (NSUInteger)kGCDWebServerMaxDecompressedBodyLength;
+    _memoryCapacity = total ? total : (NSUInteger)kGCDWebServerMaxTotalInMemoryLength;
+    os_unfair_lock_unlock(&_memoryLock);
+}
+
+NSUInteger GCDWebServerReservedMemoryLength(void) {
+    os_unfair_lock_lock(&_memoryLock);
+    NSUInteger value = _memoryReserved;
+    os_unfair_lock_unlock(&_memoryLock);
+    return value;
+}
+
+@implementation GCDWebServerMemoryReservation {
+    NSUInteger _bytes;
+}
+
+- (BOOL)reserveBytes:(NSUInteger)bytes {
+    BOOL granted = YES;
+    os_unfair_lock_lock(&_memoryLock);
+
+    if (bytes > _bytes) {
+        NSUInteger increase = bytes - _bytes;
+
+        // Refuse rather than partially grant: the caller fails the request cleanly, which
+        // is the whole point — the alternative is every connection buffering a little more
+        // until the process is killed.
+        if (_memoryReserved + increase > _memoryCapacity) {
+            granted = NO;
+        } else {
+            _memoryReserved += increase;
+            _bytes = bytes;
+        }
+    } else {
+        _memoryReserved -= (_bytes - bytes);
+        _bytes = bytes;
+    }
+
+    os_unfair_lock_unlock(&_memoryLock);
+    return granted;
+}
+
+- (void)dealloc {
+    os_unfair_lock_lock(&_memoryLock);
+    _memoryReserved -= _bytes;  // Cannot underflow: _bytes only ever moves through -reserveBytes:
+    os_unfair_lock_unlock(&_memoryLock);
+}
+
+@end
 
 static NSDateFormatter *_dateFormatterRFC822 = nil;
 static NSDateFormatter *_dateFormatterISO8601 = nil;

--- a/Sources/GCDWebServer/Core/GCDWebServerPrivate.h
+++ b/Sources/GCDWebServer/Core/GCDWebServerPrivate.h
@@ -76,6 +76,20 @@
 #define kGCDWebServerMaxDecompressedBodyLength (64 * 1024 * 1024)
 
 /**
+ *  Ceiling on request data held in memory across *all* live connections at once.
+ *
+ *  The two limits above are per-request, and they do not compose: with
+ *  kGCDWebServerMaxConnections concurrent requests the real ceiling was their product —
+ *  around 2 GB of chunked framing buffers, or 8 GB of inflated gzip output — many times
+ *  what any phone survives. Each per-request limit still applies; this bounds the sum.
+ *
+ *  Sized so that legitimate traffic never approaches it: real uploads stream to disk and
+ *  hold only a read-sized buffer in memory, so only a client deliberately parking large
+ *  in-memory bodies gets close.
+ */
+#define kGCDWebServerMaxTotalInMemoryLength (64 * 1024 * 1024)
+
+/**
  *  Check if a custom logging facility should be used instead.
  */
 
@@ -196,6 +210,43 @@ static inline BOOL GCDWebServerIsValidByteRange(NSRange range) {
 static inline NSError *GCDWebServerMakePosixError(int code) {
     return [NSError errorWithDomain:NSPOSIXErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey: (NSString *)[NSString stringWithUTF8String:strerror(code)]}];
 }
+
+/**
+ *  A share of the process-wide in-memory ceiling, held by whatever is doing the buffering.
+ *
+ *  Deliberately an object: the bytes are returned in -dealloc, so a connection that dies
+ *  mid-body — dropped, reset, timed out — cannot leak budget and permanently shrink what
+ *  the server can serve afterwards. A holder resizes its reservation as its buffer grows.
+ */
+@interface GCDWebServerMemoryReservation : NSObject
+
+/**
+ *  Resizes this reservation. Returns NO when the process-wide ceiling would be exceeded,
+ *  leaving the existing reservation untouched so the caller can fail the request cleanly.
+ *  Shrinking always succeeds.
+ */
+- (BOOL)reserveBytes:(NSUInteger)bytes;
+
+@end
+
+/**
+ *  Current limits. These read the testing overrides below, so consult them rather than the
+ *  kGCDWebServer... constants directly.
+ */
+extern NSUInteger GCDWebServerMaxInMemoryBodyLength(void);
+extern NSUInteger GCDWebServerMaxDecompressedBodyLength(void);
+
+/**
+ *  Shrinks the limits so a test can prove a bound is enforced without moving tens of
+ *  megabytes through the server — which is slow, and under AddressSanitizer is itself
+ *  enough to lose the test runner. Pass 0 for either to restore its default.
+ */
+extern void GCDWebServerSetMemoryLimitsForTesting(NSUInteger perRequest, NSUInteger decompressed, NSUInteger total);
+
+/**
+ *  Bytes currently reserved across all live reservations. For tests and diagnostics.
+ */
+extern NSUInteger GCDWebServerReservedMemoryLength(void);
 
 extern void GCDWebServerInitializeFunctions(void);
 extern NSString *_Nullable GCDWebServerNormalizeHeaderValue(NSString *_Nullable value);

--- a/Sources/GCDWebServer/Core/GCDWebServerRequest.m
+++ b/Sources/GCDWebServer/Core/GCDWebServerRequest.m
@@ -76,6 +76,7 @@ NSString *const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerReque
     z_stream _stream;
     BOOL _finished;
     NSUInteger _totalDecoded;
+    GCDWebServerMemoryReservation *_reservation;
 }
 
 - (BOOL)open:(NSError **)error {
@@ -94,6 +95,7 @@ NSString *const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerReque
         return NO;
     }
 
+    _reservation = [[GCDWebServerMemoryReservation alloc] init];
     return YES;
 }
 
@@ -130,11 +132,24 @@ NSString *const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerReque
         // bomb") cannot balloon the output buffer and exhaust memory. Checked inside
         // the loop, before the next doubling, so we stop growing as soon as the cap
         // is crossed rather than after allocating past it.
-        if (_totalDecoded + length > kGCDWebServerMaxDecompressedBodyLength) {
-            GWS_LOG_ERROR(@"Decompressed request body exceeds the %i byte limit", (int)kGCDWebServerMaxDecompressedBodyLength);
+        if (_totalDecoded + length > GCDWebServerMaxDecompressedBodyLength()) {
+            GWS_LOG_ERROR(@"Decompressed request body exceeds the %lu byte limit", (unsigned long)GCDWebServerMaxDecompressedBodyLength());
 
             if (error) {
                 *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Decompressed request body exceeds maximum size"}];
+            }
+
+            return NO;
+        }
+
+        // This is the worst offender for aggregate memory: the per-request ceiling times
+        // the connection cap is several gigabytes of inflated output. Hold the running
+        // total against the process-wide budget as well.
+        if (![_reservation reserveBytes:(_totalDecoded + length)]) {
+            GWS_LOG_ERROR(@"Refusing to inflate further: the server is already holding its %lu byte in-memory limit across all connections", (unsigned long)kGCDWebServerMaxTotalInMemoryLength);
+
+            if (error) {
+                *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Server is at its total in-memory capacity"}];
             }
 
             return NO;
@@ -154,7 +169,7 @@ NSString *const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerReque
         // cap and be rejected by the check above). Without this clamp a body that
         // inflates to just over the cap first doubles the buffer to twice the cap
         // (128 MB for the 64 MB cap) and commits it before the next check rejects it.
-        NSUInteger maxBufferLength = (NSUInteger)kGCDWebServerMaxDecompressedBodyLength - _totalDecoded + 1;
+        NSUInteger maxBufferLength = GCDWebServerMaxDecompressedBodyLength() - _totalDecoded + 1;
         NSUInteger newBufferLength = 2 * decodedData.length;
         decodedData.length = (newBufferLength < maxBufferLength) ? newBufferLength : maxBufferLength;
     }

--- a/Sources/GCDWebServer/Requests/GCDWebServerDataRequest.m
+++ b/Sources/GCDWebServer/Requests/GCDWebServerDataRequest.m
@@ -38,14 +38,17 @@
 @implementation GCDWebServerDataRequest {
     NSString *_text;
     id _jsonObject;
+    GCDWebServerMemoryReservation *_reservation;
 }
 
 - (BOOL)open:(NSError **)error {
+    _reservation = [[GCDWebServerMemoryReservation alloc] init];
+
     if (self.contentLength != NSUIntegerMax) {
         // Only a capacity hint — -writeData: enforces the real in-memory cap — so clamp
         // it to that cap rather than trusting the attacker-declared Content-Length,
         // which could otherwise request a huge (or failed) up-front allocation.
-        NSUInteger capacity = MIN(self.contentLength, (NSUInteger)kGCDWebServerMaxInMemoryBodyLength);
+        NSUInteger capacity = MIN(self.contentLength, GCDWebServerMaxInMemoryBodyLength());
         _data = [[NSMutableData alloc] initWithCapacity:capacity];
     } else {
         _data = [[NSMutableData alloc] init];
@@ -63,11 +66,25 @@
 }
 
 - (BOOL)writeData:(NSData *)data error:(NSError **)error {
-    if (_data.length + data.length > kGCDWebServerMaxInMemoryBodyLength) {
-        GWS_LOG_ERROR(@"Request body exceeds the %i byte in-memory limit", (int)kGCDWebServerMaxInMemoryBodyLength);
+    NSUInteger total = _data.length + data.length;
+
+    if (total > GCDWebServerMaxInMemoryBodyLength()) {
+        GWS_LOG_ERROR(@"Request body exceeds the %lu byte in-memory limit", (unsigned long)GCDWebServerMaxInMemoryBodyLength());
 
         if (error) {
             *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Request body exceeds maximum in-memory size"}];
+        }
+
+        return NO;
+    }
+
+    // Per-request limits do not compose: this body also has to fit alongside every other
+    // connection's, or a flood of individually-legal requests still exhausts the process.
+    if (![_reservation reserveBytes:total]) {
+        GWS_LOG_ERROR(@"Refusing request body: the server is already holding its %lu byte in-memory limit across all connections", (unsigned long)kGCDWebServerMaxTotalInMemoryLength);
+
+        if (error) {
+            *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Server is at its total in-memory capacity"}];
         }
 
         return NO;

--- a/Sources/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
+++ b/Sources/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
@@ -60,9 +60,23 @@
     NSUInteger argumentBytes;  // Total bytes retained by argument parts so far
     NSUInteger partCount;      // Total completed parts (arguments and files) so far
 }
+// This body's share of the process-wide in-memory ceiling, covering the argument parts it
+// retains. Per-request limits do not compose, so without this a flood of individually-legal
+// bodies still exhausts the process. Working buffers are charged separately, per parser,
+// because they shrink again as parts are consumed.
+@property (nonatomic, readonly) GCDWebServerMemoryReservation *reservation;
 @end
 
 @implementation GCDWebServerMIMEStreamBudget
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _reservation = [[GCDWebServerMemoryReservation alloc] init];
+    }
+
+    return self;
+}
+
 @end
 
 typedef enum {
@@ -151,7 +165,8 @@ static NSData *_dashNewlineData = nil;
     int _tmpFile;
     GCDWebServerMIMEStreamParser *_subParser;
     NSUInteger _depth;  // Nesting level; 0 for the top-level parser, +1 per multipart/mixed
-    GCDWebServerMIMEStreamBudget *_budget;  // Shared with every sub-parser
+    GCDWebServerMIMEStreamBudget *_budget;              // Shared with every sub-parser
+    GCDWebServerMemoryReservation *_workingReservation;  // This parser's own working buffer
 }
 
 + (void)initialize {
@@ -200,6 +215,7 @@ static NSData *_dashNewlineData = nil;
         _state = kParserState_Start;
         _depth = depth;
         _budget = budget;
+        _workingReservation = [[GCDWebServerMemoryReservation alloc] init];
     }
 
     return self;
@@ -368,12 +384,15 @@ static NSData *_dashNewlineData = nil;
                         }
 
                         _tmpPath = nil;
-                    } else if (_budget->argumentBytes + dataLength > (NSUInteger)kGCDWebServerMaxInMemoryBodyLength) {
+                    } else if (_budget->argumentBytes + dataLength > GCDWebServerMaxInMemoryBodyLength()) {
                         // Every argument part stays in memory for the life of the request, so the
                         // working-buffer cap in -appendBytes: does not bound them: a body of many
                         // individually-legal parts would otherwise grow without limit. File parts
                         // are drained to disk and so are governed by the part count instead.
-                        GWS_LOG_ERROR(@"Multipart form arguments retained in memory exceed the %i byte limit", (int)kGCDWebServerMaxInMemoryBodyLength);
+                        GWS_LOG_ERROR(@"Multipart form arguments retained in memory exceed the %lu byte limit", (unsigned long)GCDWebServerMaxInMemoryBodyLength());
+                        success = NO;
+                    } else if (![_budget.reservation reserveBytes:(_budget->argumentBytes + dataLength)]) {
+                        GWS_LOG_ERROR(@"Refusing multipart argument: the server is already holding its %lu byte in-memory limit across all connections", (unsigned long)kGCDWebServerMaxTotalInMemoryLength);
                         success = NO;
                     } else {
                         _budget->partCount += 1;
@@ -432,13 +451,22 @@ static NSData *_dashNewlineData = nil;
     // argument part, or a malformed stream whose content contains the boundary token
     // without the trailing CRLF (which otherwise wedges the parser and grows the
     // buffer without bound).
-    if (_data.length + length > kGCDWebServerMaxInMemoryBodyLength) {
-        GWS_LOG_ERROR(@"Multipart form data buffered in memory exceeds the %i byte limit", (int)kGCDWebServerMaxInMemoryBodyLength);
+    if (_data.length + length > GCDWebServerMaxInMemoryBodyLength()) {
+        GWS_LOG_ERROR(@"Multipart form data buffered in memory exceeds the %lu byte limit", (unsigned long)GCDWebServerMaxInMemoryBodyLength());
+        return NO;
+    }
+
+    if (![_workingReservation reserveBytes:(_data.length + length)]) {
+        GWS_LOG_ERROR(@"Refusing multipart data: the server is already holding its %lu byte in-memory limit across all connections", (unsigned long)kGCDWebServerMaxTotalInMemoryLength);
         return NO;
     }
 
     [_data appendBytes:bytes length:length];
-    return [self _parseData];
+    BOOL success = [self _parseData];
+    // -_parseData drains whatever it consumed, so give the difference straight back rather
+    // than letting this parser's reservation ratchet upward across a long body.
+    [_workingReservation reserveBytes:_data.length];
+    return success;
 }
 
 - (BOOL)isAtEnd {


### PR DESCRIPTION
Every in-memory limit was per-request, and per-request limits do not compose. With the 128-connection cap the real ceiling was their product: around 2 GB of chunked framing buffers, or 8 GB of inflated gzip output — many times what a phone survives, so a flood of individually-legal requests still killed the process. This is the same bug class already fixed twice on this branch (multipart argument bodies, then multipart part-headers); rather than wait for a third instance, close the general case.

kGCDWebServerMaxTotalInMemoryLength bounds the sum across all live connections. Everything that holds request data in memory now takes a reservation and resizes it as its buffer grows: data-request bodies, inflated gzip output, retained multipart arguments, each multipart parser's working buffer, and the chunked framing buffer. The per-request limits still apply on top.

The reservation is an object on purpose — its bytes are returned in -dealloc, so a connection dying mid-body cannot leak budget and permanently shrink what the server can serve afterwards. Buffers that rise and fall give bytes back as the parser drains them. Verified under load: 24 concurrent chunked bodies peaked at exactly the ceiling and never above it, and the reserved total returned to zero once they finished.

Making the limits injectable also fixes the long-standing flake in testChunkedTransferRejectsUnterminatedSizeLine. It had to push 16 MB through the server to prove the framing scan is bounded, which under AddressSanitizer lost the test runner in roughly half of full-suite runs — and a crashed runner reports "0 failures", so it read as a pass. It now proves the same property against a 64 KB bound. Ten consecutive full-suite runs pass with nothing skipped.

Known imprecision: exhausting the budget surfaces as 500, since the body-writer protocol reports failure as a plain BOOL. A 503 would be more honest, but threading a status code through that protocol is not worth destabilising the body-read path for.