### PR TITLE
Stop a client-side TCP reset from killing the whole process

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -517,6 +517,51 @@ static NSString* MakeTempDirectory(void) {
 // A client that connects and then goes silent while the server is waiting on
 // socket I/O must be disconnected once the idle timeout elapses, instead of
 // holding a connection slot (and file descriptor) forever.
+// A peer that resets the connection in the window between accept(2) and the server's
+// setsockopt() makes SO_NOSIGPIPE fail with EINVAL, leaving that descriptor able to raise
+// SIGPIPE — whose default disposition terminates the host application. An unauthenticated
+// client can hit the window in a handful of attempts by connecting and closing abortively,
+// without sending a single byte.
+//
+// Note the failure mode: without the fix this does not report an assertion failure, it kills
+// the test runner outright. xcodebuild surfaces that as a failed suite with a truncated
+// "Executed N tests" count rather than a named failing test, so read the count, not the
+// failure number.
+- (void)testAbortiveClientResetsDoNotKillTheProcess {
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addDefaultHandlerForMethod:@"GET"
+                          requestClass:[WSKRequest class]
+                          processBlock:^WSKResponse*(WSKRequest* request) {
+                              return [WSKDataResponse responseWithText:@"alive"];
+                          }];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // Two shapes, because the option can fail either with a request already sent or with
+    // nothing sent at all — the reset only has to land in the accept window.
+    for (int round = 0; round < 2; round++) {
+        for (int i = 0; i < 150; i++) {
+            int fd = ConnectToLocalhostPort(server.port);
+            if (fd < 0) {
+                continue;
+            }
+            if (round == 0) {
+                const char* request = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+                send(fd, request, strlen(request), 0);
+            }
+            struct linger abortive = {1, 0};  // RST rather than FIN on close
+            setsockopt(fd, SOL_SOCKET, SO_LINGER, &abortive, sizeof(abortive));
+            close(fd);
+        }
+    }
+
+    // Reaching here at all is most of the assertion; this proves the listener also still works.
+    NSString* reply = SendRawRequest(server.port, @"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([reply containsString:@"alive"], @"server stopped serving after abortive resets: %@", reply);
+
+    [server stop];
+}
+
 - (void)testConnectionIdleTimeoutClosesSilentConnection {
     WSKWebServer* server = [[WSKWebServer alloc] init];
     [server addDefaultHandlerForMethod:@"GET"

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -689,8 +689,25 @@ static inline NSString *_EncodeBase64(NSString *string) {
                 NSData *localAddress = [NSData dataWithBytes:&localSockAddr length:localAddrLen];
                 WSK_DCHECK((!isIPv6 && localSockAddr.ss_family == AF_INET) || (isIPv6 && localSockAddr.ss_family == AF_INET6));
 
+                // This must be checked rather than assumed. If the peer's RST has already
+                // reached the kernel by the time this runs, Darwin fails the option with
+                // EINVAL and leaves SO_NOSIGPIPE *off* — and the first write to that
+                // descriptor then raises SIGPIPE, whose default disposition terminates the
+                // whole host application. Neither this library nor Foundation changes that
+                // disposition, so an unauthenticated peer that connects and resets in a loop
+                // kills the process within seconds. A peer that has already reset has nothing
+                // to be served, so drop it here, before a connection slot is reserved.
+                //
+                // Deliberately not solved with signal(SIGPIPE, SIG_IGN): that mutates
+                // process-wide state belonging to the host app, and would still leave this
+                // descriptor without the option actually set.
                 int noSigPipe = 1;
-                setsockopt(socket, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe));  // Make sure this socket cannot generate SIG_PIPE
+
+                if (setsockopt(socket, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe)) != 0) {
+                    WSK_LOG_ERROR(@"Dropping accepted %s socket: SO_NOSIGPIPE could not be set (%s (%i)); the peer is already gone", isIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+                    close(socket);
+                    return;
+                }
 
                 // Cap the number of simultaneous connections so a flood of (e.g. idle)
                 // connections cannot exhaust file descriptors — especially important on


### PR DESCRIPTION
**Critical.** An unauthenticated peer can terminate the server process in under a second, without sending a byte.

## The bug

`WSKWebServer.m` — the accept handler sets `SO_NOSIGPIPE` and never checks the result:

```objc
int noSigPipe = 1;
setsockopt(socket, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe));
```

If the peer's RST reaches the kernel before that line runs, Darwin fails it with `EINVAL` and leaves the option **off**. The connection is served anyway, and the first write raises `SIGPIPE` — whose default disposition terminates the host application. Neither this library nor Foundation changes that disposition.

## Measured on this checkout

| | |
|---|---|
| 400 graceful FIN closes | alive |
| 13 abortive RSTs (`SO_LINGER {1,0}`) with a request | **dead, exit 141** (128 + SIGPIPE) |
| 13 abortive RSTs sending **nothing at all** | **dead, exit 141** |

Reproduced in `webServer`, `webUploader` and `webDAV` modes. Instrumented, the `setsockopt` genuinely fails **72–94 times per 400 connections** under that load — not a narrow race.

## Not introduced by the renames

`git log -S SO_NOSIGPIPE` puts the line in the original file move from upstream. Five audit passes missed it because they were all reading the *request* path, and this sits below it.

## The fix

Drop the socket, before a connection slot is reserved — an already-reset peer has nothing to be served. Same shape as the `getsockname` guard four lines above.

Deliberately **not** `signal(SIGPIPE, SIG_IGN)`: that mutates process-wide state the host app owns, and would still leave the descriptor without the option set.

## Note how the test fails

It asserts *survival*, so without the fix it kills the test runner rather than reporting an assertion. xcodebuild surfaces that as `Executed 0 tests` + `** TEST FAILED **`, not a named failure. Verified in both directions:

- with the fix: passes, 79/79 suite green
- without: `Restarting after unexpected exit, crash` → `Executed 0 tests` → `TEST FAILED`