### PR TITLE
Refuse client paths containing a NUL instead of truncating them

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1391,6 +1391,49 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 // files a direct DELETE would refuse — otherwise the same allow-list means two different
 // things depending on how the request is phrased. Dot-files are the one exception: the
 // client cannot see or address them, and every macOS folder carries a ".DS_Store".
+// WSKNormalizePath truncates at an embedded NUL, because the filesystem's C-string APIs do and
+// the mismatch is otherwise exploitable ("secret.dat\0.png" passes an extension allow-list and
+// opens "secret.dat"). But truncating meant the server then honoured a request the client never
+// made. Two consequences, both measured: "/list?path=\0" passed every guard on the truncated
+// path and built a per-entry dictionary literal from the RAW one, where
+// -stringByAppendingPathComponent: returns nil for a NUL-bearing receiver — NSInvalidArgumentException,
+// uncaught, process gone, from one unauthenticated GET in Debug and Release alike. And
+// "/delete?path=/Keep\0/nonexistent" named nothing that exists, yet deleted "/Keep".
+//
+// NOTE: against the unfixed source the first half does not fail, it ABORTS the test process,
+// which xctest reports as "0 failures". Read the executed count.
+- (void)testUploaderRefusesPathsContainingNULRatherThanTruncating {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    NSString* keep = [dir stringByAppendingPathComponent:@"Keep"];
+    XCTAssertTrue([fm createDirectoryAtPath:keep withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"precious" writeToFile:[keep stringByAppendingPathComponent:@"data.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+    NSString* host = [NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port];
+
+    // The listing endpoint, which is where the nil reached the dictionary literal.
+    for (NSString* encoded in @[ @"%00", @"/Keep%00", @"%00/Keep", @"/%00" ]) {
+        NSString* reply = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /list?path=%@ HTTP/1.1\r\nHost: %@\r\n\r\n", encoded, host]);
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 400"], @"\"%@\" should be refused: %@", encoded, [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+    }
+
+    // A destructive request must never be honoured against a truncated prefix.
+    NSString* body = @"path=%2FKeep%00%2Fnonexistent";
+    NSString* deleted = SendRawRequest(server.port, [NSString stringWithFormat:@"POST /delete HTTP/1.1\r\nHost: %@\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: %lu\r\n\r\n%@", host, (unsigned long)body.length, body]);
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 400"], @"a NUL-bearing delete should be refused: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:keep], @"the truncated prefix was deleted instead of the path the client sent");
+
+    // And the ordinary paths must be untouched by all of this.
+    XCTAssertTrue([SendRawRequest(server.port, [NSString stringWithFormat:@"GET /list?path=/ HTTP/1.1\r\nHost: %@\r\n\r\n", host]) hasPrefix:@"HTTP/1.1 200"], @"an ordinary listing stopped working");
+    XCTAssertTrue([SendRawRequest(server.port, [NSString stringWithFormat:@"GET /list?path=/Keep HTTP/1.1\r\nHost: %@\r\n\r\n", host]) containsString:@"data.txt"], @"listing a subdirectory stopped working");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 - (void)testUploaderRecursiveDeleteRespectsExtensionAllowList {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* dir = MakeTempDirectory();

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -103,6 +103,20 @@ NSString *WSKFormatISO8601(NSDate *date);
 NSDate *_Nullable WSKParseISO8601(NSString *string);
 
 /**
+ *  Returns YES if `path` contains an embedded NUL.
+ *
+ *  WSKNormalizePath() truncates at a NUL, because the filesystem's C-string APIs do and the
+ *  mismatch is exploitable — "secret.dat\0.png" otherwise passes an extension allow-list and
+ *  then opens "secret.dat". But truncating means the server goes on to honour a request the
+ *  client did not make: "/Keep\0/nonexistent" named nothing, and deleted "/Keep".
+ *
+ *  So a client-supplied path carrying a NUL should be REFUSED at the point it arrives, not
+ *  quietly rewritten. Normalization keeps truncating as a second line for any path that reaches
+ *  it by another route.
+ */
+BOOL WSKPathContainsNULByte(NSString *_Nullable path);
+
+/**
  *  Removes "//", "/./" and "/../" components from path as well as any trailing slash.
  */
 NSString *WSKNormalizePath(NSString *path);

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -480,6 +480,11 @@ NSString *WSKComputeMD5Digest(NSString *format, ...) {
     return (NSString *)[NSString stringWithUTF8String:buffer];
 }
 
+BOOL WSKPathContainsNULByte(NSString *path) {
+    unichar nul = 0;
+    return (path != nil) && ([path rangeOfString:[NSString stringWithCharacters:&nul length:1]].location != NSNotFound);
+}
+
 NSString *WSKNormalizePath(NSString *path) {
     // Treat an embedded NUL as a path terminator, the way the filesystem's C-string APIs do.
     // Otherwise -pathExtension reads past the NUL while -fileSystemRepresentation truncates at

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -1032,8 +1032,18 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
     // into a dictionary literal raises NSInvalidArgumentException, and nothing here
     // catches it, so a bare "GET /list" terminated the whole app.
     NSString *const requestedPath = [request query][@"path"];
+
+    if (WSKPathContainsNULByte(requestedPath)) {
+        // Refuse rather than let WSKNormalizePath truncate and act on the prefix: the request
+        // would then be honoured as something the client did not ask for. "/Keep\0/nonexistent"
+        // named nothing and deleted "/Keep"; "/list?path=\0" reached a per-entry dictionary
+        // literal with a nil value and terminated the process.
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Path contains a NUL byte"];
+    }
+
     NSString *const relativePath = requestedPath ? requestedPath : @"/";
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *const normalizedPath = WSKNormalizePath(relativePath);
+    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:normalizedPath];
     BOOL isDirectory = NO;
 
     if (!absolutePath || ![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
@@ -1071,13 +1081,13 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 
             if ([type isEqualToString:NSFileTypeRegular] && size && [self _checkFileExtension:item]) {
                 [array addObject:@{
-                    @"path": [relativePath stringByAppendingPathComponent:item],
+                    @"path": [normalizedPath stringByAppendingPathComponent:item],
                     @"name": item,
                     @"size": size
                 }];
             } else if ([type isEqualToString:NSFileTypeDirectory]) {
                 [array addObject:@{
-                    @"path": [[relativePath stringByAppendingPathComponent:item] stringByAppendingString:@"/"],
+                    @"path": [[normalizedPath stringByAppendingPathComponent:item] stringByAppendingString:@"/"],
                     @"name": item
                 }];
             }
@@ -1090,6 +1100,15 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 - (WSKResponse *)downloadFile:(WSKRequest *)request {
     // Never nil, so error bodies name a path instead of "(null)" — and match -listDirectory:.
     NSString *const requestedPath = [request query][@"path"];
+
+    if (WSKPathContainsNULByte(requestedPath)) {
+        // Refuse rather than let WSKNormalizePath truncate and act on the prefix: the request
+        // would then be honoured as something the client did not ask for. "/Keep\0/nonexistent"
+        // named nothing and deleted "/Keep"; "/list?path=\0" reached a per-entry dictionary
+        // literal with a nil value and terminated the process.
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Path contains a NUL byte"];
+    }
+
     NSString *const relativePath = requestedPath ? requestedPath : @"/";
     NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
@@ -1258,12 +1277,30 @@ static NSString *_OriginAuthority(NSString *value) {
     }
 
     NSString *const oldRelativePath = request.arguments[@"oldPath"];
+
+    if (WSKPathContainsNULByte(oldRelativePath)) {
+        // Refuse rather than let WSKNormalizePath truncate and act on the prefix: the request
+        // would then be honoured as something the client did not ask for. "/Keep\0/nonexistent"
+        // named nothing and deleted "/Keep"; "/list?path=\0" reached a per-entry dictionary
+        // literal with a nil value and terminated the process.
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Path contains a NUL byte"];
+    }
+
     NSString *const oldAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(oldRelativePath)];
     BOOL isDirectory = NO;
 
     // Neither endpoint may be the upload directory itself (a missing/empty path
     // collapses to it), which would let a move destroy or displace the root.
     NSString *const newRelativePath = request.arguments[@"newPath"];
+
+    if (WSKPathContainsNULByte(newRelativePath)) {
+        // Refuse rather than let WSKNormalizePath truncate and act on the prefix: the request
+        // would then be honoured as something the client did not ask for. "/Keep\0/nonexistent"
+        // named nothing and deleted "/Keep"; "/list?path=\0" reached a per-entry dictionary
+        // literal with a nil value and terminated the process.
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Path contains a NUL byte"];
+    }
+
     NSString *const desiredNewPath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(newRelativePath)];
     if (!WSKPathIsInsideDirectory(oldAbsolutePath, _uploadDirectory) || !WSKPathIsInsideDirectory(desiredNewPath, _uploadDirectory)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Operating on the root directory is not allowed"];
@@ -1350,6 +1387,15 @@ static NSString *_OriginAuthority(NSString *value) {
     }
 
     NSString *const relativePath = request.arguments[@"path"];
+
+    if (WSKPathContainsNULByte(relativePath)) {
+        // Refuse rather than let WSKNormalizePath truncate and act on the prefix: the request
+        // would then be honoured as something the client did not ask for. "/Keep\0/nonexistent"
+        // named nothing and deleted "/Keep"; "/list?path=\0" reached a per-entry dictionary
+        // literal with a nil value and terminated the process.
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Path contains a NUL byte"];
+    }
+
     NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
 
@@ -1451,6 +1497,15 @@ static NSString *_OriginAuthority(NSString *value) {
     }
 
     NSString *const relativePath = request.arguments[@"path"];
+
+    if (WSKPathContainsNULByte(relativePath)) {
+        // Refuse rather than let WSKNormalizePath truncate and act on the prefix: the request
+        // would then be honoured as something the client did not ask for. "/Keep\0/nonexistent"
+        // named nothing and deleted "/Keep"; "/list?path=\0" reached a per-entry dictionary
+        // literal with a nil value and terminated the process.
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Path contains a NUL byte"];
+    }
+
     NSString *const desiredPath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
 
     // An empty path collapses to the upload directory itself; refuse it (uniquing


### PR DESCRIPTION
Found by property-based testing of the path rules — **188 of 2,356 generated enumeration paths**
triggered it.

### One unauthenticated GET kills the process

`WSKNormalizePath` truncates at an embedded NUL, deliberately: the filesystem's C-string APIs do,
and the mismatch is exploitable (`secret.dat\0.png` would otherwise pass an extension allow-list
and open `secret.dat`). Truncating closes that. What it does **not** do is make the request mean
what the client wrote — and the server went on to honour the prefix.

`GET /list?path=%00` passes every guard, because normalization truncates it to the upload root:
exists, contained, not hidden. The per-entry JSON is then built from the **raw** query value,
where `-stringByAppendingPathComponent:` returns `nil` for a NUL-bearing receiver:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException',
    reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]:
             attempt to insert nil object from objects[0]'
    4  WebServerKit  -[WSKWebUploader(Methods) listDirectory:] + 1912
```

Reproduced **5/5 in Debug and 5/5 in Release** — an uncaught ObjC exception aborts either way.

### The worse half: a destructive request honoured against the prefix

```
POST /delete   path=/Keep%00/nonexistent   ->  200 OK
/Keep exists after: no
```

The client named something that does not exist. The server deleted its parent.

This library has a stated position on exactly that: *a request the server cannot honour exactly
should fail with a status that says so, leaving prior state untouched.*

### The fix

All six uploader endpoints that take a client path refuse a NUL-bearing one with **400** before
doing anything. Normalization keeps truncating as a second line for any path arriving by another
route, so the extension-allow-list bypass stays closed.

The listing also builds its JSON from the normalized path, so the paths it hands back describe the
directory it actually enumerated — belt-and-braces behind the guard, not the fix.

### Scope

**Pre-existing, not from the seventh pass** — both halves predate it, established by building the
pre-pass commit rather than by reading. It is the crash shape CLAUDE.md already names as recurring
here ("a nil value reaching a dictionary literal"), resurfacing at a site the earlier fix for it
did not cover.

### Verification

`testUploaderRefusesPathsContainingNULRatherThanTruncating` covers both halves. Against `main` it
does **not fail — it ABORTS the test process**, which xctest reports as *"Executed 0 tests, with 0
failures"*. Verified by reading the executed count.

Full harness green: **92 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.