### PR TITLE
Let an SSE channel die with its connection instead of with the reaper

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1453,7 +1453,8 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     XCTAssertTrue([gAbortRequestPeer hasPrefix:@"127.0.0.1"], @"peer address is wrong: %@", gAbortRequestPeer);
     XCTAssertTrue(gAbortRequestSawVirtualHEAD, @"a mapped HEAD must be distinguishable from a real GET on this path");
 
-    [server stop];}
+    [server stop];
+}
 
 // Hiddenness and containment are independent rules, and the hidden-item walk saw only the path
 // the client typed. A symlink named "pub" pointing at ".git" makes "/pub/config" carry no dot,
@@ -1512,7 +1513,61 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     XCTAssertTrue([legitimate hasPrefix:@"HTTP/1.1 201"], @"WebDAV stopped accepting an ordinary PUT: %@", [legitimate substringToIndex:MIN((NSUInteger)40, legitimate.length)]);
     [dav stop];
 
-    [fm removeItemAtPath:root error:NULL];}
+    [fm removeItemAtPath:root error:NULL];
+}
+
+// A channel used to outlive its own connection by a full 30s: the server learned of the client's
+// departure only when a write failed, and only *then* did the reaper start counting its two idle
+// ticks. So 16 abandoned streams — browser tabs navigating away, no hostility required — denied
+// live updates to a real client long after the server knew every one of them was gone. The
+// channel now dies with the connection, and the reaper remains the backstop for a client that is
+// merely silent.
+//
+// The clients here reset rather than closing gracefully, and a broadcast is issued to force the
+// write that discovers them. Both are for speed: they collapse the discovery delay that this fix
+// does NOT address, isolating the 30s reaper tail that it does. A graceful close is slower on
+// both sides of the fix (measured: 62s before, 32s after).
+- (void)testSSEChannelIsReleasedWhenItsConnectionEnds {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+    NSString* host = [NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port];
+    NSString* sseRequest = [NSString stringWithFormat:@"GET /events HTTP/1.1\r\nHost: %@\r\nAccept: text/event-stream\r\nSec-Fetch-Dest: empty\r\nSec-Fetch-Mode: cors\r\nSec-Fetch-Site: same-origin\r\n\r\n", host];
+
+    // Fill every one of the kMaxSSEChannels slots, then abandon them.
+    for (NSUInteger i = 0; i < 16; i++) {
+        int fd = ConnectToLocalhostPort(server.port);
+        XCTAssertTrue(fd >= 0, @"could not open stream %lu", (unsigned long)i);
+        const char* bytes = [sseRequest UTF8String];
+        send(fd, bytes, strlen(bytes), 0);
+        char buffer[2048];
+        recv(fd, buffer, sizeof(buffer), 0);  // Let the stream actually start.
+        struct linger abortive = {1, 0};      // RST, so the server's next write fails at once.
+        setsockopt(fd, SOL_SOCKET, SO_LINGER, &abortive, sizeof(abortive));
+        close(fd);
+    }
+
+    // Provoke a write to every channel, which is what discovers the dead ones.
+    NSString* createBody = @"path=/probe-folder";
+    SendRawRequest(server.port, [NSString stringWithFormat:@"POST /create HTTP/1.1\r\nHost: %@\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: %lu\r\n\r\n%@", host, (unsigned long)createBody.length, createBody]);
+
+    // Recovery is ~2s with the fix and ~31s without it, so this bound separates them widely
+    // while staying well inside a suite that otherwise runs in about eight seconds.
+    BOOL granted = NO;
+    for (NSUInteger attempt = 0; (attempt < 12) && !granted; attempt++) {
+        [NSThread sleepForTimeInterval:1.0];
+        NSString* reply = SendRawRequestUntilMarker(server.port, sseRequest, @"retry: 3000\n\n", 2.0);
+        // "retry: 30000" (refused) contains "retry: 3000" (accepted), so test the longer first.
+        granted = ![reply containsString:@"retry: 30000"] && [reply containsString:@"retry: 3000\n\n"];
+    }
+    XCTAssertTrue(granted, @"channels were still held long after the server knew every client had gone");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
 
 // An SSE stream is only ever released when the client that is reading it goes away. A HEAD
 // mapped to GET has no reader at all — the connection layer discards the body unsent — so the

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -144,6 +144,32 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
+// WSKConnection calls -performClose on the response the moment its body write chain ends,
+// including the write that fails because the client has gone. Nothing listened for that, so a
+// channel outlived its own connection by a full 30 seconds: the server only learned of the
+// departure when a heartbeat write failed (15-30s), and only then did the reaper begin counting
+// its two idle ticks. Sixteen abandoned streams therefore denied live updates to a real client
+// for roughly 45-60s — a browser tab navigating away is enough, no hostility required.
+@interface WSKWebUploaderSSEResponse : WSKStreamedResponse
+@property (nonatomic, copy, nullable) dispatch_block_t onClose;
+@end
+
+@implementation WSKWebUploaderSSEResponse
+
+- (void)close {
+    // Taken once: -close is reachable more than once, and the block drops the channel.
+    dispatch_block_t const block = _onClose;
+
+    _onClose = nil;
+    [super close];
+
+    if (block) {
+        block();
+    }
+}
+
+@end
+
 @interface WSKWebUploader () <NSFilePresenter>
 @end
 
@@ -551,8 +577,8 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
                              // back-off above for a client that was refused on an earlier attempt.
                              [channel enqueueData:(NSData *)[kSSEAcceptedStreamPreamble dataUsingEncoding:NSUTF8StringEncoding]];
 
-                             WSKStreamedResponse *response =
-                                 [WSKStreamedResponse responseWithContentType:@"text/event-stream"
+                             WSKWebUploaderSSEResponse *response =
+                                 [WSKWebUploaderSSEResponse responseWithContentType:@"text/event-stream"
                                                                       asyncStreamBlock:^(WSKBodyReaderCompletionBlock dataBlock) {
                                      dispatch_async(server->_sseQueue, ^{
                                          [channel parkReader:^(NSData *data) {
@@ -560,6 +586,25 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
                                          }];
                                      });
                                  }];
+                             // Let the channel die with the connection rather than waiting for
+                             // the reaper to notice. The reaper stays as the backstop for a
+                             // client that is merely silent — this only fires when the body
+                             // write chain has actually ended. Weak, because the response
+                             // outlives nothing but must not keep the uploader alive; the
+                             // handler's own capture is __unsafe_unretained.
+                             __weak WSKWebUploader *const weakServer = server;
+                             response.onClose = ^{
+                                 WSKWebUploader *const strongServer = weakServer;
+
+                                 if (strongServer == nil) {
+                                     return;
+                                 }
+
+                                 dispatch_async(strongServer->_sseQueue, ^{
+                                     [strongServer->_sseChannels removeObject:channel];
+                                     [channel close];  // Completes any parked reader; harmless if already closed.
+                                 });
+                             };
                              response.cacheControlMaxAge = 0;
                              [response setValue:@"no-cache" forAdditionalHeader:@"Cache-Control"];
                              // No "Connection: keep-alive" here: it would overwrite the connection


### PR DESCRIPTION
`WSKConnection` calls `-performClose` on the response the moment its body write chain ends —
including the write that fails because the client has gone. Nothing in the uploader listened, so
a channel outlived its own connection by a full **30 seconds**: the server learned of the
departure when a write failed (15–30s), and only *then* did the reaper start counting its two
idle ticks.

Sixteen abandoned streams therefore denied live updates to a real client for about a minute, and
it takes no hostility to produce them — browser tabs opening the page and navigating away is
enough.

### Measured, with graceful closes (what a tab actually does)

| | recovery |
|---|---|
| `main` | **62s** |
| this branch | **32s** |

### What it does not fix

A halving, not a cure, and the remainder is worth stating plainly: this removes the reaper's 30s
tail **only**. The 15–30s the server takes to *discover* the departure is untouched, because
nothing tells it until a write fails. The reaper stays as the backstop for a client that is
merely silent rather than gone.

(A related one-constant lever exists if this ever matters more: the refusal body sets
`retry: 30000`, so a refused `EventSource` then waits out its own 30s backoff on top.)

### How

A file-private `WSKStreamedResponse` subclass carries a close hook; the uploader drops the
channel from `_sseChannels` and closes it, completing any parked reader. The capture is weak so
the response cannot keep the uploader alive, and the hook is taken-once because `-close` is
reachable more than once.

### Verification

`testSSEChannelIsReleasedWhenItsConnectionEnds` runs in **under two seconds** and fails against
`main` (run from a pristine `git archive` copy).

Its clients reset rather than closing gracefully, and it issues a broadcast to force the
discovering write. Both are deliberate: they collapse the discovery delay this change does *not*
address, isolating the reaper tail it does — recovery is ~2s with the fix and ~31s without, so
the bound separates them widely while keeping a suite that otherwise runs in ~8s fast.

Full harness green: **87 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.