### PR TITLE
Vet WebDAV's recursive delete, and make the index agree with the handler

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1434,6 +1434,78 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// The uploader vets a subtree before destroying it; WebDAV did not, so a folder was a spelling
+// that bypassed the allow-list entirely. Measured: with allowedFileExtensions=[txt],
+// DELETE /Folder answered 204 and destroyed both "id_rsa" and ".env" — each of which the same
+// server refuses with 403 when addressed directly.
+- (void)testDAVRecursiveDeleteRespectsExtensionAllowList {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    server.allowedFileExtensions = @[ @"txt" ];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* guarded = [dir stringByAppendingPathComponent:@"Guarded"];
+    XCTAssertTrue([fm createDirectoryAtPath:guarded withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"ok" writeToFile:[guarded stringByAppendingPathComponent:@"note.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"KEYDATA" writeToFile:[guarded stringByAppendingPathComponent:@"id_rsa"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    // The same file, addressed directly, is refused — so the recursive form must be too, or one
+    // request means two different things.
+    XCTAssertTrue([SendRawRequest(server.port, @"DELETE /Guarded/id_rsa HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 403"], @"a direct delete of a disallowed file should be refused");
+
+    NSString* refused = SendRawRequest(server.port, @"DELETE /Guarded HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([refused hasPrefix:@"HTTP/1.1 403"], @"expected 403 for a collection holding a disallowed file: %@", [refused substringToIndex:MIN((NSUInteger)40, refused.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:[guarded stringByAppendingPathComponent:@"id_rsa"]], @"the recursive delete destroyed a file a direct delete refuses");
+
+    // A folder whose only extra entry is filesystem noise must still be deletable, or every
+    // macOS folder becomes permanently undeletable by its own .DS_Store.
+    NSString* ordinary = [dir stringByAppendingPathComponent:@"Ordinary"];
+    XCTAssertTrue([fm createDirectoryAtPath:ordinary withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"ok" writeToFile:[ordinary stringByAppendingPathComponent:@"note.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"junk" writeToFile:[ordinary stringByAppendingPathComponent:@".DS_Store"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    NSString* allowed = SendRawRequest(server.port, @"DELETE /Ordinary HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertFalse([allowed hasPrefix:@"HTTP/1.1 403"], @"a .DS_Store must not make an ordinary folder undeletable: %@", [allowed substringToIndex:MIN((NSUInteger)40, allowed.length)]);
+    XCTAssertFalse([fm fileExistsAtPath:ordinary], @"the deletable folder was not removed: %@", allowed);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// The browsable index has to describe the tree that is actually being vended. With
+// allowHiddenItems:YES the handler served a dot-file while the listing omitted it — the same
+// disagreement the sixth pass fixed in the opposite direction, when the listing hid items the
+// handler would happily serve.
+- (void)testDirectoryIndexAgreesWithWhatIsServed {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    XCTAssertTrue([fm createDirectoryAtPath:[root stringByAppendingPathComponent:@".hidden"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"HIDDENDATA" writeToFile:[root stringByAppendingPathComponent:@".hidden/secret.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"PUBLIC" writeToFile:[root stringByAppendingPathComponent:@"plain.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+
+    WSKWebServer* refusing = [[WSKWebServer alloc] init];
+    [refusing addGETHandlerForBasePath:@"/f/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:NO];
+    XCTAssertTrue([refusing startWithOptions:options error:NULL]);
+    XCTAssertFalse([SendRawRequest(refusing.port, @"GET /f/ HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@".hidden"], @"the default listing must not advertise a hidden item");
+    XCTAssertFalse([SendRawRequest(refusing.port, @"GET /f/.hidden/secret.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"HIDDENDATA"], @"the default handler must not serve a hidden item");
+    XCTAssertTrue([SendRawRequest(refusing.port, @"GET /f/ HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"plain.txt"], @"ordinary entries must still be listed");
+    [refusing stop];
+
+    WSKWebServer* permissive = [[WSKWebServer alloc] init];
+    [permissive addGETHandlerForBasePath:@"/f/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:NO allowHiddenItems:YES];
+    XCTAssertTrue([permissive startWithOptions:options error:NULL]);
+    XCTAssertTrue([SendRawRequest(permissive.port, @"GET /f/.hidden/secret.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"HIDDENDATA"], @"allowHiddenItems:YES must serve a hidden item");
+    XCTAssertTrue([SendRawRequest(permissive.port, @"GET /f/ HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@".hidden"], @"the listing must advertise what the handler will serve");
+    [permissive stop];
+
+    [fm removeItemAtPath:root error:NULL];
+}
+
 - (void)testUploaderRecursiveDeleteRespectsExtensionAllowList {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* dir = MakeTempDirectory();

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1511,7 +1511,7 @@ static NSString *_EscapeHTMLString(NSString *string) {
     return escaped;
 }
 
-- (WSKResponse *)_responseWithContentsOfDirectory:(NSString *)path {
+- (WSKResponse *)_responseWithContentsOfDirectory:(NSString *)path includingHiddenItems:(BOOL)includeHiddenItems {
     NSArray *const contents = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:NULL] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
 
     if (contents == nil) {
@@ -1524,7 +1524,12 @@ static NSString *_EscapeHTMLString(NSString *string) {
     [html appendString:@"<ul>\n"];
 
     for (NSString *entry in contents) {
-        if (![entry hasPrefix:@"."]) {
+        // The index must agree with what the handler will actually serve. With
+        // allowHiddenItems:YES it served a dot-file happily while omitting it here, so the
+        // browsable listing described a *smaller* tree than the one being vended — the same
+        // disagreement, in the opposite direction, that the sixth pass fixed by refusing to
+        // serve what this listing hid.
+        if (includeHiddenItems || ![entry hasPrefix:@"."]) {
             NSString *const type = [[NSFileManager defaultManager] attributesOfItemAtPath:[path stringByAppendingPathComponent:entry] error:NULL][NSFileType];
 
             // Any process can delete the entry between the directory read above and this
@@ -1649,7 +1654,7 @@ static NSString *_EscapeHTMLString(NSString *string) {
                             }
                         }
 
-                        response = [server _responseWithContentsOfDirectory:filePath];
+                        response = [server _responseWithContentsOfDirectory:filePath includingHiddenItems:allowHiddenItems];
                     } else if ([fileType isEqualToString:NSFileTypeRegular]) {
                         if (allowRangeRequests) {
                             response = [WSKFileResponse responseWithFile:filePath byteRange:request.byteRange isAttachment:NO ifRange:request.ifRange];

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -483,6 +483,37 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed", relativePath];
     }
 
+    // Deleting a collection removes its whole subtree, which must not become a way to destroy
+    // files a direct DELETE would refuse — the extension check above applies only to files, so a
+    // folder was a spelling that bypassed it entirely. Measured before this: with an allow-list
+    // of "txt", DELETE /Folder answered 204 and destroyed both "id_rsa" and ".env", each of
+    // which this same server refuses with 403 when addressed directly.
+    //
+    // This mirrors -[WSKWebUploader deleteItem:], deliberately including its two judgement
+    // calls. Dot-names and everything under them are skipped whatever -allowHiddenItems says:
+    // they are incidental metadata rather than content the allow-list protects, and a
+    // ".DS_Store" sits in every macOS folder with an empty pathExtension that is in no
+    // allow-list, so vetting them would make ordinary folders permanently undeletable. And an
+    // extensionless file ("README") is vetted like any other, because a direct DELETE of it is
+    // already refused and letting the recursive form through would make one request mean two
+    // different things.
+    if (isDirectory && _allowedFileExtensions) {
+        NSDirectoryEnumerator<NSString *> *const enumerator = [[NSFileManager defaultManager] enumeratorAtPath:absolutePath];
+
+        for (NSString *subpath in enumerator) {
+            if ([[subpath lastPathComponent] hasPrefix:@"."]) {
+                [enumerator skipDescendants];
+                continue;
+            }
+
+            NSString *const subpathType = [enumerator fileAttributes][NSFileType];
+
+            if ([subpathType isEqualToString:NSFileTypeRegular] && ![self _checkFileExtension:subpath]) {
+                return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed: it contains \"%@\"", relativePath, subpath];
+            }
+        }
+    }
+
     if (![self shouldDeleteItemAtPath:absolutePath]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not permitted", relativePath];
     }


### PR DESCRIPTION
Two of the ten lower-severity property-test violations. **The other eight were resolved by
re-measuring rather than by fixing** — see below.

### WebDAV's recursive DELETE bypassed the allow-list

A folder was a spelling that skipped the extension check entirely:

| | before |
|---|---|
| uploader `POST /delete /Folder` | 403, files survive |
| WebDAV `DELETE /Folder` | **204, `id_rsa` and `.env` destroyed** |
| WebDAV `DELETE /Folder/id_rsa` (direct) | 403 |
| WebDAV `DELETE /Folder/.env` (direct) | 403 |

WebDAV destroyed via a collection exactly what it refuses to delete directly. The uploader has
vetted its subtree since the fifth pass, and **this repo's design notes already claimed the
property** — *"a recursive delete refuses when it would destroy a file a direct delete would have
refused"* — while only one of the two servers actually had it.

The vetting mirrors `-[WSKWebUploader deleteItem:]` including both of its judgement calls, which
are the difference between a rule that works and one that makes the feature unusable:

- dot-names and their descendants are skipped whatever `allowHiddenItems` says — a `.DS_Store`
  sits in every macOS folder, with an empty `pathExtension` that is in no allow-list;
- an extensionless file (`README`) *is* vetted, since a direct DELETE of it is already refused.

### The index disagreed with the handler

`allowHiddenItems:YES` served a dot-file while the directory listing still omitted it — the
browsable index described a *smaller* tree than the one being vended. Same disagreement the sixth
pass fixed in the opposite direction. **This one arrived with the opt-out I added in #36, so it is
mine.**

### The other eight, re-measured against current `main`

Worth recording, because fixing from a stale report would have been busywork:

- **Five are already fixed** — benign symlinks (to files and to directories) are now served
  correctly and *consistently* by all three servers (200 / 200 / 207). The "unservable", "500 with
  an empty body" and "three servers, three answers" findings all came from serving the client's
  path; serving the **resolved** path cured them as a side effect of #41.
- **One** was the containment race #41 closed.
- **One remains, cosmetic**: a target beginning `//` gives 501 from the base-path handler and 404
  from WebDAV. Both refuse; only the status differs. Not worth churn in this code.
- **One** is the hidden-children-in-a-recursive-delete case, which the DELETE fix above covers.

### Verification

Both tests fail against `main` — the DELETE one at `204` with the file destroyed, the index one on
a listing that omits what the handler serves. Both also assert what must keep working: a folder
whose only extra entry is a `.DS_Store` stays deletable, and the default configuration still hides
*and* refuses hidden items.

Full harness green: **96 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.