### PR TITLE
Populate the aborted request, which could crash the process

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -262,6 +262,29 @@ static NSString* MakeTempDirectory(void) {
     return dir;
 }
 
+// A request matching no handler still reaches -abortRequest:withStatusCode:, which
+// WSKOption_ConnectionClass makes a host-app subclassing point. That branch populated none of
+// the request's address data, so reading -remoteAddressString there dereferenced a NULL
+// sockaddr — WSKStringFromSockAddr evaluates addr->sa_len before getnameinfo, so there is
+// nothing to fail closed on. NOTE: against the unfixed source this does not fail, it SEGVs and
+// takes the whole test process with it, which xctest reports as "0 failures". Read the executed
+// count.
+static NSString* gAbortRequestPeer = nil;
+static BOOL gAbortRequestSawVirtualHEAD = NO;
+
+@interface AbortProbeConnection : WSKConnection
+@end
+
+@implementation AbortProbeConnection
+
+- (void)abortRequest:(WSKRequest*)request withStatusCode:(NSInteger)statusCode {
+    gAbortRequestPeer = request.remoteAddressString;
+    gAbortRequestSawVirtualHEAD = request.isVirtualHEAD;
+    [super abortRequest:request withStatusCode:statusCode];
+}
+
+@end
+
 @interface Tests : XCTestCase
 @end
 
@@ -1414,6 +1437,32 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 // real client, and unusually cheap to sustain: each request *completes*, so the sender holds
 // no connection slot and can repeat the burst every 30s from anywhere on the network.
 // Measured before the fix: 16 HEADs, then a genuine EventSource is refused for 30s.
+- (void)testAbortedRequestCarriesItsAddressesAndHEADFlag {
+    gAbortRequestPeer = nil;
+    gAbortRequestSawVirtualHEAD = NO;
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addHandlerForMethod:@"GET"
+                           path:@"/ok"
+                   requestClass:[WSKRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"ok"];
+                   }];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_ConnectionClass : [AbortProbeConnection class]};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // HEAD, so the method has been rewritten to GET before matching; no handler claims
+    // "/nope", so this takes the 501 branch that builds its own request.
+    NSString* reply = SendRawRequest(server.port, @"HEAD /nope HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 501"], @"expected 501 for an unclaimed path: %@", reply);
+
+    XCTAssertNotNil(gAbortRequestPeer, @"the aborted request carried no peer address");
+    XCTAssertTrue([gAbortRequestPeer hasPrefix:@"127.0.0.1"], @"peer address is wrong: %@", gAbortRequestPeer);
+    XCTAssertTrue(gAbortRequestSawVirtualHEAD, @"a mapped HEAD must be distinguishable from a real GET on this path");
+
+    [server stop];
+}
+
 - (void)testHEADOnEventsDoesNotConsumeSSEChannels {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* dir = MakeTempDirectory();

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -699,6 +699,20 @@ static NSString *_WithoutRootLabel(NSString *host) {
                         self->_request = [[WSKRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:requestPath query:requestQuery];
 
                         if (self->_request) {
+                            // The matched path populates these three; this branch populated
+                            // none of them, and the request still reaches
+                            // -abortRequest:withStatusCode:, which is a subclassing point a
+                            // host app reaches through WSKOption_ConnectionClass. Reading
+                            // -remoteAddressString on it dereferenced a NULL sockaddr and took
+                            // the process down — WSKStringFromSockAddr evaluates addr->sa_len
+                            // before calling getnameinfo, so there is nothing to fail closed on
+                            // — from a single unauthenticated request to any path no handler
+                            // claims. virtualHEAD belongs here for the related reason: the
+                            // method was rewritten to GET before matching, so without it a
+                            // subclass cannot tell a mapped HEAD from a real GET on this path.
+                            self->_request.localAddressData = self.localAddressData;
+                            self->_request.remoteAddressData = self.remoteAddressData;
+                            self->_request.virtualHEAD = self->_virtualHEAD;
                             [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_NotImplemented];
                         } else {
                             // The base request rejected these headers too — a framing conflict


### PR DESCRIPTION
Found while triaging a much smaller report from the seventh pass. The small report was real; what
it was sitting next to is worse.

### The crash

A request matching no handler is built in its own branch of `-_readRequestHeaders` and handed to
`-abortRequest:withStatusCode:` — a subclassing point host apps reach through the public
`WSKOption_ConnectionClass`. That branch set **none** of the three fields the matched path sets.

A subclass doing the obvious thing in that hook — logging who the refused request came from —
reads `-remoteAddressString` on a request whose address data is `nil`:

```
AddressSanitizer: SEGV on unknown address 0x000000000000
    #0  WSKStringFromSockAddr  WSKFunctions.m:380
    #1  -[WSKRequest remoteAddressString]  WSKRequest.m:522
    #2  -[ProbeConnection abortRequest:withStatusCode:]
    #3  __36-[WSKConnection _readRequestHeaders]_block_invoke  WSKConnection.m:702
```

`WSKStringFromSockAddr` evaluates `addr->sa_len` *before* calling `getnameinfo`, so there is
nothing to fail closed on. One unauthenticated request to any path no handler claims.

### The smaller half

`isVirtualHEAD` was also left `NO` there, so a subclass could not tell a mapped HEAD from a real
GET on this path — `WSKConnection` exposes no other accessor for it. That one **is** the sixth
pass's omission: it added the flag to the matched path only. Same three lines fix both.

Fixed in the branch rather than by hoisting the matched path's assignments, which sit after other
work there and would need reordering or a nil guard for no gain.

### Verification

`testAbortedRequestCarriesItsAddressesAndHEADFlag`. Against the unfixed source it does **not
fail — it SEGVs and takes the whole test process down**, which xctest reports as *"0 failures"*.
The test carries a note to read the executed count; this repo has been bitten by that before.

Full harness green: **87 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.