### PR TITLE
Stop the base-path handler serving the dotfiles its own listing hides

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -2014,6 +2014,63 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 // only stripped ".." textually, and lstat/O_NOFOLLOW refuse a symlink solely as the *final*
 // component. Any symlinked directory under the served root therefore served whatever it
 // pointed at.
+// -addGETHandlerForBasePath: was the one file-vending path with no hidden-item concept,
+// while its own directory listing skips every dot-entry — so the browsable index advertised
+// a smaller tree than the one actually served, and an operator checking in a browser would
+// never notice. Both subclasses already refuse hidden items.
+- (void)testBasePathHandlerRefusesHiddenItems {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    XCTAssertTrue([fm createDirectoryAtPath:[root stringByAppendingPathComponent:@".git"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"url = https://user:TOKEN@example.com/x.git" writeToFile:[root stringByAppendingPathComponent:@".git/config"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"SECRET=1" writeToFile:[root stringByAppendingPathComponent:@".env"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"public" writeToFile:[root stringByAppendingPathComponent:@"build.ipa"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    XCTAssertTrue([SendRawRequest(server.port, @"GET /build.ipa HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"200"], @"ordinary files must still be served");
+
+    // A dotfile at the root, and a file *inside* a dot-directory — the latter is where the
+    // interesting secrets live, so the check has to walk every component, not just the leaf.
+    NSString* env = SendRawRequest(server.port, @"GET /.env HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([env containsString:@"404"], @"a dotfile must not be served: %@", [env substringToIndex:MIN((NSUInteger)40, env.length)]);
+    XCTAssertFalse([env containsString:@"SECRET"], @"the dotfile's contents leaked");
+
+    NSString* git = SendRawRequest(server.port, @"GET /.git/config HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([git containsString:@"404"], @"a file inside a dot-directory must not be served: %@", [git substringToIndex:MIN((NSUInteger)40, git.length)]);
+    XCTAssertFalse([git containsString:@"TOKEN"], @"the credential leaked");
+
+    [server stop];
+    [fm removeItemAtPath:root error:NULL];
+}
+
+// The listing HTML-escapes each entry's link *text* but built the href from percent-encoding
+// alone. URLPathAllowedCharacterSet leaves "&" and ";" intact and an HTML parser decodes named
+// character references inside attribute values, so "javascript&colon;alert(1)" became a live
+// javascript: URL in the server's own origin.
+- (void)testDirectoryListingEscapesHrefEntities {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    NSString* hostile = @"javascript&colon;alert(1)";
+    XCTAssertTrue([@"x" writeToFile:[root stringByAppendingPathComponent:hostile] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:NO];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* listing = SendRawRequest(server.port, @"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertNotNil(listing);
+    XCTAssertTrue([listing containsString:@"&amp;colon;"], @"href entity not escaped: %@", listing);
+    XCTAssertFalse([listing containsString:@"\"javascript&colon;"], @"a raw entity survived into the href attribute: %@", listing);
+
+    [server stop];
+    [fm removeItemAtPath:root error:NULL];
+}
+
 - (void)testBasePathHandlerRefusesSymlinkEscape {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* root = MakeTempDirectory();

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1516,7 +1516,15 @@ static NSString *_EscapeHTMLString(NSString *string) {
                 continue;
             }
 
-            NSString *const escapedFile = [entry stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
+            // Percent-encoding alone is not enough for an attribute value. URLPathAllowedCharacterSet
+            // leaves "&" and ";" intact, and an HTML parser decodes named character references
+            // inside attributes — so a file named "javascript&colon;alert(1)" was emitted
+            // verbatim and the browser read the href as "javascript:alert(1)". The link *text*
+            // has been HTML-escaped since the fourth pass; the attribute never was, and the two
+            // halves disagreed about whether filenames are hostile. Percent-encoding has already
+            // removed <, >, " and ', so this only turns "&" into "&amp;" — which is exactly what
+            // defeats the entity.
+            NSString *const escapedFile = _EscapeHTMLString([entry stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]]);
             WSK_DCHECK(escapedFile);
 
             NSString *const escapedEntry = _EscapeHTMLString(entry);  // The filename is reflected into HTML text; escape it to prevent stored XSS via crafted names.
@@ -1551,7 +1559,23 @@ static NSString *_EscapeHTMLString(NSString *string) {
             }
             processBlock:^WSKResponse *(WSKRequest *request) {
                 WSKResponse *response = nil;
-                NSString *filePath = [directoryPath stringByAppendingPathComponent:WSKNormalizePath([request.path substringFromIndex:basePath.length])];
+                NSString *const relativePath = WSKNormalizePath([request.path substringFromIndex:basePath.length]);
+
+                // The directory listing below deliberately omits every dot-entry, so without
+                // this the browsable index actively advertises a *smaller* tree than the one
+                // being served: ".git/config", ".env" and friends stayed directly fetchable
+                // and an operator checking in a browser would never see them. Both subclasses
+                // that vend files already refuse hidden items; this was the one file-serving
+                // path in the library with no such concept. Every component is tested, not
+                // just the leaf, because the interesting secrets live *inside* a dot-directory.
+                for (NSString *component in [relativePath componentsSeparatedByString:@"/"]) {
+                    if ([component hasPrefix:@"."]) {
+                        WSK_LOG_WARNING(@"Refusing to serve \"%@\": \"%@\" is a hidden item", relativePath, component);
+                        return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
+                    }
+                }
+
+                NSString *filePath = [directoryPath stringByAppendingPathComponent:relativePath];
                 // Stripping ".." textually is not containment: -attributesOfItemAtPath: uses
                 // lstat, which only refuses a symlink as the *final* component, and O_NOFOLLOW
                 // in the file response does the same — so any symlinked directory anywhere


### PR DESCRIPTION
Two defects in `-addGETHandlerForBasePath:`, the handler **Puck runs** (`-mode webServer` registers exactly this one).

## 1. Hidden items — the listing lies about what is served

The directory listing deliberately skips every dot-entry. The handler that serves files had no hidden-item concept at all. So the browsable index advertises a *smaller* tree than the one being served.

Verified before the fix, pointing a server at a directory containing a `.git` checkout:

```
listing shows:      build.ipa, sub/
GET /build.ipa   -> 200
GET /.env        -> 200          <-- not in the listing
GET /.git/config -> 200          <-- not in the listing
                    url = https://user:SECRETTOKEN@github.com/x/y.git
```

An operator who points this at a build directory and checks in a browser that only builds are listed has no way to see that. Both subclasses already refuse hidden items — `WSKWebUploader` tests `allowHiddenItems` at 8 sites, `WSKWebDAVServer` at 10, and passes three and four each fixed this bug class for one of them. The base class was never given the concept.

Every path component is tested, not just the leaf, because the interesting secrets live *inside* a dot-directory rather than being one.

## 2. Directory-listing hrefs were never HTML-escaped

The link *text* has been escaped since the fourth pass; the attribute was built from percent-encoding alone. `URLPathAllowedCharacterSet` leaves `&` and `;` intact, and an HTML parser decodes named character references inside attribute values — so a file named `javascript&colon;alert(1)` (a legal APFS name) was emitted verbatim and the browser read the href as `javascript:alert(1)`, in the server's own origin.

Percent-encoding has already removed `<`, `>`, `"` and `'`, so escaping the href only converts `&` → `&amp;` — exactly what defeats the entity.

## Verification

Both tests were run against the unfixed source and fail there — the first reporting *"the credential leaked"*, the second that a raw entity reached the href attribute. Suite green at 80 tests, all 8 trace suites, all targets.