### PR TITLE
Resolve once in the uploader and WebDAV too, and act on that

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -2610,6 +2610,82 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 // This asserts the property, not a timing: the request is issued while a helper flips the link,
 // and the invariant is that NO response ever carries content from outside the root. Against the
 // unfixed source it fails within a few hundred iterations.
+// The same single-resolution property for the two servers that write. WebDAV was the sharpest:
+// with a symlink retargeted underneath it, 228 of 600 PUTs landed files OUTSIDE the share, and
+// 25.7% of GETs served content from outside it. The uploader's /download leaked 18.4%.
+- (void)testRetargetedSymlinkCannotEscapeTheUploaderOrWebDAV {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* base = MakeTempDirectory();
+    NSString* root = [base stringByAppendingPathComponent:@"root"];
+    NSString* outside = [base stringByAppendingPathComponent:@"outside"];
+    XCTAssertTrue([fm createDirectoryAtPath:[root stringByAppendingPathComponent:@"good"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([fm createDirectoryAtPath:outside withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"PUBLIC_MARKER" writeToFile:[root stringByAppendingPathComponent:@"good/target.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"SECRET_OUTSIDE_MARKER" writeToFile:[outside stringByAppendingPathComponent:@"target.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    NSString* link = [root stringByAppendingPathComponent:@"link"];
+    NSString* staging = [root stringByAppendingPathComponent:@".flip"];
+    XCTAssertEqual(symlink("good", link.fileSystemRepresentation), 0);
+
+    __block BOOL stop = NO;
+    dispatch_queue_t flipper = dispatch_queue_create("flip", DISPATCH_QUEUE_SERIAL);
+    dispatch_async(flipper, ^{
+        NSUInteger i = 0;
+        while (!stop) {
+            unlink(staging.fileSystemRepresentation);
+            if (symlink((i++ & 1) ? "good" : "../outside", staging.fileSystemRepresentation) == 0) {
+                rename(staging.fileSystemRepresentation, link.fileSystemRepresentation);
+            }
+        }
+    });
+
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+
+    WSKWebUploader* uploader = [[WSKWebUploader alloc] initWithUploadDirectory:root];
+    XCTAssertTrue([uploader startWithOptions:options error:NULL]);
+    NSUInteger uploaderLeaks = 0;
+    for (NSUInteger i = 0; i < 400; i++) {
+        if ([SendRawRequest(uploader.port, @"GET /download?path=/link/target.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"SECRET_OUTSIDE_MARKER"]) {
+            uploaderLeaks++;
+        }
+    }
+    [uploader stop];
+
+    WSKWebDAVServer* dav = [[WSKWebDAVServer alloc] initWithUploadDirectory:root];
+    XCTAssertTrue([dav startWithOptions:options error:NULL]);
+    NSUInteger davLeaks = 0;
+    NSUInteger escapedWrites = 0;
+    for (NSUInteger i = 0; i < 400; i++) {
+        if ([SendRawRequest(dav.port, @"GET /link/target.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"SECRET_OUTSIDE_MARKER"]) {
+            davLeaks++;
+        }
+        NSString* name = [NSString stringWithFormat:@"pwn%lu.txt", (unsigned long)i];
+        SendRawRequest(dav.port, [NSString stringWithFormat:@"PUT /link/%@ HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nPWNED", name]);
+        if ([fm fileExistsAtPath:[outside stringByAppendingPathComponent:name]]) {
+            escapedWrites++;
+        }
+    }
+    [dav stop];
+
+    stop = YES;
+    dispatch_sync(flipper, ^{
+    });
+
+    XCTAssertEqual(uploaderLeaks, (NSUInteger)0, @"%lu uploader downloads served content from outside the share", (unsigned long)uploaderLeaks);
+    XCTAssertEqual(davLeaks, (NSUInteger)0, @"%lu WebDAV GETs served content from outside the share", (unsigned long)davLeaks);
+    XCTAssertEqual(escapedWrites, (NSUInteger)0, @"%lu WebDAV PUTs wrote files outside the share", (unsigned long)escapedWrites);
+
+    // The honest cases must still work through both servers.
+    unlink(link.fileSystemRepresentation);
+    XCTAssertEqual(symlink("good", link.fileSystemRepresentation), 0);
+    WSKWebUploader* settled = [[WSKWebUploader alloc] initWithUploadDirectory:root];
+    XCTAssertTrue([settled startWithOptions:options error:NULL]);
+    XCTAssertTrue([SendRawRequest(settled.port, @"GET /download?path=/link/target.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"PUBLIC_MARKER"], @"a stable in-root symlink stopped being served");
+    [settled stop];
+
+    [fm removeItemAtPath:base error:NULL];
+}
+
 - (void)testRetargetedSymlinkCannotEscapeTheServedRoot {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* base = MakeTempDirectory();

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -177,27 +177,40 @@ NS_ASSUME_NONNULL_END
 // Hidden-item protection has to cover every component of the path, not only the leaf:
 // refusing "/.git" while serving "/.git/config" protects nothing. Normalizing first means
 // a benign "." or ".." is resolved away rather than read as a name starting with a period.
-- (BOOL)_isHiddenPath:(NSString *)relativePath {
-    if (_allowHiddenItems) {
-        return NO;
+// See the identical helper in WSKWebUploader: resolve once, judge both rules on that single
+// observation, and act on the returned path rather than the one the client sent. A symlink
+// retargeted between two independent resolutions served content from outside the share and
+// landed a PUT outside it.
+- (nullable NSString *)_resolvedPathForRelativePath:(NSString *)relativePath hidden:(BOOL *)outHidden {
+    NSString *const normalizedPath = WSKNormalizePath(relativePath);
+    NSString *resolvedRelativePath = nil;
+    NSString *const resolvedPath = WSKResolveWithinDirectory([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory, &resolvedRelativePath);
+
+    if (outHidden) {
+        *outHidden = NO;
     }
 
-    NSString *const normalizedPath = WSKNormalizePath(relativePath);
+    if (resolvedPath == nil) {
+        return nil;
+    }
 
-    for (NSString *component in [normalizedPath pathComponents]) {
-        if ([component hasPrefix:@"."]) {  // The leading "/" component never matches.
-            return YES;
+    if (outHidden && !_allowHiddenItems) {
+        for (NSString *component in [normalizedPath pathComponents]) {
+            if ([component hasPrefix:@"."]) {
+                *outHidden = YES;
+                return resolvedPath;
+            }
+        }
+
+        for (NSString *component in [resolvedRelativePath pathComponents]) {
+            if ([component hasPrefix:@"."]) {
+                *outHidden = YES;
+                return resolvedPath;
+            }
         }
     }
 
-    // The walk above sees only what the client typed, and that is not where the bytes live: a
-    // symlink named "pub" pointing at ".git" makes "/pub/config" carry no dot at all, while
-    // containment passes because the target is inside the share. Both rules were satisfied by a
-    // path inside a dot-directory — readable here, enumerable through /list, and writable
-    // through DAV PUT, which refuses the same write spelled "/.git/hooks/x". Resolving is the
-    // only way to see it. The cheap textual walk stays in front so the realpath is only paid
-    // when it can change the answer.
-    return WSKResolvedPathHasHiddenComponent([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory);
+    return resolvedPath;
 }
 
 // A unique, hidden sibling of `path`. Building a replacement here — rather than removing
@@ -303,16 +316,21 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
 
 - (WSKResponse *)performGET:(WSKRequest *)request {
     NSString *const relativePath = request.path;
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
 
     // Containment comes before the item is stat'ed: answering 404-vs-403 from a path that
     // has not been checked yet is an existence oracle for the whole filesystem. Verify the
     // resolved location, not just the path text — a symlink inside the share can point out
     // of it, and the textual normalize/prefix checks cannot see that.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Downloading \"%@\" is not allowed", relativePath];
     }
+
+    absolutePath = resolvedPath;
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
@@ -320,7 +338,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
 
     NSString *const itemName = [absolutePath lastPathComponent];
 
-    if ([self _isHiddenPath:relativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    if (isHidden || (!isDirectory && ![self _checkFileExtension:itemName])) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Downloading \"%@\" is not allowed", relativePath];
     }
 
@@ -361,7 +379,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     }
 
     NSString *const relativePath = request.path;
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory;
 
     if (!WSKPathIsInsideDirectory(absolutePath, _uploadDirectory)) {
@@ -375,9 +393,14 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     // Checked after the parent-exists test above so a genuinely missing collection still
     // reports 409 rather than 403. The destination itself need not exist: the resolver
     // falls back to resolving the parent, so intermediate symlinks are still caught.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Uploading to \"%@\" is not allowed", relativePath];
     }
+
+    absolutePath = resolvedPath;
 
     BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory];
 
@@ -387,7 +410,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
 
     NSString *const fileName = [absolutePath lastPathComponent];
 
-    if ([self _isHiddenPath:relativePath] || ![self _checkFileExtension:fileName]) {
+    if (isHidden || ![self _checkFileExtension:fileName]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Uploading to \"%@\" is not allowed", relativePath];
     }
 
@@ -430,7 +453,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     }
 
     NSString *const relativePath = request.path;
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
 
     // Refuse to operate on the upload directory itself: "DELETE /" collapses to it
@@ -441,9 +464,14 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
 
     // Deleting is destructive, so also confirm the resolved target is inside the share
     // rather than whatever a symlink points to outside it.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed", relativePath];
     }
+
+    absolutePath = resolvedPath;
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
@@ -451,7 +479,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
 
     NSString *const itemName = [absolutePath lastPathComponent];
 
-    if ([self _isHiddenPath:relativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    if (isHidden || (!isDirectory && ![self _checkFileExtension:itemName])) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed", relativePath];
     }
 
@@ -480,7 +508,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     }
 
     NSString *const relativePath = request.path;
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory;
 
     if (!WSKPathIsInsideDirectory(absolutePath, _uploadDirectory)) {
@@ -492,11 +520,16 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     }
 
     // After the parent-exists test, so a missing collection still reports 409 not 403.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Creating \"%@\" is not allowed", relativePath];
     }
 
-    if ([self _isHiddenPath:relativePath]) {
+    absolutePath = resolvedPath;
+
+    if (isHidden) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Creating \"%@\" is not allowed", relativePath];
     }
 
@@ -556,7 +589,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     }
 
     NSString *const srcRelativePath = request.path;
-    NSString *const srcAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(srcRelativePath)];
+    NSString * srcAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(srcRelativePath)];
 
     NSString *const destinationHeader = request.headers[@"Destination"];
     NSString *const hostHeader = request.headers[@"Host"];
@@ -588,7 +621,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Malformed 'Destination' header: %@", destinationHeader];
     }
 
-    NSString *const dstAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(dstRelativePath)];
+    NSString * dstAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(dstRelativePath)];
 
     // Neither source nor destination may be the upload directory itself: a Destination
     // that collapses to the root (e.g. "/" or "/..") would otherwise let a MOVE with
@@ -617,19 +650,27 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     // parent and the source's existence are established above, so those errors keep
     // their own status codes; the destination itself need not exist, since the resolver
     // falls back to its parent.
-    if (!WSKResolvedPathIsWithinDirectory(srcAbsolutePath, _uploadDirectory) || !WSKResolvedPathIsWithinDirectory(dstAbsolutePath, _uploadDirectory)) {
+    BOOL srcIsHidden = NO;
+    BOOL dstIsHidden = NO;
+    NSString *const resolvedSrcPath = [self _resolvedPathForRelativePath:srcRelativePath hidden:&srcIsHidden];
+    NSString *const resolvedDstPath = [self _resolvedPathForRelativePath:dstRelativePath hidden:&dstIsHidden];
+
+    if ((resolvedSrcPath == nil) || (resolvedDstPath == nil)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"%@ \"%@\" to \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", srcRelativePath, dstRelativePath];
     }
 
+    srcAbsolutePath = resolvedSrcPath;
+    dstAbsolutePath = resolvedDstPath;
+
     NSString *const srcName = [srcAbsolutePath lastPathComponent];
 
-    if ([self _isHiddenPath:srcRelativePath] || (!srcIsDirectory && ![self _checkFileExtension:srcName])) {
+    if (srcIsHidden || (!srcIsDirectory && ![self _checkFileExtension:srcName])) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"%@ from \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", srcRelativePath];
     }
 
     NSString *const dstName = [dstAbsolutePath lastPathComponent];
 
-    if ([self _isHiddenPath:dstRelativePath] || (!srcIsDirectory && ![self _checkFileExtension:dstName])) {
+    if (dstIsHidden || (!srcIsDirectory && ![self _checkFileExtension:dstName])) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"%@ to \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", dstRelativePath];
     }
 
@@ -848,14 +889,19 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
     }
 
     NSString *relativePath = request.path;
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
 
     // As in -performGET:, containment is confirmed before the item is stat'ed so that the
     // 404-vs-403 answer is not an existence oracle for paths outside the share.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Retrieving properties for \"%@\" is not allowed", relativePath];
     }
+
+    absolutePath = resolvedPath;
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
@@ -863,7 +909,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
 
     NSString *const itemName = [absolutePath lastPathComponent];
 
-    if ([self _isHiddenPath:relativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    if (isHidden || (!isDirectory && ![self _checkFileExtension:itemName])) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Retrieving properties for \"%@\" is not allowed", relativePath];
     }
 
@@ -924,15 +970,20 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
     }
 
     NSString *const relativePath = request.path;
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
 
     // Locking neither reads nor writes content, but the resolved location is checked here
     // — before the item is stat'ed — so that no path-handling entry point is left without
     // one, and so the 404-vs-403 answer is not an existence oracle outside the share.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Locking \"%@\" is not allowed", relativePath];
     }
+
+    absolutePath = resolvedPath;
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
@@ -998,7 +1049,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
 
     NSString *const itemName = [absolutePath lastPathComponent];
 
-    if ([self _isHiddenPath:relativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    if (isHidden || (!isDirectory && ![self _checkFileExtension:itemName])) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Locking \"%@\" is not allowed", relativePath];
     }
 
@@ -1056,14 +1107,19 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
     }
 
     NSString *const relativePath = request.path;
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
 
     // As in -performLOCK:, checked so that no path-handling entry point lacks one, and
     // ahead of the stat so the 404-vs-403 answer reveals nothing outside the share.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Unlocking \"%@\" is not allowed", relativePath];
     }
