### PR TITLE
Stop weak date validators producing partial and not-modified responses

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1869,6 +1869,96 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 // "Send me this range only if the representation is unchanged". Ignoring If-Range meant a
 // resumed download spliced bytes from two versions of a file together under a 206 that
 // asserted they belonged to the same one.
+// If-Range requires a strong validator. st_mtime has one-second resolution, so a file
+// modified within the current second could change again without the timestamp moving — the
+// case where a build is rewritten under a client that is downloading it. RFC 9110 8.8.2.2
+// lets the origin treat the timestamp as strong only once it is at least a second old.
+//
+// Both directions are asserted here, because the obvious "just never honour a date" is a real
+// compatibility regression: macOS Finder's WebDAV client resumes with a date and nothing else
+// (Tests/WebDAV-Finder/059), so refusing outright turns every Finder resume into a full
+// re-download.
+- (void)testIfRangeDateIsHonouredOnlyWhenTheTimestampIsStrong {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    NSString* path = [root stringByAppendingPathComponent:@"build.bin"];
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // (a) Settled file: the timestamp is at least a second old, so it is strong and a resume
+    // must still work. This is the Finder case.
+    XCTAssertTrue([@"AAAAAAAAAAAAAAAAAAAA" writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    NSDate* settled = [NSDate dateWithTimeIntervalSince1970:1400000000];
+    XCTAssertTrue([fm setAttributes:@{NSFileModificationDate : settled} ofItemAtPath:path error:NULL]);
+    NSString* settledRequest = [NSString stringWithFormat:@"GET /build.bin HTTP/1.1\r\nHost: localhost\r\nRange: bytes=0-4\r\nIf-Range: %@\r\n\r\n", WSKFormatRFC822(settled)];
+    XCTAssertTrue([SendRawRequest(server.port, settledRequest) hasPrefix:@"HTTP/1.1 206"], @"a settled timestamp must still allow a resume");
+
+    // (b) Just-written file: the timestamp is inside the current second, so it is weak and a
+    // range must NOT be served from it — the file could be rewritten again without the
+    // timestamp moving, which splices two builds together under a 206 that claims otherwise.
+    // The write and the request have to land in the same wall-clock second for that to be the
+    // regime under test, so a run that straddles a second boundary is retried rather than
+    // asserted on — otherwise this flakes roughly once in a few hundred runs.
+    NSString* fresh = nil;
+    for (NSUInteger attempt = 0; attempt < 5; attempt++) {
+        time_t const before = time(NULL);
+        XCTAssertTrue([@"BBBBBBBBBBBBBBBBBBBB" writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        NSDate* justNow = [[fm attributesOfItemAtPath:path error:NULL] fileModificationDate];
+        NSString* freshRequest = [NSString stringWithFormat:@"GET /build.bin HTTP/1.1\r\nHost: localhost\r\nRange: bytes=0-4\r\nIf-Range: %@\r\n\r\n", WSKFormatRFC822(justNow)];
+        fresh = SendRawRequest(server.port, freshRequest);
+        if (time(NULL) == before) {
+            break;
+        }
+    }
+    XCTAssertTrue([fresh hasPrefix:@"HTTP/1.1 200"], @"a timestamp inside the current second is weak and must not yield a partial response: %@", [fresh substringToIndex:MIN((NSUInteger)40, fresh.length)]);
+    XCTAssertTrue([fresh containsString:@"BBBBBBBBBBBBBBBBBBBB"], @"the whole current representation must be served");
+
+    [server stop];
+    [fm removeItemAtPath:root error:NULL];
+}
+
+// If-Modified-Since answered 304 whenever mtime was equal *or older*. Restoring a previous
+// build then pins a date-only client on stale bytes forever: it is told 304, keeps the old
+// body, and adopts the current ETag from that 304 — so every later revalidation matches too.
+- (void)testStaleDateDoesNotPinAClientOnAnOlderRepresentation {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    NSString* path = [root stringByAppendingPathComponent:@"build.bin"];
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:NO];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // The client holds build B, dated later. The server is rolled back to build A, dated earlier.
+    NSDate* clientHolds = [NSDate dateWithTimeIntervalSince1970:1500000000];
+    XCTAssertTrue([@"ROLLED-BACK-BUILD-A" writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([fm setAttributes:@{NSFileModificationDate : [NSDate dateWithTimeIntervalSince1970:1400000000]} ofItemAtPath:path error:NULL]);
+
+    NSString* stale = [NSString stringWithFormat:@"GET /build.bin HTTP/1.1\r\nHost: localhost\r\nIf-Modified-Since: %@\r\n\r\n", WSKFormatRFC822(clientHolds)];
+    NSString* reply = SendRawRequest(server.port, stale);
+    XCTAssertFalse([reply containsString:@"304"], @"an older representation must not be reported unchanged: %@", [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+    XCTAssertTrue([reply containsString:@"ROLLED-BACK-BUILD-A"], @"the current bytes must be served: %@", reply);
+
+    // A future date must not validate anything either.
+    NSString* future = [NSString stringWithFormat:@"GET /build.bin HTTP/1.1\r\nHost: localhost\r\nIf-Modified-Since: %@\r\n\r\n", WSKFormatRFC822([NSDate dateWithTimeIntervalSince1970:4000000000])];
+    XCTAssertFalse([SendRawRequest(server.port, future) containsString:@"304"], @"a future If-Modified-Since must not validate");
+
+    // The ordinary unchanged-file revalidation must still work, or this is a cache regression.
+    NSString* first = SendRawRequest(server.port, @"GET /build.bin HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    NSRange r = [first rangeOfString:@"last-modified: " options:NSCaseInsensitiveSearch];
+    XCTAssertNotEqual(r.location, (NSUInteger)NSNotFound, @"%@", first);
+    NSString* echoed = [[[first substringFromIndex:(r.location + r.length)] componentsSeparatedByString:@"\r\n"] firstObject];
+    NSString* same = [NSString stringWithFormat:@"GET /build.bin HTTP/1.1\r\nHost: localhost\r\nIf-Modified-Since: %@\r\n\r\n", echoed];
+    XCTAssertTrue([SendRawRequest(server.port, same) containsString:@"304"], @"echoing back the served Last-Modified must still revalidate");
+
+    [server stop];
+    [fm removeItemAtPath:root error:NULL];
+}
+
 - (void)testIfRangeMismatchServesTheWholeRepresentation {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* root = MakeTempDirectory();
@@ -1891,14 +1981,16 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     NSString* tail = [full substringFromIndex:(etagRange.location + etagRange.length)];
     NSString* etag = [[tail componentsSeparatedByString:@"\r\n"] firstObject];
 
+    // Assert on the status line, not containsString:@"206" — the ETag embeds the inode, whose
+    // digits contain "206" often enough to make that assertion flaky in both directions.
     NSString* matching = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /f.txt HTTP/1.1\r\nHost: localhost\r\nRange: bytes=0-4\r\nIf-Range: %@\r\n\r\n", etag]);
-    XCTAssertTrue([matching containsString:@"206"], @"a matching If-Range must still serve the range: %@", matching);
+    XCTAssertTrue([matching hasPrefix:@"HTTP/1.1 206"], @"a matching If-Range must still serve the range: %@", matching);
 
     // ...but a stale one must serve the entire representation, not a slice of a file the
     // client has never seen.
     NSString* stale = SendRawRequest(server.port, @"GET /f.txt HTTP/1.1\r\nHost: localhost\r\nRange: bytes=0-4\r\nIf-Range: \"0/0/0\"\r\n\r\n");
     XCTAssertNotNil(stale);
-    XCTAssertFalse([stale containsString:@"206"], @"a stale If-Range must not produce a partial response: %@", [stale substringToIndex:MIN((NSUInteger)40, stale.length)]);
+    XCTAssertTrue([stale hasPrefix:@"HTTP/1.1 200"], @"a stale If-Range must not produce a partial response: %@", [stale substringToIndex:MIN((NSUInteger)40, stale.length)]);
     XCTAssertTrue([stale containsString:@"AAAAAAAAAAAAAAAAAAAA"], @"the whole representation must be served: %@", stale);
 
     [server stop];

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -1632,8 +1632,22 @@ static inline BOOL _CompareResources(NSString *responseETag, NSString *requestET
         return [requestETag isEqualToString:@"*"] || _ETagMatchesIfNoneMatch(responseETag, requestETag);
     }
 
+    // Exact equality, not "not newer". The old comparison answered 304 whenever the file's
+    // mtime was equal *or older*, which pins a date-only client on stale bytes permanently:
+    // restore a previous build (or rsync -a / cp -p / touch -t from an older source) and the
+    // client revalidating with the newer representation's Last-Modified is told 304, keeps the
+    // body it has, and — per RFC 9111 §4.3.4 — adopts the *current* ETag and Last-Modified from
+    // that 304. Its next revalidation therefore matches on the ETag too, so no request will
+    // ever dislodge it. It also answered 304 for an If-Modified-Since in the future, i.e. for a
+    // resource the client demonstrably does not hold.
+    //
+    // Safe to tighten here specifically because _NSDateFromTimeSpec truncates the response's
+    // Last-Modified to whole seconds (see the comment on it), and WSKParseRFC822 parses at the
+    // same precision, so a client echoing back the value it was given still compares equal and
+    // ordinary unchanged-file revalidation keeps working. This is also nginx's default
+    // ("if_modified_since exact"), so it is not an unusual reading.
     if (requestLastModified && responseLastModified) {
-        return [responseLastModified compare:requestLastModified] != NSOrderedDescending;
+        return [responseLastModified compare:requestLastModified] == NSOrderedSame;
     }
 
     return NO;

--- a/Sources/WebServerKit/Responses/WSKFileResponse.m
+++ b/Sources/WebServerKit/Responses/WSKFileResponse.m
@@ -210,10 +210,27 @@ static NSString *_EscapeExtValue(NSString *string) {
         if ([trimmedIfRange hasPrefix:@"\""]) {
             matches = [trimmedIfRange isEqualToString:entityTag];
         } else if (![trimmedIfRange hasPrefix:@"W/"]) {
+            // A date is only usable here if it is a *strong* validator, which If-Range requires
+            // (RFC 9110 §13.1.5). st_mtime has one-second resolution, so a file modified within
+            // the current second could be modified again inside that same second without the
+            // timestamp changing — exactly the case where a build is rewritten under a client
+            // that is downloading it, and the server would then splice the tail of one
+            // representation onto the prefix of another and assert with a 206 that they belong
+            // together. §8.8.2.2 gives the deduction that makes it strong: the origin may treat
+            // the timestamp as strong once it is at least one second in the past, because no
+            // further change can land in that second any more.
+            //
+            // Not simply refused, because real clients resume this way: macOS Finder's WebDAV
+            // client sends "If-Range: <HTTP-date>" and nothing else (see
+            // Tests/WebDAV-Finder/059), so ignoring dates outright turns every Finder resume
+            // into a full re-download. What remains unclosed is a replacement that *preserves*
+            // mtime (rsync -a, cp -p, tar -x): no date-based scheme can detect that, here or in
+            // any other server. A client that has this server's strong ETag — which this
+            // initializer always sets — is unaffected either way, since the branch above
+            // decides it.
             NSDate *const ifRangeDate = WSKParseRFC822(trimmedIfRange);
-            // RFC822 has one-second resolution, so compare at that granularity rather than
-            // against the nanosecond mtime, which would never be equal.
-            matches = ifRangeDate && ((long)ifRangeDate.timeIntervalSince1970 == (long)info.st_mtimespec.tv_sec);
+            BOOL const timestampIsStrong = (time(NULL) - info.st_mtimespec.tv_sec) >= 1;
+            matches = ifRangeDate && timestampIsStrong && ((long)ifRangeDate.timeIntervalSince1970 == (long)info.st_mtimespec.tv_sec);
         }
 
         if (!matches) {


### PR DESCRIPTION
Two conditional-validator defects, both of which answer a client about a representation it
does not hold. Both matter most for the long-lived build-vending deployment, where the
served file is rewritten under clients that are still downloading it.

### `If-Range` honoured a date unconditionally

`st_mtime` has one-second resolution, so a file modified within the current second can be
modified *again* inside that same second without the timestamp moving — which is why
`If-Range` requires a **strong** validator (RFC 9110 §13.1.5). A build rewritten inside one
wall-clock second read as "unchanged", so the server spliced the tail of one representation
onto the prefix of another and asserted with a `206` that they belonged together. It is
silent: `Content-Length` agrees with `Content-Range`, so nothing downstream notices.

**A first attempt at this refused dates outright** and honoured only the entity-tag form.
That breaks real clients — the recorded macOS Finder session in `Tests/WebDAV-Finder/059`
resumes with `If-Range: <HTTP-date>` and no entity tag, so every Finder resume would have
become a full re-download. The trace suite caught it.

What ships instead is the deduction RFC 9110 §8.8.2.2 provides for exactly this case: the
origin may treat the timestamp as strong once it is **at least one second in the past**,
because no further change can land in that second any more. Dates older than a second still
resume; a date inside the current second does not.

Not closed by this (or by any date-based scheme, in any server): a replacement that
*preserves* mtime — `rsync -a`, `cp -p`, `tar -x`. A client holding this server's strong
ETag is unaffected either way.

### `If-Modified-Since` answered `304` for equal *or older* mtimes

Restoring a previous build pinned a date-only client permanently: told `304`, it keeps the
stale body and — per RFC 9111 §4.3.4 — adopts the *current* `ETag`/`Last-Modified` from that
`304`, so its next revalidation matches on the ETag too and no request ever dislodges it. A
*future* `If-Modified-Since` validated everything.

Now requires exact equality, which is safe because `_NSDateFromTimeSpec` truncates the
response's `Last-Modified` to whole seconds and `WSKParseRFC822` parses at the same
precision — echoing back the served value still revalidates (asserted). This is nginx's
default too (`if_modified_since exact`).

### Verification

Both tests were run against the unfixed source and fail there on the intended assertion:

| Test | On unfixed `main` |
|---|---|
| `testIfRangeDateIsHonouredOnlyWhenTheTimestampIsStrong` | `206 Partial Content` carrying the wrong build's bytes |
| `testStaleDateDoesNotPinAClientOnAnOlderRepresentation` | `304 Not Modified` for a rolled-back file, and for a date in 2096 |

The If-Range test writes and requests inside one wall-clock second and retries if it
straddles a boundary, so it measures the regime it claims to rather than racing the clock.

Full harness green: **83 tests, 0 failures**, all 8 trace suites, Release builds for all
three platforms, `swift build`.

Also fixes a latent flake in the pre-existing If-Range test, which asserted on
`containsString:@"206"` — the ETag embeds the inode, whose digits contain `206` often enough
to misfire in both directions. It now anchors on the status line.
