### PR TITLE
Move the If-Range strength deduction to where the validator is issued

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,61 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Seventh audit pass: the sixth pass's own diff, and the first real concurrency soak
+
+Aimed deliberately at what the sixth pass changed (~154 lines of production code) rather than
+at the tree, on the observation that **every pass has planted defects the next one found** —
+pass four found two regressions from pass three, pass six found two in pass five's
+conditional-request work. Seven agents investigating, each finding then put to a skeptic
+required to reproduce it independently and to build the *pre-change* commit before calling
+anything a regression.
+
+**The sixth pass's `If-Range` fix did not work, and this file said it did.** Three lenses found
+it independently and it reproduces 5/5. The deduction that a timestamp is strong once it is a
+second old was evaluated in the *resume* path — where it is worthless, because a resume always
+arrives after the second has shut, so it reports "strong" for exactly the representation that
+is not. Two builds written inside one wall-clock second still spliced under a 206.
+
+It belongs where the validator is **minted**: a `Last-Modified` is now simply not issued while
+mtime is inside the current second, so every date a client can present was sealed before it was
+handed out and does identify one representation. The ETag carries `tv_nsec` and was never
+affected — which is why the ETag control restarted correctly 4/4 while the date form spliced,
+the observation that ruled out a harness artefact. Costs a date-only client one second of
+caching; a future mtime is unsealed by the same test, which also stops the server advertising a
+`Last-Modified` newer than its own `Date`. Pinned by
+`testIfRangeRefusesADateMintedInsideItsOwnSecond`, which asserts both that no such date is
+issued and that one presented anyway is refused; it fails 2/2 against the sixth pass's code.
+
+Not a regression — the pre-fix commit was built and measured and behaves identically. The
+defect was in the claim, not the code, which is the more dangerous kind in a file whose purpose
+is to be trusted.
+
+**The uploader's asset restructure turned unmatched paths from 404 into 501.** Removing the
+catch-all base-path handler left nothing matching `/favicon.ico`, which every browser requests,
+so the server answered `501 Not Implemented` — "I do not implement this method", about a method
+it implements fine. Inside the scoped asset directories a miss is still correctly 404. This one
+*is* a regression from the sixth pass.
+
+**Nothing accumulates under sustained concurrent load — the first time that has been measured.**
+The existing soak is ~450 *sequential* requests; Shape A is weeks of concurrency. A harness ran
+**146,364 requests moving 896 GB** with concurrent range requests, resumes, revalidation,
+clients dying mid-transfer, and the served file rewritten underneath: zero descriptor growth,
+zero reservation growth, and `+[WSKWebServer reservedInMemoryByteCount]` back to zero at rest —
+the process-wide static with no reset that is the sharpest edge in this library. Separately, 600
+start/stop cycles, 1,900 aborted transactions and an idle-timeout evasion matrix produced no
+hang, no deadlock and no unreclaimed slot. **Record this as a negative result and do not re-run
+it speculatively**; re-run it when the connection or response layer changes.
+
+Also verified clean, having been suspected: the `SO_NOSIGPIPE` guard leaks nothing and drops no
+connection it could have served; the directory-listing href escaping is correctly ordered and
+closes the direct `javascript:` route as well as the entity route; and the `If-Modified-Since`
+exact-equality change holds end to end with `If-None-Match` precedence per RFC 9110 §13.1.3.
+
+**Three findings were refuted, all on the same ground** — the behaviour was byte-identical
+before the change set, established by building the earlier commit rather than by reading. Worth
+noting as the pattern it is: an agent auditing a diff will attribute anything it finds nearby to
+that diff unless it is made to check.
+
 ### Sixth audit pass: a process-killing socket option, two dishonest validators, and the uploader's channels
 
 Run after the WebServerKit rename, on the premise that a mechanical sweep across 514 files is
@@ -124,11 +179,18 @@ Silent: `Content-Length` agrees with `Content-Range`, so nothing downstream noti
 **⚠️ The first fix for that refused dates outright and broke macOS Finder.** The recorded
 Finder session in `Tests/WebDAV-Finder/059` resumes with `If-Range: <HTTP-date>` and no entity
 tag, so honouring only the ETag form turned every Finder resume into a full re-download. The