+
+    absolutePath = resolvedPath;
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
@@ -1077,7 +1133,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
 
     NSString *const itemName = [absolutePath lastPathComponent];
 
-    if ([self _isHiddenPath:relativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    if (isHidden || (!isDirectory && ![self _checkFileExtension:itemName])) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Unlocking \"%@\" is not allowed", relativePath];
     }
 

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -952,27 +952,52 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 // ("/.git/config" listed, downloaded, deleted and overwritten happily). Test every
 // component instead. The path is normalized first so that a benign "." or ".."
 // component is resolved away rather than mistaken for a hidden name.
-- (BOOL)_isHiddenPath:(NSString *)relativePath {
-    if (_allowHiddenItems) {
-        return NO;
+// Resolve the client's path ONCE, so containment and hiddenness are judged on the same
+// observation of the filesystem — and so the caller can act on what was actually vetted.
+//
+// Checking containment with one realpath(3) and hiddenness with another meant two observations
+// that need not agree, and then operating on a *third* path: the one the client sent, symlinks
+// intact. A symlink retargeted between those steps served content from outside the share, and
+// landed a WebDAV PUT outside it. Callers must use the returned path for the filesystem
+// operation that follows: a resolved path contains no symlinks, so retargeting one cannot
+// redirect it. Paths that do not exist yet resolve through their parent, so this works for
+// upload and rename destinations too.
+//
+// Returns nil when the path does not resolve inside the share. Sets *outHidden when the
+// resolved location — or the path the client typed — lies inside a hidden item.
+- (nullable NSString *)_resolvedPathForRelativePath:(NSString *)relativePath hidden:(BOOL *)outHidden {
+    NSString *const normalizedPath = WSKNormalizePath(relativePath);
+    NSString *resolvedRelativePath = nil;
+    NSString *const resolvedPath = WSKResolveWithinDirectory([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory, &resolvedRelativePath);
+
+    if (outHidden) {
+        *outHidden = NO;
     }
 
-    NSString *const normalizedPath = WSKNormalizePath(relativePath);
+    if (resolvedPath == nil) {
+        return nil;
+    }
 
-    for (NSString *component in [normalizedPath pathComponents]) {
-        if ([component hasPrefix:@"."]) {  // The leading "/" component never matches.
-            return YES;
+    if (outHidden && !_allowHiddenItems) {
+        // Both spellings: what the client typed, and where the bytes actually live. The first
+        // catches "/.git/config"; the second catches a symlink named "pub" pointing at ".git",
+        // which carries no dot at all in the path the client sent.
+        for (NSString *component in [normalizedPath pathComponents]) {
+            if ([component hasPrefix:@"."]) {
+                *outHidden = YES;
+                return resolvedPath;
+            }
+        }
+
+        for (NSString *component in [resolvedRelativePath pathComponents]) {
+            if ([component hasPrefix:@"."]) {
+                *outHidden = YES;
+                return resolvedPath;
+            }
         }
     }
 
-    // The walk above sees only what the client typed, and that is not where the bytes live: a
-    // symlink named "pub" pointing at ".git" makes "/pub/config" carry no dot at all, while
-    // containment passes because the target is inside the share. Both rules were satisfied by a
-    // path inside a dot-directory — readable here, enumerable through /list, and writable
-    // through DAV PUT, which refuses the same write spelled "/.git/hooks/x". Resolving is the
-    // only way to see it. The cheap textual walk stays in front so the realpath is only paid
-    // when it can change the answer.
-    return WSKResolvedPathHasHiddenComponent([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory);
+    return resolvedPath;
 }
 
 // Map an absolute path inside the share back to the client-facing relative path used in
@@ -1033,7 +1058,7 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
     // catches it, so a bare "GET /list" terminated the whole app.
     NSString *const requestedPath = [request query][@"path"];
     NSString *const relativePath = requestedPath ? requestedPath : @"/";
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
 
     if (!absolutePath || ![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
@@ -1046,13 +1071,20 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 
     // Verify the resolved location, not just the path text: a symlink somewhere inside
     // the share can point out of it, and normalize/prefix checks cannot see that.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Listing \"%@\" is not allowed", relativePath];
     }
 
-    if ([self _isHiddenPath:relativePath]) {
+    if (isHidden) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Listing hidden path \"%@\" is not allowed", relativePath];
     }
+
+    // Everything below enumerates the location that was just vetted, not the one the client
+    // sent: a resolved path holds no symlinks, so retargeting one cannot redirect it.
+    absolutePath = resolvedPath;
 
     NSError *error = nil;
     NSArray *const contents = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:absolutePath error:&error] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
@@ -1091,7 +1123,7 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
     // Never nil, so error bodies name a path instead of "(null)" — and match -listDirectory:.
     NSString *const requestedPath = [request query][@"path"];
     NSString *const relativePath = requestedPath ? requestedPath : @"/";
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
@@ -1102,14 +1134,19 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"\"%@\" is a directory", relativePath];
     }
 
-    // As in -listDirectory:, confirm the resolved location is still inside the share.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    // As in -listDirectory:, resolved once and served from that resolution.
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Downloading \"%@\" is not allowed", relativePath];
     }
 
-    if ([self _isHiddenPath:relativePath]) {
+    if (isHidden) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Downloading hidden path \"%@\" is not allowed", relativePath];
     }
