### PR TITLE
Restore the uploader's 404 for paths nothing serves

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1442,6 +1442,39 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// Scoping the asset handlers removed the catch-all that used to serve the bundle root, and with
+// it the incidental 404 every unmatched GET fell through to — so "/favicon.ico", which browsers
+// request unprompted, started answering 501 Not Implemented. 501 is a statement about the
+// method, which the server implements perfectly well.
+- (void)testUploaderAnswersNotFoundRatherThanNotImplemented {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+    NSString* host = [NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port];
+
+    for (NSString* path in @[ @"/favicon.ico", @"/apple-touch-icon.png", @"/nope.txt", @"/css/missing.css" ]) {
+        NSString* reply = SendRawRequest(server.port, [NSString stringWithFormat:@"GET %@ HTTP/1.1\r\nHost: %@\r\n\r\n", path, host]);
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 404"], @"\"%@\" should be Not Found: %@", path, [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+    }
+
+    // The catch-all matches GET only, exactly as the base path handler it replaces did, so no
+    // other method's status is affected by it.
+    NSString* posted = SendRawRequest(server.port, [NSString stringWithFormat:@"POST /nope.txt HTTP/1.1\r\nHost: %@\r\nContent-Length: 0\r\n\r\n", host]);
+    XCTAssertFalse([posted hasPrefix:@"HTTP/1.1 404"], @"the catch-all must not claim non-GET methods: %@", [posted substringToIndex:MIN((NSUInteger)40, posted.length)]);
+
+    // And it must sit behind every real handler, not in front of them.
+    NSString* page = SendRawRequest(server.port, [NSString stringWithFormat:@"GET / HTTP/1.1\r\nHost: %@\r\n\r\n", host]);
+    XCTAssertTrue([page hasPrefix:@"HTTP/1.1 200"], @"the catch-all shadowed the page handler: %@", [page substringToIndex:MIN((NSUInteger)40, page.length)]);
+    NSString* asset = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /css/index.css HTTP/1.1\r\nHost: %@\r\n\r\n", host]);
+    XCTAssertTrue([asset hasPrefix:@"HTTP/1.1 200"], @"the catch-all shadowed the asset handlers: %@", [asset substringToIndex:MIN((NSUInteger)40, asset.length)]);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 // The uploader's bundle contains index.html, and the base-path handler serves that bundle at
 // "/", so "/index.html" returned the raw template — the same UI, with none of the framing
 // headers the "/" handler sets. Framing that path instead of "/" therefore defeated the

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -260,6 +260,25 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
         // an hour. Unchanged files still return a cheap 304, but after an app
         // update the rebuilt bundle changes each file's ETag, so the new assets
         // (e.g. index.js) are picked up immediately rather than served stale.
+        // Registered FIRST so that it is matched LAST — handlers are inserted at index 0, so
+        // registration order is reverse match order. A GET that nothing else claims answers 404
+        // rather than the 501 the server returns when no handler matches at all, which is a
+        // statement about the *method* and wrong here. Serving the bundle root used to supply
+        // this incidentally: every unmatched GET fell through to a missing-file 404. Scoping the
+        // asset handlers below took that away, so "/favicon.ico" — which browsers request
+        // unprompted — began answering "Not Implemented". Matches GET only, which is exactly
+        // what the base path handler did, so no other method's status changes.
+        [self addHandlerWithMatchBlock:^WSKRequest *(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery) {
+            if (![requestMethod isEqualToString:@"GET"]) {
+                return nil;
+            }
+
+            return [[WSKRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+        }
+            processBlock:^WSKResponse *(WSKRequest *request) {
+                return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", request.path];
+            }];
+
         //
         // Only the three asset directories the page actually loads are served. Serving the
         // bundle's *root* also exposed index.html — which is the template, and which the base


### PR DESCRIPTION
A regression from the sixth pass, found by the seventh.

Scoping the uploader's asset serving to `css`/`js`/`fonts` — so the raw `index.html` template
could not be reached by any spelling — also removed the catch-all that had been serving the
bundle root, and with it the *incidental* 404 that every unmatched GET used to fall through to.

So `/favicon.ico`, which browsers request unprompted, began answering:

```
GET /favicon.ico        -> HTTP/1.1 501 Not Implemented
GET /apple-touch-icon.png -> HTTP/1.1 501 Not Implemented
GET /nope.txt           -> HTTP/1.1 501 Not Implemented
GET /css/missing.css    -> HTTP/1.1 404 Not Found      <- inside a scoped dir, still correct
```

`501` says the server does not implement the *method*. It implements GET perfectly well.

### The fix

A catch-all GET handler, registered **first** so that it matches **last** — handlers are
inserted at index 0, so registration order is reverse match order. Getting that backwards would
shadow the page and every asset while still passing a naive 404 check, so the test asserts
explicitly that `/` and `/css/index.css` still return 200.

It matches GET only, exactly as the base-path handler it replaces did, so no other method's
status changes — also asserted.

### Verification

`testUploaderAnswersNotFoundRatherThanNotImplemented` fails on three paths with `501` against
the sixth pass's code.

Full harness green: **87 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.