### PR TITLE
Refuse hidden items through symlinks, in the uploader and WebDAV

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1430,13 +1430,6 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
-// An SSE stream is only ever released when the client that is reading it goes away. A HEAD
-// mapped to GET has no reader at all — the connection layer discards the body unsent — so the
-// channel the handler registered was held by nobody and freed only by the heartbeat reaper,
-// two ticks (~30s) later. That made sixteen HEADs a complete denial of live updates for every
-// real client, and unusually cheap to sustain: each request *completes*, so the sender holds
-// no connection slot and can repeat the burst every 30s from anywhere on the network.
-// Measured before the fix: 16 HEADs, then a genuine EventSource is refused for 30s.
 - (void)testAbortedRequestCarriesItsAddressesAndHEADFlag {
     gAbortRequestPeer = nil;
     gAbortRequestSawVirtualHEAD = NO;
@@ -1460,9 +1453,74 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     XCTAssertTrue([gAbortRequestPeer hasPrefix:@"127.0.0.1"], @"peer address is wrong: %@", gAbortRequestPeer);
     XCTAssertTrue(gAbortRequestSawVirtualHEAD, @"a mapped HEAD must be distinguishable from a real GET on this path");
 
-    [server stop];
-}
+    [server stop];}
 
+// Hiddenness and containment are independent rules, and the hidden-item walk saw only the path
+// the client typed. A symlink named "pub" pointing at ".git" makes "/pub/config" carry no dot,
+// while containment passes because the target is inside the served root — so both rules were
+// satisfied by a path whose bytes live inside a dot-directory. Read through the base-path
+// handler, read AND enumerated through the uploader, and written through DAV PUT, which refuses
+// the same write spelled "/.git/hooks/x".
+- (void)testHiddenItemsAreRefusedThroughSymlinksToo {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    XCTAssertTrue([fm createDirectoryAtPath:[root stringByAppendingPathComponent:@".git/hooks"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([fm createDirectoryAtPath:[root stringByAppendingPathComponent:@"data/sub"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"SECRETGITCONFIG" writeToFile:[root stringByAppendingPathComponent:@".git/config"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"PUBLICOK" writeToFile:[root stringByAppendingPathComponent:@"data/normal.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"NESTEDOK" writeToFile:[root stringByAppendingPathComponent:@"data/sub/deep.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    // The hostile link, a chain of them, and a benign one that must keep working.
+    XCTAssertTrue([fm createSymbolicLinkAtPath:[root stringByAppendingPathComponent:@"pub"] withDestinationPath:@".git" error:NULL]);
+    XCTAssertTrue([fm createSymbolicLinkAtPath:[root stringByAppendingPathComponent:@"hop"] withDestinationPath:@"pub" error:NULL]);
+    XCTAssertTrue([fm createSymbolicLinkAtPath:[root stringByAppendingPathComponent:@"latest"] withDestinationPath:@"data/sub" error:NULL]);
+
+    WSKWebServer* basePath = [[WSKWebServer alloc] init];
+    [basePath addGETHandlerForBasePath:@"/files/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([basePath startWithOptions:options error:NULL]);
+
+    for (NSString* path in @[ @"/files/pub/config", @"/files/hop/config", @"/files/.git/config" ]) {
+        NSString* reply = SendRawRequest(basePath.port, [NSString stringWithFormat:@"GET %@ HTTP/1.1\r\nHost: localhost\r\n\r\n", path]);
+        XCTAssertFalse([reply containsString:@"SECRETGITCONFIG"], @"\"%@\" served a file inside a dot-directory", path);
+    }
+    // Neither over-refusal: an ordinary file, and a benign symlink staying inside the root.
+    XCTAssertTrue([SendRawRequest(basePath.port, @"GET /files/data/normal.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"PUBLICOK"], @"an ordinary file stopped being served");
+    XCTAssertTrue([SendRawRequest(basePath.port, @"GET /files/latest/deep.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"NESTEDOK"], @"a benign in-root symlink stopped being served");
+    [basePath stop];
+
+    // The opt-out has to actually opt in, or it is not an escape hatch.
+    WSKWebServer* permissive = [[WSKWebServer alloc] init];
+    [permissive addGETHandlerForBasePath:@"/files/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:YES allowHiddenItems:YES];
+    XCTAssertTrue([permissive startWithOptions:options error:NULL]);
+    XCTAssertTrue([SendRawRequest(permissive.port, @"GET /files/pub/config HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"SECRETGITCONFIG"], @"allowHiddenItems:YES did not permit a hidden item");
+    [permissive stop];
+
+    WSKWebUploader* uploader = [[WSKWebUploader alloc] initWithUploadDirectory:root];
+    XCTAssertTrue([uploader startWithOptions:options error:NULL]);
+    XCTAssertFalse([SendRawRequest(uploader.port, @"GET /download?path=/pub/config HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"SECRETGITCONFIG"], @"the uploader downloaded through the symlink");
+    XCTAssertFalse([SendRawRequest(uploader.port, @"GET /list?path=/pub HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"config"], @"the uploader enumerated a dot-directory through the symlink");
+    XCTAssertTrue([SendRawRequest(uploader.port, @"GET /download?path=/data/normal.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"PUBLICOK"], @"the uploader stopped serving an ordinary file");
+    [uploader stop];
+
+    WSKWebDAVServer* dav = [[WSKWebDAVServer alloc] initWithUploadDirectory:root];
+    XCTAssertTrue([dav startWithOptions:options error:NULL]);
+    XCTAssertFalse([SendRawRequest(dav.port, @"GET /pub/config HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"SECRETGITCONFIG"], @"WebDAV read through the symlink");
+    // The write is the sharpest one: the same PUT spelled "/.git/hooks/x" is refused.
+    SendRawRequest(dav.port, @"PUT /pub/hooks/x HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\nevil");
+    XCTAssertFalse([fm fileExistsAtPath:[root stringByAppendingPathComponent:@".git/hooks/x"]], @"WebDAV wrote inside a dot-directory through the symlink");
+    NSString* legitimate = SendRawRequest(dav.port, @"PUT /data/ok.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\ngood");
+    XCTAssertTrue([legitimate hasPrefix:@"HTTP/1.1 201"], @"WebDAV stopped accepting an ordinary PUT: %@", [legitimate substringToIndex:MIN((NSUInteger)40, legitimate.length)]);
+    [dav stop];
+
+    [fm removeItemAtPath:root error:NULL];}
+
+// An SSE stream is only ever released when the client that is reading it goes away. A HEAD
+// mapped to GET has no reader at all — the connection layer discards the body unsent — so the
+// channel the handler registered was held by nobody and freed only by the heartbeat reaper,
+// two ticks (~30s) later. That made sixteen HEADs a complete denial of live updates for every
+// real client, and unusually cheap to sustain: each request *completes*, so the sender holds
+// no connection slot and can repeat the burst every 30s from anywhere on the network.
+// Measured before the fix: 16 HEADs, then a genuine EventSource is refused for 30s.
 - (void)testHEADOnEventsDoesNotConsumeSSEChannels {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* dir = MakeTempDirectory();

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -137,13 +137,30 @@ BOOL WSKPathIsInsideDirectory(NSString *path, NSString *directory);
 BOOL WSKResolvedPathIsWithinDirectory(NSString *path, NSString *directory);
 
 /**
- *  As above, but returns the fully resolved location expressed relative to the
- *  resolved `directory` (empty string when it *is* the directory), or nil when it
- *  is outside or cannot be resolved. Test hidden components against this rather
- *  than against the request path: a non-hidden symlink to a dot-directory has no
- *  dot in the path the client sent.
+ *  Returns `path` resolved and expressed relative to `directory` resolved, or nil if it does
+ *  not resolve inside `directory` — which is exactly the condition
+ *  WSKResolvedPathIsWithinDirectory() reports, so that function is now a wrapper around this
+ *  one and the two cannot drift apart.
+ *
+ *  Relative to the *resolved* root, deliberately: the root itself may live under a hidden
+ *  directory (NSTemporaryDirectory() under a sandboxed app commonly does), and a caller
+ *  examining the absolute resolved path would then judge every file it serves to be hidden.
  */
 NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory);
+
+/**
+ *  Returns YES if `path`, once symlinks are resolved, lies under a component starting with "."
+ *  relative to `directory`.
+ *
+ *  A textual test on the path a client sent cannot see this: a symlink named `pub` pointing at
+ *  `.git` yields the request path "/pub/config", which carries no dot, while containment passes
+ *  too because the target is inside the served root. Both servers' hidden-item rules were
+ *  therefore satisfied by a path whose bytes live inside a dot-directory.
+ *
+ *  Returns NO for a path that does not resolve inside `directory` at all — that is containment's
+ *  business, and reporting it as "hidden" here would mislabel an escape attempt.
+ */
+BOOL WSKResolvedPathHasHiddenComponent(NSString *path, NSString *directory);
 
 #ifdef __cplusplus
 }

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -561,16 +561,43 @@ NSString *WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory
     }
 
     if ([resolvedPath isEqualToString:resolvedDirectory]) {
-        return @"";
+        return @"";  // The root itself, which is inside itself but has no relative part.
     }
 
     if (!WSKPathIsInsideDirectory(resolvedPath, resolvedDirectory)) {
         return nil;
     }
 
+    // Relative to the *resolved* root, which is the whole point: the root itself may sit under
+    // a dot-directory — NSTemporaryDirectory() under a sandboxed app routinely does — and
+    // testing the absolute resolved path for hidden components would then refuse every file
+    // it serves.
     return [resolvedPath substringFromIndex:(resolvedDirectory.length + ([resolvedDirectory hasSuffix:@"/"] ? 0 : 1))];
 }
 
 BOOL WSKResolvedPathIsWithinDirectory(NSString *path, NSString *directory) {
     return (WSKResolvedPathRelativeToDirectory(path, directory) != nil);
+}
+
+BOOL WSKResolvedPathHasHiddenComponent(NSString *path, NSString *directory) {
+    NSString *const relativePath = WSKResolvedPathRelativeToDirectory(path, directory);
+
+    if (relativePath == nil) {
+        // Outside the root, or unresolvable. Containment is a separate check and reports that
+        // separately; answering YES here would mislabel an escape as a hidden item, so say no
+        // and let containment refuse it.
+        return NO;
+    }
+
+    // Resolved, so this catches what a textual test on the request path cannot: a symlink whose
+    // own name carries no dot but whose target lives inside a dot-directory. Both tests are
+    // needed — this one alone would miss nothing here, but it costs a realpath, so callers keep
+    // their cheap textual walk in front of it.
+    for (NSString *component in [relativePath pathComponents]) {
+        if ([component hasPrefix:@"."]) {
+            return YES;
+        }
+    }
+
+    return NO;
 }

--- a/Sources/WebServerKit/Core/WSKWebServer.h
+++ b/Sources/WebServerKit/Core/WSKWebServer.h
@@ -584,6 +584,20 @@ extern NSString *const WSKAuthenticationMethod_DigestAccess;
  */
 - (void)addGETHandlerForBasePath:(NSString *)basePath directoryPath:(NSString *)directoryPath indexFilename:(nullable NSString *)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests;
 
+/**
+ *  As above, but able to serve hidden items.
+ *
+ *  Hidden items are refused by default, and "hidden" means where the bytes actually live, not
+ *  what the client typed: a symlink whose own name carries no dot but which resolves inside a
+ *  dot-directory is refused too. That is what makes this opt-out necessary — a deliberate
+ *  convenience link such as "latest" pointing at ".builds/2026-07-25" is otherwise
+ *  unreachable, with no way to permit it.
+ *
+ *  Passing YES serves dot-files and dot-directories like any other content. Containment is
+ *  unaffected either way: a path resolving outside `directoryPath` is always refused.
+ */
+- (void)addGETHandlerForBasePath:(NSString *)basePath directoryPath:(NSString *)directoryPath indexFilename:(nullable NSString *)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests allowHiddenItems:(BOOL)allowHiddenItems;
+
 @end
 
 /**

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1560,6 +1560,10 @@ static NSString *_EscapeHTMLString(NSString *string) {
 }
 
 - (void)addGETHandlerForBasePath:(NSString *)basePath directoryPath:(NSString *)directoryPath indexFilename:(NSString *)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests {
+    [self addGETHandlerForBasePath:basePath directoryPath:directoryPath indexFilename:indexFilename cacheAge:cacheAge allowRangeRequests:allowRangeRequests allowHiddenItems:NO];
+}
+
+- (void)addGETHandlerForBasePath:(NSString *)basePath directoryPath:(NSString *)directoryPath indexFilename:(NSString *)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests allowHiddenItems:(BOOL)allowHiddenItems {
     if ([basePath hasPrefix:@"/"] && [basePath hasSuffix:@"/"]) {
         WSKWebServer *__unsafe_unretained server = self;
         [self
@@ -1585,6 +1589,15 @@ static NSString *_EscapeHTMLString(NSString *string) {
                 // that vend files already refuse hidden items; this was the one file-serving
                 // path in the library with no such concept. Every component is tested, not
                 // just the leaf, because the interesting secrets live *inside* a dot-directory.
+                if (!allowHiddenItems) {
+                    for (NSString *component in [relativePath componentsSeparatedByString:@"/"]) {
+                        if ([component hasPrefix:@"."]) {
+                            WSK_LOG_WARNING(@"Refusing to serve \"%@\": \"%@\" is a hidden item", relativePath, component);
+                            return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
+                        }
+                    }
+                }
+
                 NSString *filePath = [directoryPath stringByAppendingPathComponent:relativePath];
                 // Stripping ".." textually is not containment: -attributesOfItemAtPath: uses
                 // lstat, which only refuses a symlink as the *final* component, and O_NOFOLLOW
@@ -1599,11 +1612,14 @@ static NSString *_EscapeHTMLString(NSString *string) {
                     return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
                 }
 
-                for (NSString *component in [resolvedRelativePath componentsSeparatedByString:@"/"]) {
-                    if ([component hasPrefix:@"."]) {
-                        WSK_LOG_WARNING(@"Refusing to serve \"%@\": \"%@\" is a hidden item", relativePath, component);
-                        return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
-                    }
+                // Containment and hiddenness are independent, and the textual walk above only
+                // sees the path the *client* typed. A symlink named "pub" pointing at ".git"
+                // carries no dot in "/pub/config" and resolves inside the root, so both checks
+                // passed and the file was served. Tested after containment so an escape is still
+                // reported as an escape rather than mislabelled a hidden item.
+                if (!allowHiddenItems && WSKResolvedPathHasHiddenComponent(filePath, directoryPath)) {
+                    WSK_LOG_WARNING(@"Refusing to serve \"%@\": it resolves inside a hidden item", relativePath);
+                    return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
                 }
 
                 NSString *fileType = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:NULL] fileType];

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -182,13 +182,22 @@ NS_ASSUME_NONNULL_END
         return NO;
     }
 
-    for (NSString *component in [WSKNormalizePath(relativePath) pathComponents]) {
+    NSString *const normalizedPath = WSKNormalizePath(relativePath);
+
+    for (NSString *component in [normalizedPath pathComponents]) {
         if ([component hasPrefix:@"."]) {  // The leading "/" component never matches.
             return YES;
         }
     }
 
-    return NO;
+    // The walk above sees only what the client typed, and that is not where the bytes live: a
+    // symlink named "pub" pointing at ".git" makes "/pub/config" carry no dot at all, while
+    // containment passes because the target is inside the share. Both rules were satisfied by a
+    // path inside a dot-directory — readable here, enumerable through /list, and writable
+    // through DAV PUT, which refuses the same write spelled "/.git/hooks/x". Resolving is the
+    // only way to see it. The cheap textual walk stays in front so the realpath is only paid
+    // when it can change the answer.
+    return WSKResolvedPathHasHiddenComponent([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory);
 }
 
 // A unique, hidden sibling of `path`. Building a replacement here — rather than removing

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -912,13 +912,22 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
         return NO;
     }
 
-    for (NSString *component in [WSKNormalizePath(relativePath) pathComponents]) {
+    NSString *const normalizedPath = WSKNormalizePath(relativePath);
+
+    for (NSString *component in [normalizedPath pathComponents]) {
         if ([component hasPrefix:@"."]) {  // The leading "/" component never matches.
             return YES;
         }
     }
 
-    return NO;
+    // The walk above sees only what the client typed, and that is not where the bytes live: a
+    // symlink named "pub" pointing at ".git" makes "/pub/config" carry no dot at all, while
+    // containment passes because the target is inside the share. Both rules were satisfied by a
+    // path inside a dot-directory — readable here, enumerable through /list, and writable
+    // through DAV PUT, which refuses the same write spelled "/.git/hooks/x". Resolving is the
+    // only way to see it. The cheap textual walk stays in front so the realpath is only paid
+    // when it can change the answer.
+    return WSKResolvedPathHasHiddenComponent([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory);
 }
 
 // Map an absolute path inside the share back to the client-facing relative path used in


### PR DESCRIPTION
Hiddenness and containment are **independent** rules, and the hidden-item checks tested only the
path the client typed. A symlink named `pub` pointing at `.git` makes `/pub/config` carry no dot,
and containment passes because the target is inside the served root — so both rules were
satisfied by a path whose bytes live inside a dot-directory.

### State against current `main`

| vector | on `main` now |
|---|---|
| base-path `GET /files/pub/config` | already refused |
| base-path via a chain of links | already refused |
| uploader `GET /download?path=/pub/config` | **serves `.git/config`** |
| uploader `GET /list?path=/pub` | **enumerates `.git`** — discoverable, not guessed |
| DAV `GET /pub/config` | **serves it** |
| DAV `PUT /pub/hooks/x` | **201 Created**, lands in `.git/hooks/x` |

That last one is the sharpest: the same server refuses the same write spelled `/.git/hooks/x`.

### Correction about how the base-path half got fixed

Those first two rows are closed on `main`, but **not deliberately**. That half arrived as an
unreviewed edit swept into commit `aa1969a` by a `git add -A` while background audit agents were
writing to the working tree. `aa1969a`'s message describes only the If-Range change, so the
record is wrong about how it got there — noted in CLAUDE.md rather than left implicit.

Two differences from that version are kept here:
- the cheap **textual walk goes back in front** of the resolved one, so a `realpath` is only paid
  when it can change the answer;
- the resolved test moves **after containment**, so an escape is still reported as an escape
  rather than mislabelled a hidden item.

### The fix

`WSKResolvedPathHasHiddenComponent()` tests the **resolved** path expressed relative to the
**resolved root**. Relative to the root deliberately — the root itself may live under a
dot-directory (`NSTemporaryDirectory()` under a sandboxed app routinely does), and testing the
absolute path would refuse every file the server vends. **That case is in the test**, because it
is the trap a naive version of this springs.

### The opt-out

"Hidden" now means where the bytes live, so a deliberate convenience link like
`latest -> .builds/2026-07-25` stops resolving — and `addGETHandlerForBasePath:` had no
`allowHiddenItems` concept at all, leaving no way to permit it. It gains an `allowHiddenItems:`
variant; the existing five-argument form delegates with `NO`, so **no existing caller changes
behaviour**. The uploader and WebDAV already had the property.

### Verification

`testHiddenItemsAreRefusedThroughSymlinksToo` fails with **exactly those four failures** against
current `main` (run from a pristine `git archive` copy). Its "must still serve" assertions — an
ordinary file, a benign in-root symlink, an ordinary DAV PUT, and the opt-out actually opting in
— pass on both sides, so it is not simply refusing everything.

Full harness green: **90 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.