+
+    absolutePath = resolvedPath;
 
     NSString *const fileName = [absolutePath lastPathComponent];
 
@@ -1205,19 +1242,22 @@ static NSString *_OriginAuthority(NSString *value) {
     }
 
     NSString *const relativePath = [[request firstArgumentForControlName:@"path"] string];
-    NSString *const desiredPath = [[_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)] stringByAppendingPathComponent:fileName];
+    // Vet the destination DIRECTORY once — the leaf is already reduced to a single validated
+    // component above — and compose onto the resolved directory. The client-supplied "path" may
+    // traverse a symlink out of the share, and a non-hidden file name is not enough on its own:
+    // an upload could otherwise drop files into ".git" and friends.
+    BOOL isHidden = NO;
+    NSString *const resolvedDirectory = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
 
-    // A non-hidden file name is not enough: the destination directory must not be hidden
-    // either, at any depth, or an upload could drop files into ".git" and friends.
-    if ([self _isHiddenPath:relativePath]) {
+    if (isHidden) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Uploading to hidden path \"%@\" is not allowed", relativePath];
     }
 
-    // The leaf is already reduced to a single component above, but the client-supplied
-    // "path" it is appended to may traverse a symlink out of the share.
-    if (!WSKResolvedPathIsWithinDirectory(desiredPath, _uploadDirectory)) {
+    if (resolvedDirectory == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Uploading to \"%@\" is not allowed", relativePath];
     }