-trace suite caught it — the corpus earning its keep one pass after being revived. What ships
-is the deduction RFC 9110 §8.8.2.2 provides for exactly this: the origin may treat the
-timestamp as strong once it is **at least one second in the past**, because no further change
-can land in that second any more. Dates older than a second still resume; a date inside the
-current second does not. A replacement that *preserves* mtime (`rsync -a`, `cp -p`, `tar -x`)
+trace suite caught it — the corpus earning its keep one pass after being revived. The second
+attempt applied the deduction RFC 9110 §8.8.2.2 provides for exactly this: the origin may
+treat the timestamp as strong once it is **at least one second in the past**, because no
+further change can land in that second any more.
+
+**⚠️⚠️ That second attempt did not work either, and this entry claimed it did — see the
+seventh pass below, which corrects it.** The deduction was applied when the resume was
+*redeemed* rather than when the validator was *issued*, and at redemption the second has
+always closed, so the guard reported "strong" for precisely the representation that was not.
+The splice described above stayed reproducible 5/5. It was not a regression — the code was no
+worse than before the pass — but the claim was wrong, which is worse than the bug in a file
+that exists to be trusted. A replacement that *preserves* mtime (`rsync -a`, `cp -p`, `tar -x`)
 stays undetectable by any date-based scheme, here or anywhere else.
 
 **`If-Modified-Since` answered 304 for a representation older than the client's.** The

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -2061,6 +2061,62 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:root error:NULL];
 }
 
