### PR TITLE
Resolve the served path once, and serve that

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -2600,6 +2600,71 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:root error:NULL];
 }
 
+// Containment was decided on one realpath, hiddenness on a second, and the file was then opened
+// by a THIRD path — the one the client typed, symlinks and all. Those are three observations of a
+// filesystem that need not agree. Retargeting a symlink between them served content from outside
+// the served root in 24% of requests measured, with no concurrency on the client side at all.
+// Serving the resolved path closes that: a resolved path contains no symlinks, so retargeting one
+// cannot redirect the open.
+//
+// This asserts the property, not a timing: the request is issued while a helper flips the link,
+// and the invariant is that NO response ever carries content from outside the root. Against the
+// unfixed source it fails within a few hundred iterations.
+- (void)testRetargetedSymlinkCannotEscapeTheServedRoot {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* base = MakeTempDirectory();
+    NSString* root = [base stringByAppendingPathComponent:@"root"];
+    NSString* outside = [base stringByAppendingPathComponent:@"outside"];
+    XCTAssertTrue([fm createDirectoryAtPath:[root stringByAppendingPathComponent:@"good"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([fm createDirectoryAtPath:outside withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"PUBLIC_MARKER" writeToFile:[root stringByAppendingPathComponent:@"good/target.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"SECRET_OUTSIDE_MARKER" writeToFile:[outside stringByAppendingPathComponent:@"target.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    NSString* link = [root stringByAppendingPathComponent:@"link"];
+    NSString* staging = [root stringByAppendingPathComponent:@".flip"];
+    XCTAssertEqual(symlink("good", link.fileSystemRepresentation), 0);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/files/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:NO];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // Retarget atomically via rename(2), so the link is never absent — an unlink/symlink pair
+    // would leave ENOENT windows and make the run look cleaner than it is.
+    __block BOOL stop = NO;
+    dispatch_queue_t flipper = dispatch_queue_create("flip", DISPATCH_QUEUE_SERIAL);
+    dispatch_async(flipper, ^{
+        NSUInteger i = 0;
+        while (!stop) {
+            unlink(staging.fileSystemRepresentation);
+            if (symlink((i++ & 1) ? "good" : "../outside", staging.fileSystemRepresentation) == 0) {
+                rename(staging.fileSystemRepresentation, link.fileSystemRepresentation);
+            }
+        }
+    });
+
+    NSUInteger escapes = 0;
+    for (NSUInteger i = 0; i < 600; i++) {
+        NSString* reply = SendRawRequest(server.port, @"GET /files/link/target.txt HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        if ([reply containsString:@"SECRET_OUTSIDE_MARKER"]) {
+            escapes++;
+        }
+    }
+    stop = YES;
+    dispatch_sync(flipper, ^{
+    });
+
+    XCTAssertEqual(escapes, (NSUInteger)0, @"%lu of 600 responses served content from outside the served root", (unsigned long)escapes);
+
+    // And the honest case must still work, or this has just broken symlinks entirely.
+    unlink(link.fileSystemRepresentation);
+    XCTAssertEqual(symlink("good", link.fileSystemRepresentation), 0);
+    XCTAssertTrue([SendRawRequest(server.port, @"GET /files/link/target.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"PUBLIC_MARKER"], @"a stable in-root symlink stopped being served");
+
+    [server stop];
+    [fm removeItemAtPath:base error:NULL];
+}
+
 - (void)testBasePathHandlerRefusesSymlinkEscape {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* root = MakeTempDirectory();

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -146,6 +146,26 @@ BOOL WSKResolvedPathIsWithinDirectory(NSString *path, NSString *directory);
  *  directory (NSTemporaryDirectory() under a sandboxed app commonly does), and a caller
  *  examining the absolute resolved path would then judge every file it serves to be hidden.
  */
+/**
+ *  Resolves `path` ONCE and reports everything a caller needs from that single observation:
+ *  returns the fully resolved absolute location if it is inside `directory` (or is `directory`
+ *  itself), nil otherwise, and writes the same location expressed relative to the resolved
+ *  `directory` into `outRelativePath` when that is non-NULL.
+ *
+ *  Prefer this to calling the two predicates below in sequence. Each of those performs its own
+ *  realpath(3), so a caller that checks containment with one and hiddenness with the other is
+ *  acting on two observations of a filesystem that need not agree — and then usually operates on
+ *  a *third*, the unresolved path the client sent. A symlink retargeted between those steps was
+ *  measured serving content from outside the served root in 24% of requests.
+ *
+ *  Act on the returned path, not on the caller's own: a resolved path contains no symlinks, so
+ *  retargeting one cannot redirect the operation that follows. This narrows the window rather
+ *  than closing it — a real directory renamed between resolution and use would still slip
+ *  through, and closing that needs an openat(2) component walk or O_NOFOLLOW_ANY, which would
+ *  also refuse the benign intermediate symlinks that work today.
+ */
+NSString *_Nullable WSKResolveWithinDirectory(NSString *path, NSString *directory, NSString *_Nullable __autoreleasing *_Nullable outRelativePath);
+
 NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory);
 
 /**

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -550,6 +550,31 @@ static NSString *_RealPath(NSString *path) {
     return nil;
 }
 
+NSString *WSKResolveWithinDirectory(NSString *path, NSString *directory, NSString *__autoreleasing *outRelativePath) {
+    NSString *const resolvedPath = _RealPath(path);
+    NSString *const resolvedDirectory = _RealPath(directory);
+
+    if (outRelativePath) {
+        *outRelativePath = nil;
+    }
+
+    if ((resolvedPath == nil) || (resolvedDirectory == nil)) {
+        return nil;  // Fail closed rather than acting on a path we could not verify.
+    }
+
+    if (![resolvedPath isEqualToString:resolvedDirectory] && !WSKPathIsInsideDirectory(resolvedPath, resolvedDirectory)) {
+        return nil;
+    }
+
+    if (outRelativePath) {
+        *outRelativePath = [resolvedPath isEqualToString:resolvedDirectory]
+                               ? @""
+                               : [resolvedPath substringFromIndex:(resolvedDirectory.length + ([resolvedDirectory hasSuffix:@"/"] ? 0 : 1))];
+    }
+
+    return resolvedPath;
+}
+
 NSString *WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory) {
     NSString *const resolvedPath = _RealPath(path);
     // Resolve the directory too: /var is itself a symlink to /private/var on Apple

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1605,22 +1605,36 @@ static NSString *_EscapeHTMLString(NSString *string) {
                 // under directoryPath (a git checkout, an unpacked archive) would serve files
                 // from wherever it points. Resolve the whole path and require it to stay
                 // inside, the way every other file-serving handler in this library does.
-                NSString *const resolvedRelativePath = WSKResolvedPathRelativeToDirectory(filePath, directoryPath);
+                // Resolved ONCE, and everything below acts on the result. Checking containment
+                // with one realpath and hiddenness with another meant two observations of a
+                // filesystem that need not agree, and then serving a *third* path — the one the
+                // client typed, symlinks and all. A symlink retargeted between those steps served
+                // content from outside the served root in 24% of requests, with no concurrency on
+                // the client side at all. Serving the resolved path instead means a retargeted
+                // link cannot redirect the open: a resolved path contains no symlinks.
+                NSString *resolvedRelativePath = nil;
+                NSString *const resolvedPath = WSKResolveWithinDirectory(filePath, directoryPath, &resolvedRelativePath);
 
-                if (resolvedRelativePath == nil) {
+                if (resolvedPath == nil) {
                     WSK_LOG_WARNING(@"Refusing to serve \"%@\": it resolves outside \"%@\"", filePath, directoryPath);
                     return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
                 }
 
-                // Containment and hiddenness are independent, and the textual walk above only
-                // sees the path the *client* typed. A symlink named "pub" pointing at ".git"
-                // carries no dot in "/pub/config" and resolves inside the root, so both checks
-                // passed and the file was served. Tested after containment so an escape is still
-                // reported as an escape rather than mislabelled a hidden item.
-                if (!allowHiddenItems && WSKResolvedPathHasHiddenComponent(filePath, directoryPath)) {
-                    WSK_LOG_WARNING(@"Refusing to serve \"%@\": it resolves inside a hidden item", relativePath);
-                    return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
+                // Hiddenness is judged on that same observation. The textual walk above sees only
+                // the path the client typed, and a symlink named "pub" pointing at ".git" carries
+                // no dot in "/pub/config" while resolving inside the root — so both rules passed
+                // and the file was served. Tested after containment so an escape is still reported
+                // as an escape rather than mislabelled a hidden item.
+                if (!allowHiddenItems) {
+                    for (NSString *component in [resolvedRelativePath pathComponents]) {
+                        if ([component hasPrefix:@"."]) {
+                            WSK_LOG_WARNING(@"Refusing to serve \"%@\": it resolves inside a hidden item", relativePath);
+                            return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_NotFound];
+                        }
+                    }
                 }
+
+                filePath = resolvedPath;
 
                 NSString *fileType = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:NULL] fileType];
 


### PR DESCRIPTION
The base-path handler checked containment with one `realpath(3)`, hiddenness with a **second,
independent** one, and then opened a **third** path entirely — the one the client typed, symlinks
and all. Three observations of a filesystem that need not agree.

### Measured

| | escapes |
|---|---|
| `main`, symlink retargeted mid-request | **977 / 4000 (24.4%)** |
| `main`, link held fixed (control) | 0 / 1000 |
| this branch, retargeted | **0 / 4000**, three runs |

The response carried a file from a *sibling directory of the share*. It needs no concurrency on
the client side — the window is between the server's own steps inside a single request.

Not hypothetical for Shape A: a build server that retargets a `latest ->` symlink while serving is
exactly this shape.

### The fix

`WSKResolveWithinDirectory()` resolves once and reports both the absolute resolved location and
its path relative to the resolved root, so containment and hiddenness are judged on the **same**
observation. The handler then serves the resolved path rather than the client's — a resolved path
contains no symlinks, so retargeting one cannot redirect the open.

**It narrows the window, it does not close it**, and the header documents that. A real directory
renamed between resolution and use would still slip through; closing that needs an `openat(2)`
component walk or `O_NOFOLLOW_ANY`, which would also refuse the benign intermediate symlinks that
work today.

### Scope — deliberately partial

This fixes the **base-path handler only**. The uploader and WebDAV have the same shape and the
same measurements (22% and 23%), including **WebDAV PUT landing a file outside the share**.

They are not in this change because their call sites cover writes to paths that *do not exist
yet*, where resolution falls back to the parent. That deserves its own reviewed change rather
than being swept in behind a read-only fix — this is the most security-critical code in the
library and a wrong fix here is worse than the bug.

### Verification

`testRetargetedSymlinkCannotEscapeTheServedRoot` asserts the property, not a timing: it flips the
link with `rename(2)` so the link is never absent, and requires that no response carries the
outside marker. Against `main` it fails at **151 of 600**.

It also asserts a stable in-root symlink is still served, so this cannot quietly become "symlinks
no longer work" — and `testBasePathHandlerRefusesSymlinkEscape`,
`testHiddenItemsAreRefusedThroughSymlinksToo` and `testBasePathHandlerRefusesHiddenItems` all
still pass.

Full harness green: **92 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.