+
+    NSString *const desiredPath = [resolvedDirectory stringByAppendingPathComponent:fileName];
 
     // Resolving a unique name and moving the uploaded file into place must be
     // atomic against concurrent requests, otherwise two uploads of the same
@@ -1258,31 +1298,39 @@ static NSString *_OriginAuthority(NSString *value) {
     }
 
     NSString *const oldRelativePath = request.arguments[@"oldPath"];
-    NSString *const oldAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(oldRelativePath)];
+    NSString * oldAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(oldRelativePath)];
     BOOL isDirectory = NO;
 
     // Neither endpoint may be the upload directory itself (a missing/empty path
     // collapses to it), which would let a move destroy or displace the root.
     NSString *const newRelativePath = request.arguments[@"newPath"];
-    NSString *const desiredNewPath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(newRelativePath)];
+    NSString * desiredNewPath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(newRelativePath)];
     if (!WSKPathIsInsideDirectory(oldAbsolutePath, _uploadDirectory) || !WSKPathIsInsideDirectory(desiredNewPath, _uploadDirectory)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Operating on the root directory is not allowed"];
     }
 
-    // Both endpoints must also resolve inside the share, so neither can reach out of it
-    // through a symlink (which the textual check above cannot detect).
-    if (!WSKResolvedPathIsWithinDirectory(oldAbsolutePath, _uploadDirectory) || !WSKResolvedPathIsWithinDirectory(desiredNewPath, _uploadDirectory)) {
+    // Both endpoints resolved ONCE each, so neither can reach out of the share through a symlink
+    // (which the textual check above cannot detect) and neither can be redirected between the
+    // check and the rename by a link retargeted underneath us. Hidden components are refused at
+    // any depth, not just the leaf: a move out of a dot-directory would exfiltrate its contents
+    // into plain view, and a move into one would smuggle files past the same guard.
+    BOOL oldIsHidden = NO;
+    BOOL newIsHidden = NO;
+    NSString *const resolvedOldPath = [self _resolvedPathForRelativePath:oldRelativePath hidden:&oldIsHidden];
+    NSString *const resolvedNewPath = [self _resolvedPathForRelativePath:newRelativePath hidden:&newIsHidden];
+
+    if ((resolvedOldPath == nil) || (resolvedNewPath == nil)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Moving \"%@\" to \"%@\" is not allowed", oldRelativePath, newRelativePath];
     }