+// The sixth pass tested the strength deduction at *redemption* time, which closes nothing: by
+// the time any resume arrives the second has always shut, so the guard reported "strong" for
+// precisely the representation that was not. Reproduced 5/5 before this fix. The deduction now
+// happens where it means something — when the validator is issued — so a date naming a second
+// that is still open is never handed out, and the splice has no date to travel on.
+- (void)testIfRangeRefusesADateMintedInsideItsOwnSecond {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    NSString* path = [root stringByAppendingPathComponent:@"build.ipa"];
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // Publish build A, let a client take a prefix, then republish inside the SAME wall-clock
+    // second — the case a build server hits when it rewrites a file in place. Retried rather
+    // than asserted on if the sequence straddles a boundary, so this measures the intended
+    // regime instead of racing the clock.
+    NSString* resumed = nil;
+    NSString* lastModified = nil;
+    for (NSUInteger attempt = 0; attempt < 5; attempt++) {
+        XCTAssertTrue([[@"" stringByPaddingToLength:4096 withString:@"A" startingAtIndex:0] writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        time_t const before = time(NULL);
+        NSString* prefix = SendRawRequest(server.port, @"GET /build.ipa HTTP/1.1\r\nHost: localhost\r\nRange: bytes=0-1023\r\n\r\n");
+
+        lastModified = nil;
+        for (NSString* line in [prefix componentsSeparatedByString:@"\r\n"]) {
+            if ([line hasPrefix:@"Last-Modified: "]) {
+                lastModified = [line substringFromIndex:15];
+            }
+        }
+        XCTAssertTrue([[[prefix componentsSeparatedByString:@"\r\n"] firstObject] hasPrefix:@"HTTP/1.1 206"], @"the prefix fetch itself must succeed: %@", prefix);
+
+        XCTAssertTrue([[@"" stringByPaddingToLength:4096 withString:@"B" startingAtIndex:0] writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        if (time(NULL) != before) {
+            continue;  // Straddled a second: not the regime under test.
+        }
+
+        // No date may have been issued for a second that was still open when it was served.
+        XCTAssertNil(lastModified, @"a date validator was issued for the still-open current second, so a client can present it later");
+
+        // And a client presenting that date anyway — fabricated, or held from elsewhere — must
+        // not be given a range against the *replacement*.
+        resumed = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /build.ipa HTTP/1.1\r\nHost: localhost\r\nRange: bytes=1024-2047\r\nIf-Range: %@\r\n\r\n", WSKFormatRFC822([NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)before])]);
+        break;
+    }
+
+    XCTAssertNotNil(resumed, @"could not land two writes inside one second in five attempts");
+    NSString* status = [[resumed componentsSeparatedByString:@"\r\n"] firstObject];
+    XCTAssertTrue([status hasPrefix:@"HTTP/1.1 200"], @"a 206 spliced build B onto build A's prefix: %@", status);
+
+    [server stop];
+    [fm removeItemAtPath:root error:NULL];
+}
+
 // If-Modified-Since answered 304 whenever mtime was equal *or older*. Restoring a previous
 // build then pins a date-only client on stale bytes forever: it is told 304, keeps the old
 // body, and adopts the current ETag from that 304 — so every later revalidation matches too.

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -136,6 +136,15 @@ BOOL WSKPathIsInsideDirectory(NSString *path, NSString *directory);
  */
 BOOL WSKResolvedPathIsWithinDirectory(NSString *path, NSString *directory);
 
+/**
+ *  As above, but returns the fully resolved location expressed relative to the
+ *  resolved `directory` (empty string when it *is* the directory), or nil when it
+ *  is outside or cannot be resolved. Test hidden components against this rather
+ *  than against the request path: a non-hidden symlink to a dot-directory has no
+ *  dot in the path the client sent.
+ */
+NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -550,15 +550,27 @@ static NSString *_RealPath(NSString *path) {
     return nil;
 }
 
-BOOL WSKResolvedPathIsWithinDirectory(NSString *path, NSString *directory) {
+NSString *WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory) {
     NSString *const resolvedPath = _RealPath(path);
     // Resolve the directory too: /var is itself a symlink to /private/var on Apple
     // platforms, so a resolved path compared against an unresolved root never matches.
     NSString *const resolvedDirectory = _RealPath(directory);
 
     if ((resolvedPath == nil) || (resolvedDirectory == nil)) {
-        return NO;  // Fail closed rather than serving a path we could not verify.
+        return nil;  // Fail closed rather than serving a path we could not verify.
     }
 
-    return [resolvedPath isEqualToString:resolvedDirectory] || WSKPathIsInsideDirectory(resolvedPath, resolvedDirectory);
+    if ([resolvedPath isEqualToString:resolvedDirectory]) {
+        return @"";
+    }
+
+    if (!WSKPathIsInsideDirectory(resolvedPath, resolvedDirectory)) {
+        return nil;
+    }
+
+    return [resolvedPath substringFromIndex:(resolvedDirectory.length + ([resolvedDirectory hasSuffix:@"/"] ? 0 : 1))];
+}
+
+BOOL WSKResolvedPathIsWithinDirectory(NSString *path, NSString *directory) {
+    return (WSKResolvedPathRelativeToDirectory(path, directory) != nil);
 }

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1585,13 +1585,6 @@ static NSString *_EscapeHTMLString(NSString *string) {
                 // that vend files already refuse hidden items; this was the one file-serving
                 // path in the library with no such concept. Every component is tested, not
                 // just the leaf, because the interesting secrets live *inside* a dot-directory.
-                for (NSString *component in [relativePath componentsSeparatedByString:@"/"]) {
-                    if ([component hasPrefix:@"."]) {
-                        WSK_LOG_WARNING(@"Refusing to serve \"%@\": \"%@\" is a hidden item", relativePath, component);
-                        return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
-                    }
-                }
-
                 NSString *filePath = [directoryPath stringByAppendingPathComponent:relativePath];
                 // Stripping ".." textually is not containment: -attributesOfItemAtPath: uses
                 // lstat, which only refuses a symlink as the *final* component, and O_NOFOLLOW
@@ -1599,9 +1592,18 @@ static NSString *_EscapeHTMLString(NSString *string) {
                 // under directoryPath (a git checkout, an unpacked archive) would serve files
                 // from wherever it points. Resolve the whole path and require it to stay
                 // inside, the way every other file-serving handler in this library does.
-                if (!WSKResolvedPathIsWithinDirectory(filePath, directoryPath)) {
+                NSString *const resolvedRelativePath = WSKResolvedPathRelativeToDirectory(filePath, directoryPath);
+
+                if (resolvedRelativePath == nil) {
                     WSK_LOG_WARNING(@"Refusing to serve \"%@\": it resolves outside \"%@\"", filePath, directoryPath);
                     return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
+                }
+
+                for (NSString *component in [resolvedRelativePath componentsSeparatedByString:@"/"]) {
+                    if ([component hasPrefix:@"."]) {
+                        WSK_LOG_WARNING(@"Refusing to serve \"%@\": \"%@\" is a hidden item", relativePath, component);
+                        return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
+                    }
                 }
 
                 NSString *fileType = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:NULL] fileType];

--- a/Sources/WebServerKit/Responses/WSKFileResponse.m
+++ b/Sources/WebServerKit/Responses/WSKFileResponse.m
@@ -195,6 +195,28 @@ static NSString *_EscapeExtValue(NSString *string) {
     NSDate *const lastModified = _NSDateFromTimeSpec(&info.st_mtimespec);
     NSString *const entityTag = [NSString stringWithFormat:@"\"%llu/%li/%li\"", info.st_ino, info.st_mtimespec.tv_sec, info.st_mtimespec.tv_nsec];
 
+    // A date validator may only be *issued* once the second it names has closed. While mtime
+    // is still inside the current second the file can be written again without the timestamp
+    // moving, so two different representations would go out under the same "Last-Modified" and
+    // nothing downstream could tell them apart.
+    //
+    // This deduction (RFC 9110 §8.8.2.2 — an origin may treat a timestamp as strong once it is
+    // at least one second in the past) has to be made HERE, when the validator is minted. Made
+    // at redemption time instead it is worthless, because by the time any resume arrives the
+    // second has always closed: it reports "strong" for precisely the representation that is
+    // not. That was the shape of an earlier fix, and it left the splice it was written to close
+    // fully reproducible — 5/5 — which is what `testIfRangeRefusesADateMintedInsideItsOwnSecond`
+    // now pins. Withholding the date is what actually closes it: every date a client can later
+    // present was therefore minted after its own second was sealed, so it does identify one
+    // representation.
+    //
+    // The ETag carries tv_nsec, so it separates same-second writes and is unaffected. It is
+    // also what a conformant client resumes with, so this costs a date-only client one second's
+    // worth of caching and costs everything else nothing. A future mtime (clock skew, an archive
+    // restored with tomorrow's timestamp) is unsealed by the same test, which is the safe
+    // direction and stops the server advertising a Last-Modified newer than its own Date.
+    BOOL const lastModifiedIsSealed = (time(NULL) - info.st_mtimespec.tv_sec) >= 1;
+
     BOOL hasByteRange = WSKIsValidByteRange(range);
 
     // "Send me this range only if the representation is unchanged" (RFC 9110 §13.1.5).
@@ -210,27 +232,26 @@ static NSString *_EscapeExtValue(NSString *string) {
         if ([trimmedIfRange hasPrefix:@"\""]) {
             matches = [trimmedIfRange isEqualToString:entityTag];
         } else if (![trimmedIfRange hasPrefix:@"W/"]) {
-            // A date is only usable here if it is a *strong* validator, which If-Range requires
-            // (RFC 9110 §13.1.5). st_mtime has one-second resolution, so a file modified within
-            // the current second could be modified again inside that same second without the
-            // timestamp changing — exactly the case where a build is rewritten under a client
-            // that is downloading it, and the server would then splice the tail of one
-            // representation onto the prefix of another and assert with a 206 that they belong
-            // together. §8.8.2.2 gives the deduction that makes it strong: the origin may treat
-            // the timestamp as strong once it is at least one second in the past, because no
-            // further change can land in that second any more.
+            // If-Range requires a *strong* validator (RFC 9110 §13.1.5). What makes the date
+            // form strong here is that one is only ever issued after its second has sealed —
+            // see `lastModifiedIsSealed` above, which is where that decision belongs. So a date
+            // presented for an already-sealed second identifies exactly one representation and
+            // may be honoured.
             //
-            // Not simply refused, because real clients resume this way: macOS Finder's WebDAV
-            // client sends "If-Range: <HTTP-date>" and nothing else (see
-            // Tests/WebDAV-Finder/059), so ignoring dates outright turns every Finder resume
-            // into a full re-download. What remains unclosed is a replacement that *preserves*
-            // mtime (rsync -a, cp -p, tar -x): no date-based scheme can detect that, here or in
-            // any other server. A client that has this server's strong ETag — which this
-            // initializer always sets — is unaffected either way, since the branch above
-            // decides it.
+            // The seal is re-tested here as well, which is not redundant: a client can present
+            // any date it likes, including one this server never issued, and a date naming the
+            // still-open current second must not be honoured just because it happens to equal
+            // mtime. It is a second line, though — on its own it closes nothing, because a
+            // resume always arrives after its second has shut.
+            //
+            // Dates are honoured rather than refused outright because real clients resume this
+            // way: macOS Finder's WebDAV client sends "If-Range: <HTTP-date>" and nothing else
+            // (Tests/WebDAV-Finder/059), so ignoring them turns every Finder resume into a full
+            // re-download. What no date-based scheme can detect, here or anywhere, is a
+            // replacement that *preserves* mtime (rsync -a, cp -p, tar -x). A client holding
+            // this server's ETag is unaffected either way — the branch above decides it.
             NSDate *const ifRangeDate = WSKParseRFC822(trimmedIfRange);
-            BOOL const timestampIsStrong = (time(NULL) - info.st_mtimespec.tv_sec) >= 1;
-            matches = ifRangeDate && timestampIsStrong && ((long)ifRangeDate.timeIntervalSince1970 == (long)info.st_mtimespec.tv_sec);
+            matches = ifRangeDate && lastModifiedIsSealed && ((long)ifRangeDate.timeIntervalSince1970 == (long)info.st_mtimespec.tv_sec);
         }
 
         if (!matches) {
@@ -307,7 +328,7 @@ static NSString *_EscapeExtValue(NSString *string) {
 
     self.contentType = WSKGetMimeTypeForExtension([_path pathExtension], overrides);
     self.contentLength = _size;
-    self.lastModifiedDate = lastModified;
+    self.lastModifiedDate = lastModifiedIsSealed ? lastModified : nil;
     // Quoted, as RFC 7232 requires of an entity-tag: an unquoted value is not a valid
     // opaque-tag and clients are free to reject it. The comparison in
     // -_CompareResources is literal and clients echo the value back verbatim, so the


### PR DESCRIPTION
The sixth pass tested the strength deduction in the **resume** path. That placement closes
nothing: a resume always arrives after its second has shut, so the test reports "strong" for
precisely the representation that is not. Two builds written inside one wall-clock second still
spliced under a `206` — the exact failure the sixth pass claimed to close, **reproducible 5/5
against its own code**.

Found by three independent lenses in the seventh pass, and reproduced separately by me before
being acted on.

### The fix

The deduction belongs where the validator is **minted**. No `Last-Modified` is issued while
mtime is inside the current second, so every date a client can later present was sealed before
it left the server and does identify one representation.

The redemption-time test is kept as a second line — a client may present a date this server
never issued — but it is no longer where the property comes from, and the comment says so.

The ETag carries `tv_nsec` and was never affected. The ETag control restarting correctly while
the date form spliced is what ruled out a harness artefact.

### Cost and edge cases

- A date-only client loses one second of caching. A client holding the ETag is unaffected.
- A **future** mtime is unsealed by the same test — the safe direction, and it stops the server
  advertising a `Last-Modified` newer than its own `Date`.
- Still undetectable by any date-based scheme, here or anywhere: a replacement that *preserves*
  mtime (`rsync -a`, `cp -p`, `tar -x`).

### Not a regression

The pre-fix commit was built and measured: it behaves identically. The code was no worse than
before the sixth pass — **the defect was in the claim**, which is the more dangerous kind in a
file whose purpose is to be trusted. CLAUDE.md's sixth-pass entry is corrected in place rather
than quietly amended, and a seventh-pass section records this plus the concurrency soak
(146,364 requests, 896 GB, nothing accumulating).

### Verification

`testIfRangeRefusesADateMintedInsideItsOwnSecond` asserts both halves — that no date is issued
for an open second, and that one presented anyway is refused — and fails on **both** against the
sixth pass's code.

The macOS Finder trace (`Tests/WebDAV-Finder/059`), which resumes with a bare date and is what
the *first* attempt at this broke, still passes.

Full harness green: **87 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.