### PR TITLE
Stop the uploader handing out SSE channels and its own page frame-free

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -212,6 +212,43 @@ static NSString* SendRawDataRequest(NSUInteger port, NSData* request) {
     return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 
+// As SendRawRequest, but for an endpoint whose response is not meant to end: an accepted SSE
+// stream is held open deliberately, so reading to EOF costs the socket's whole timeout on
+// every *successful* assertion. Returns as soon as `marker` arrives (the fast path), when the
+// server closes, or at the deadline — so only a genuine failure waits.
+static NSString* SendRawRequestUntilMarker(NSUInteger port, NSString* request, NSString* marker, NSTimeInterval seconds) {
+    int fd = ConnectToLocalhostPort(port);
+    if (fd < 0) {
+        return nil;
+    }
+    const char* bytes = [request UTF8String];
+    send(fd, bytes, strlen(bytes), 0);
+
+    struct timeval tv = {0, 200000};  // Poll; the deadline below is what actually bounds this.
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    NSMutableData* data = [NSMutableData data];
+    NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:seconds];
+    char buffer[4096];
+
+    while ([deadline timeIntervalSinceNow] > 0) {
+        ssize_t result = recv(fd, buffer, sizeof(buffer), 0);
+        if (result > 0) {
+            [data appendBytes:buffer length:(NSUInteger)result];
+            NSString* soFar = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            if ((marker == nil) || [soFar containsString:marker]) {
+                break;
+            }
+        } else if (result == 0) {
+            break;  // Server closed: what we have is the whole reply.
+        } else if ((errno != EAGAIN) && (errno != EWOULDBLOCK)) {
+            break;
+        }
+    }
+    close(fd);
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
 // Descriptors currently open by this process. Used to prove that sustained serving does not
 // leak them: on a server that lives for weeks, a descriptor leaked once per request is the
 // difference between working and hitting the process limit.
@@ -1365,6 +1402,110 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     NSString* allowed = deleteFolder(@"Ordinary");
     XCTAssertFalse([allowed containsString:@"403"], @"a .DS_Store must not make an ordinary folder undeletable, got: %@", allowed);
     XCTAssertFalse([fm fileExistsAtPath:ordinary], @"the deletable folder was not removed: %@", allowed);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// An SSE stream is only ever released when the client that is reading it goes away. A HEAD
+// mapped to GET has no reader at all — the connection layer discards the body unsent — so the
+// channel the handler registered was held by nobody and freed only by the heartbeat reaper,
+// two ticks (~30s) later. That made sixteen HEADs a complete denial of live updates for every
+// real client, and unusually cheap to sustain: each request *completes*, so the sender holds
+// no connection slot and can repeat the burst every 30s from anywhere on the network.
+// Measured before the fix: 16 HEADs, then a genuine EventSource is refused for 30s.
+- (void)testHEADOnEventsDoesNotConsumeSSEChannels {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+    NSString* host = [NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port];
+    NSString* sseHeaders = @"Accept: text/event-stream\r\nSec-Fetch-Dest: empty\r\nSec-Fetch-Mode: cors\r\nSec-Fetch-Site: same-origin\r\n";
+
+    // "retry: 30000" (refused, backing the client off) has "retry: 3000" (accepted) as a
+    // prefix, so the accepted marker is matched including its terminator.
+    NSString* const acceptedMarker = @"retry: 3000\n\n";
+    NSString* const refusedMarker = @"retry: 30000";
+
+    // kMaxSSEChannels is 16: enough HEADs to have exhausted every slot.
+    for (NSUInteger i = 0; i < 16; i++) {
+        SendRawRequest(server.port, [NSString stringWithFormat:@"HEAD /events HTTP/1.1\r\nHost: %@\r\n%@\r\n", host, sseHeaders]);
+    }
+
+    NSString* granted = SendRawRequestUntilMarker(server.port, [NSString stringWithFormat:@"GET /events HTTP/1.1\r\nHost: %@\r\n%@\r\n", host, sseHeaders], acceptedMarker, 5.0);
+    XCTAssertFalse([granted containsString:refusedMarker], @"16 HEADs exhausted the SSE channels, denying a real client: %@", granted);
+    XCTAssertTrue([granted containsString:acceptedMarker], @"a genuine EventSource must still be given a stream: %@", granted);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// The uploader's bundle contains index.html, and the base-path handler serves that bundle at
+// "/", so "/index.html" returned the raw template — the same UI, with none of the framing
+// headers the "/" handler sets. Framing that path instead of "/" therefore defeated the
+// clickjacking defence outright, on a UI whose one-click buttons delete and move files.
+- (void)testUploaderTemplatePathCannotBypassFramingHeaders {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+    NSString* host = [NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port];
+
+    NSString* (^get)(NSString*) = ^(NSString* path) {
+        return SendRawRequest(server.port, [NSString stringWithFormat:@"GET %@ HTTP/1.1\r\nHost: %@\r\n\r\n", path, host]);
+    };
+
+    for (NSString* path in @[ @"/", @"/index.html" ]) {
+        NSString* reply = get(path);
+        XCTAssertTrue([reply containsString:@"X-Frame-Options: DENY"], @"\"%@\" is framable: %@", path, reply);
+        XCTAssertTrue([reply containsString:@"frame-ancestors 'none'"], @"\"%@\" has no frame-ancestors: %@", path, reply);
+        XCTAssertTrue([reply containsString:@"X-Content-Type-Options: nosniff"], @"\"%@\" may be sniffed: %@", path, reply);
+    }
+
+    // No spelling may reach the template. Excluding it by path is not enough — the base path
+    // handler normalizes, so the last two here still reached the raw file when the fix was an
+    // exact-path alias sitting in front of it. The unsubstituted placeholder is what identifies
+    // the template, independently of which headers happen to be on the reply.
+    for (NSString* path in @[ @"/", @"/index.html", @"/INDEX.HTML", @"/./index.html", @"/x/../index.html" ]) {
+        XCTAssertFalse([get(path) containsString:@"%device%"], @"\"%@\" served the raw template", path);
+    }
+
+    // ...and the page's own assets must still be served, or this has merely broken the UI.
+    // Asked for with HEAD: a font body is not UTF-8, so a GET would come back as a nil string
+    // here and read as a failure whether or not the asset was served.
+    for (NSString* asset in @[ @"/css/index.css", @"/js/index.js", @"/fonts/glyphicons-halflings-regular.ttf" ]) {
+        NSString* reply = SendRawRequest(server.port, [NSString stringWithFormat:@"HEAD %@ HTTP/1.1\r\nHost: %@\r\n\r\n", asset, host]);
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 200"], @"asset \"%@\" is no longer served: %@", asset, [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+    }
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// The Sec-Fetch-* checks that keep a cross-origin page from pinning every SSE channel fail
+// *open* when those headers are absent — and they are absent on every browser predating them
+// (Safari < 16.4, Firefox < 90), which is exactly the browser an attacker would choose. The
+// Origin check the mutating endpoints already use closes that, without affecting non-browser
+// clients, which send no Origin at all.
+- (void)testEventsRefusesCrossOriginRequestWithoutSecFetchHeaders {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+    NSString* host = [NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port];
+
+    NSString* hostile = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /events HTTP/1.1\r\nHost: %@\r\nOrigin: http://evil.example\r\nAccept: text/event-stream\r\n\r\n", host]);
+    XCTAssertTrue([hostile hasPrefix:@"HTTP/1.1 403"], @"a cross-origin page holding a channel: %@", [hostile substringToIndex:MIN((NSUInteger)40, hostile.length)]);
+
+    // The page's own EventSource must be unaffected: it sends a matching Origin.
+    NSString* sameOrigin = SendRawRequestUntilMarker(server.port, [NSString stringWithFormat:@"GET /events HTTP/1.1\r\nHost: %@\r\nOrigin: http://%@\r\nAccept: text/event-stream\r\nSec-Fetch-Dest: empty\r\nSec-Fetch-Mode: cors\r\nSec-Fetch-Site: same-origin\r\n\r\n", host, host], @"retry: 3000\n\n", 5.0);
+    XCTAssertTrue([sameOrigin containsString:@"retry: 3000\n\n"], @"the served page's own EventSource was refused: %@", sameOrigin);
 
     [server stop];
     [fm removeItemAtPath:dir error:NULL];

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -639,6 +639,10 @@ static NSString *_WithoutRootLabel(NSString *host) {
                     if (self->_request) {
                         self->_request.localAddressData = self.localAddressData;
                         self->_request.remoteAddressData = self.remoteAddressData;
+                        // The method was rewritten to GET above so a GET handler would match,
+                        // which leaves the handler unable to see that nothing will ever read
+                        // the body it is about to produce. Tell it.
+                        self->_request.virtualHEAD = self->_virtualHEAD;
 
                         if ([self->_request hasBody]) {
                             // Decide the header-only refusals before a single body byte is

--- a/Sources/WebServerKit/Core/WSKPrivate.h
+++ b/Sources/WebServerKit/Core/WSKPrivate.h
@@ -288,6 +288,7 @@ extern NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL include
 
 @interface WSKRequest ()
 @property (nonatomic, readonly) BOOL usesChunkedTransferEncoding;
+@property (nonatomic, getter=isVirtualHEAD) BOOL virtualHEAD;
 @property (nonatomic) NSData *localAddressData;
 @property (nonatomic) NSData *remoteAddressData;
 - (void)prepareForWriting;

--- a/Sources/WebServerKit/Core/WSKRequest.h
+++ b/Sources/WebServerKit/Core/WSKRequest.h
@@ -95,6 +95,20 @@ extern NSString *const WSKRequestAttribute_RegexCaptures;
 @property (nonatomic, readonly) NSString *method;
 
 /**
+ *  Returns YES if the client actually sent HEAD and the server rewrote the method to GET
+ *  because -shouldAutomaticallyMapHEADToGET is enabled. In that case `method` reads "GET",
+ *  the handler runs as if for a GET, and the response body is then discarded unsent.
+ *
+ *  Handlers that merely return bytes can ignore this. It matters to a handler whose response
+ *  *is* a long-lived resource — a stream that registers a channel, holds a slot, or otherwise
+ *  costs something for as long as the client reads it — because for a mapped HEAD nothing
+ *  will ever read it: the body block is never invoked, so whatever the handler allocated is
+ *  left to be cleaned up by a timeout instead of by the client going away. Such a handler
+ *  should return a bodiless response (correct for HEAD anyway) rather than allocate.
+ */
+@property (nonatomic, readonly, getter=isVirtualHEAD) BOOL virtualHEAD;
+
+/**
  *  Returns the URL for the request.
  */
 @property (nonatomic, readonly) NSURL *URL;

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -137,6 +137,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable WSKResponse *)moveItem:(WSKURLEncodedFormRequest *)request;
 - (nullable WSKResponse *)deleteItem:(WSKURLEncodedFormRequest *)request;
 - (nullable WSKResponse *)createDirectory:(WSKURLEncodedFormRequest *)request;
+// Declared here, with the rest of this category's methods, because the handler blocks in
+// -initWithUploadDirectory: call it before its definition appears further down the file.
+- (nullable WSKResponse *)_rejectIfCrossOrigin:(WSKRequest *)request;
 @end
 
 NS_ASSUME_NONNULL_END
@@ -257,13 +260,28 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
         // an hour. Unchanged files still return a cheap 304, but after an app
         // update the rebuilt bundle changes each file's ETag, so the new assets
         // (e.g. index.js) are picked up immediately rather than served stale.
-        [self addGETHandlerForBasePath:@"/" directoryPath:(NSString *)[siteBundle resourcePath] indexFilename:nil cacheAge:0 allowRangeRequests:NO];
+        //
+        // Only the three asset directories the page actually loads are served. Serving the
+        // bundle's *root* also exposed index.html — which is the template, and which the base
+        // path handler returns raw: placeholders unsubstituted and, the point, without the
+        // framing headers the page handler below sets. Framing "/index.html" instead of "/"
+        // therefore defeated the clickjacking defence completely.
+        //
+        // Excluding it by path does not hold: the base path handler normalizes, so with an
+        // exact-path alias in front of it "/./index.html" and "/x/../index.html" still reach
+        // the raw file (both verified). Serving only what the page asks for takes the template
+        // — and en.lproj/Localizable.strings, which no browser ever needs — out of the URL
+        // space altogether, so there is no spelling left to find.
+        for (NSString *const assetDirectory in @[ @"css", @"js", @"fonts" ]) {
+            [self addGETHandlerForBasePath:[NSString stringWithFormat:@"/%@/", assetDirectory]
+                             directoryPath:[(NSString *)[siteBundle resourcePath] stringByAppendingPathComponent:assetDirectory]
+                             indexFilename:nil
+                                  cacheAge:0
+                        allowRangeRequests:NO];
+        }
 
         // Web page
-        [self addHandlerForMethod:@"GET"
-                             path:@"/"
-                     requestClass:[WSKRequest class]
-                     processBlock:^WSKResponse *(WSKRequest *request) {
+        WSKProcessBlock const servePage = ^WSKResponse *(WSKRequest *request) {
 #if TARGET_OS_IPHONE
                          NSString *device = [[UIDevice currentDevice] name];
 #else
@@ -352,7 +370,14 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
                          [response setValue:@"frame-ancestors 'none'" forAdditionalHeader:@"Content-Security-Policy"];
                          [response setValue:@"nosniff" forAdditionalHeader:@"X-Content-Type-Options"];
                          return response;
-                     }];
+        };
+
+        [self addHandlerForMethod:@"GET" path:@"/" requestClass:[WSKRequest class] processBlock:servePage];
+        // Convenience only — "/index.html" is the obvious thing to type, and it used to work
+        // when the bundle root was served. It is *not* what keeps the raw template unreachable:
+        // that is the scoped asset handlers above, because an exact path like this one is not a
+        // containment boundary ("/./index.html" does not match it).
+        [self addHandlerForMethod:@"GET" path:@"/index.html" requestClass:[WSKRequest class] processBlock:servePage];
 
         // File listing
         [self addHandlerForMethod:@"GET"
@@ -409,6 +434,32 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
              asyncProcessBlock:^(WSKRequest *request, WSKCompletionBlock completionBlock) {
                          if (!server.serverSentEventsEnabled) {
                              completionBlock([WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"SSE not enabled"]);
+                             return;
+                         }
+
+                         // A mapped HEAD never reads the body, so registering a channel for one
+                         // hands out a slot that no client will ever hold or release: it is only
+                         // recovered by the heartbeat reaper, two ticks later. Sixteen HEADs — which
+                         // cost the sender nothing, since each request *completes* and frees its
+                         // connection slot immediately — therefore deny live updates to every real
+                         // client for ~30s, and repeating them sustains that indefinitely. The
+                         // Sec-Fetch-* checks below do not help: they are about which origin is
+                         // asking, and this costs nothing to ask from anywhere on the network.
+                         // A bodiless reply is the right answer to HEAD regardless.
+                         if (request.isVirtualHEAD) {
+                             completionBlock([WSKDataResponse responseWithData:[NSData data] contentType:@"text/event-stream"]);
+                             return;
+                         }
+
+                         // The same rule the mutating endpoints use. Without it this endpoint is
+                         // the one place a cross-origin page can still reach: the Sec-Fetch-*
+                         // checks below fail *open* when the headers are absent, and they are
+                         // absent on every browser predating them (Safari < 16.4, Firefox < 90).
+                         // Such a browser can hold every channel from any origin.
+                         WSKResponse *const crossOrigin = [server _rejectIfCrossOrigin:request];
+
+                         if (crossOrigin) {
+                             completionBlock(crossOrigin);
                              return;
                          }
 


### PR DESCRIPTION
Three defects in the uploader's browser-facing surface, all reachable by anyone who can reach
the port.

### A `HEAD` request took an SSE channel and gave nothing back

`HEAD` is mapped to `GET` *before* handler matching, so the `/events` handler ran and
registered a channel — but the connection layer discards the body of a mapped HEAD unsent, so
the stream block never ran and **no client ever held the channel**. Nothing released it either:
only the heartbeat reaper did, two ticks (~30s) later.

Sixteen HEADs — one per slot — therefore denied live updates to every real client, and they
are unusually cheap to send: each request *completes*, so the sender holds no connection slot
and can repeat the burst indefinitely.

Measured before the fix:

| | |
|---|---|
| fresh server, first `GET /events` | stream granted |
| after 16 completed `HEAD /events` | **refused (at cap)** |
| +10s, +20s | still refused |
| +30s (two heartbeats) | recovers |

The `Sec-Fetch-*` checks are no help here — they decide *which origin* may ask, and this costs
nothing to ask from anywhere on the network. The handler now answers a mapped HEAD with a
bodiless response (the correct answer to HEAD anyway) and allocates nothing.

Handlers previously had no way to see this, so `WSKRequest` gains `-isVirtualHEAD`, set by the
connection where it rewrites the method. It matters to any handler whose response *is* a
long-lived resource rather than just bytes.

### The uploader's own page could be framed by asking for it a different way

The bundle root was served by a base-path handler, and `index.html` is a file in that bundle —
so `/index.html` returned the template **raw**: placeholders unsubstituted and, the point,
without the `X-Frame-Options`/CSP/`nosniff` headers the `/` handler sets. Framing that path
instead of `/` defeated the clickjacking defence completely, on a UI whose one-click buttons
delete and move files and whose `#/path` fragment aims it at a chosen folder.

**The first fix here was an exact-path alias for `/index.html`, and it does not hold** — the
base-path handler normalizes, so `/./index.html` and `/x/../index.html` both still reached the
raw file. Verified, and the test covers both.

What ships instead serves only the three asset directories the page actually loads (`css`,
`js`, `fonts`), taking the template — and `en.lproj/Localizable.strings`, which no browser
needs — out of the URL space altogether, so there is no spelling left to find. `/index.html`
is kept as a convenience alias, and the test asserts the assets still load so this cannot
silently become "the UI is broken".

### `/events` failed open when `Sec-Fetch-*` was absent

Those headers are what stop a cross-origin page pinning every channel, and they are absent on
every browser predating them (Safari < 16.4, Firefox < 90) — precisely the browser an attacker
would pick. `/events` now runs the same `-_rejectIfCrossOrigin:` check the mutating endpoints
use, which reads `Origin`.

| request | before | after |
|---|---|---|
| same-origin (the served page) | granted | granted |
| no `Origin` (curl, non-browser) | granted | granted |
| cross-origin, with `Sec-Fetch-*` | 403 | 403 |
| cross-origin, **no** `Sec-Fetch-*` | **granted** | 403 |

Refusing the real UI would be the easy mistake here, so the first two rows are asserted too.

### Verification

All three tests were run against the unfixed source and fail there on the intended assertion.
Full harness green: **84 tests, 0 failures**, all 8 trace suites, Release builds for all three
platforms, `swift build`.