+
+    oldAbsolutePath = resolvedOldPath;
+    desiredNewPath = resolvedNewPath;
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:oldAbsolutePath isDirectory:&isDirectory]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", oldRelativePath];
     }
 
-    // Check both endpoints for a hidden component at any depth, not just the leaf: a move
-    // out of a dot-directory would otherwise exfiltrate its contents into plain view, and
-    // a move into one would smuggle files past the same guard.
-    if ([self _isHiddenPath:oldRelativePath] || [self _isHiddenPath:newRelativePath]) {
+    if (oldIsHidden || newIsHidden) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Moving \"%@\" to \"%@\" is not allowed: a hidden path is involved", oldRelativePath, newRelativePath];
     }
 
@@ -1350,7 +1398,7 @@ static NSString *_OriginAuthority(NSString *value) {
     }
 
     NSString *const relativePath = request.arguments[@"path"];
-    NSString *const absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *absolutePath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
     BOOL isDirectory = NO;
 
     // A missing/empty path collapses to the upload directory itself; refuse to
@@ -1359,17 +1407,22 @@ static NSString *_OriginAuthority(NSString *value) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Operating on the root directory is not allowed"];
     }
 
-    // Deleting is destructive, so also confirm the resolved target is inside the share
-    // rather than something a symlink points to outside it.
-    if (!WSKResolvedPathIsWithinDirectory(absolutePath, _uploadDirectory)) {
+    // Deleting is destructive, so resolve once and destroy exactly what was vetted: a symlink
+    // retargeted between the check and the unlink would otherwise decide what gets removed.
+    BOOL isHidden = NO;
+    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed", relativePath];
     }
+
+    absolutePath = resolvedPath;
 
     if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
     }
 
-    if ([self _isHiddenPath:relativePath]) {
+    if (isHidden) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting hidden path \"%@\" is not allowed", relativePath];
     }
 
@@ -1398,7 +1451,7 @@ static NSString *_OriginAuthority(NSString *value) {
                 // says. They are incidental metadata rather than content the allow-list is
                 // meant to protect (a ".DS_Store" sits in every macOS folder, and its empty
                 // pathExtension is in no allow-list), so vetting them would make ordinary
-                // directories permanently undeletable. Note this cannot use -_isHiddenPath:,
+                // directories permanently undeletable. Note this cannot use the shared rule,
                 // which reports NO for everything once hidden items are allowed.
                 if ([[subpath lastPathComponent] hasPrefix:@"."]) {
                     [enumerator skipDescendants];
@@ -1451,23 +1504,26 @@ static NSString *_OriginAuthority(NSString *value) {
     }
 
     NSString *const relativePath = request.arguments[@"path"];
-    NSString *const desiredPath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
+    NSString *const requestedPath = [_uploadDirectory stringByAppendingPathComponent:WSKNormalizePath(relativePath)];
 
     // An empty path collapses to the upload directory itself; refuse it (uniquing
     // the root would otherwise create a sibling directory outside the share).
-    if (!WSKPathIsInsideDirectory(desiredPath, _uploadDirectory)) {
+    if (!WSKPathIsInsideDirectory(requestedPath, _uploadDirectory)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Operating on the root directory is not allowed"];
     }
 
-    // The parent of the new directory must resolve inside the share, so a symlinked
-    // intermediate component cannot place it outside.
-    if (!WSKResolvedPathIsWithinDirectory(desiredPath, _uploadDirectory)) {
+    // Resolved once — the parent must resolve inside the share, so a symlinked intermediate
+    // component cannot place the new directory outside it — and a hidden component is refused
+    // anywhere in the chain, not just in the new directory's own name, or /create becomes a way
+    // to populate a dot-directory. The mkdir below then targets the resolved location.
+    BOOL isHidden = NO;
+    NSString *const desiredPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+
+    if (desiredPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Creating \"%@\" is not allowed", relativePath];
     }
 
-    // Refuse a hidden component anywhere, not just in the new directory's own name: the
-    // parent chain must be visible too, or /create becomes a way to populate a dot-directory.
-    if ([self _isHiddenPath:relativePath]) {
+    if (isHidden) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Creating hidden path \"%@\" is not allowed", relativePath];
     }
 


### PR DESCRIPTION
**Stacked on #39** — completes for the uploader and WebDAV what that PR did for the base-path
handler. Merge #39 first; this branch is based on it.

Both servers had the same shape at every path-taking endpoint: containment from one `realpath(3)`,
hiddenness from a **second independent one**, then the filesystem operation against a **third**
path — the one the client sent, symlinks intact.

### Measured, symlink retargeted underneath by a helper thread

| | before | after |
|---|---|---|
| uploader `/download` | 551 / 3000 leaked (**18.4%**) | **0 / 3000** |
| WebDAV `GET` | 772 / 3000 leaked (**25.7%**) | **0 / 3000** |
| WebDAV `PUT` | **228 / 600 files written OUTSIDE the share** | **0 / 600** |
| control, link held fixed | 0 / 1000 | 0 / 1000 |

**The WebDAV write is the sharpest finding of either pass**: a remote client causing files to be
written outside the shared directory, 38% of attempts. It needs only a symlink in the tree and
something retargeting it — which, for a build server rewriting a `latest ->` link while serving,
is ordinary operation rather than an attack.

### How

`-_resolvedPathForRelativePath:hidden:` on each server resolves once, judges both rules on that
single observation, and returns the vetted absolute path for the caller to act on.

Callers **bind it to the variable the rest of the method already used**, rather than rewriting
each downstream use — so no use can be silently missed, which is the failure mode that would
matter most in this code.

`-_isHiddenPath:` is **removed** from both servers. With every caller converted it was a second,
unused implementation of a security rule sitting beside the live one, and the next person needing
a hidden-item check would have found it first.

### Not closed

A real directory renamed between resolution and use. Closing that needs an `openat(2)` component
walk or `O_NOFOLLOW_ANY`, which would also refuse the benign intermediate symlinks that work
today.

### Verification

`testRetargetedSymlinkCannotEscapeTheUploaderOrWebDAV` asserts the property across both servers
and both directions. Against the parent it fails on **all three counters** — 129 uploader reads,
166 DAV reads, 195 DAV writes. It also asserts a stable in-root symlink is still served.

The four recorded **WebDAV trace suites — real Finder and Cyberduck sessions — still pass**, which
is the evidence that mattered most for a change touching every DAV verb.

Full harness green: **93 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.