### PR TITLE
Stop two remote process kills and a symlink that destroyed the whole share

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1402,6 +1402,146 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 //
 // NOTE: against the unfixed source the first half does not fail, it ABORTS the test process,
 // which xctest reports as "0 failures". Read the executed count.
+// A symlink whose target resolves to the share root turned every destructive endpoint into
+// "destroy everything". The "not the root directory" guards are correct, but they are evaluated
+// on the path the CLIENT typed; the resolve-once work then substituted the resolved path — which
+// is the root — with no re-check. Measured: one unauthenticated request emptied the share through
+// DAV DELETE, DAV MOVE and the uploader's /delete alike, each answering 204 or 200.
+//
+// The lesson generalises past this instance: resolving once and acting on the resolved path is
+// right, but every rule stated about the unresolved path has to be restated about the resolved
+// one. This is refused centrally, in the resolver, so a destructive site added later cannot
+// forget it.
+// The NUL guards added for the query and form fields missed the two values that arrive through
+// the multipart parser. A NUL in the multipart "filename" reached
+// -stringByAppendingPathComponent:, which returns nil for a NUL-bearing receiver, and the nil
+// then reached -[NSFileManager moveItemAtPath:toPath:error:] as its destination —
+// NSInvalidArgumentException, uncaught, process gone, from one unauthenticated POST /upload.
+//
+// NOTE: against the unfixed source this aborts the test process rather than failing. Read the
+// executed count.
+- (void)testMultipartFilenameAndPathRefuseNULRatherThanCrashing {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // The uploader takes its file part under the control name "files[]".
+    NSData* (^upload)(NSString*, BOOL, NSString*, BOOL) = ^(NSString* fileName, BOOL nulInName, NSString* pathField, BOOL nulInPath) {
+        NSMutableData* body = [NSMutableData data];
+        void (^add)(NSString*) = ^(NSString* text) {
+            [body appendData:[text dataUsingEncoding:NSUTF8StringEncoding]];
+        };
+        add(@"--B\r\nContent-Disposition: form-data; name=\"path\"\r\n\r\n");
+        add(pathField);
+        if (nulInPath) {
+            [body appendBytes:"\0" length:1];
+        }
+        add(@"\r\n--B\r\nContent-Disposition: form-data; name=\"files[]\"; filename=\"");
+        add(fileName);
+        if (nulInName) {
+            [body appendBytes:"\0" length:1];
+        }
+        add(@".txt\"\r\nContent-Type: text/plain\r\n\r\nPAYLOAD\r\n--B--\r\n");
+
+        NSString* head = [NSString stringWithFormat:@"POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: %lu\r\n\r\n", (unsigned long)body.length];
+        NSMutableData* request = [[head dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+        [request appendData:body];
+        return (NSData*)request;
+    };
+
+    // An ordinary upload must work, or the assertions below prove nothing — this is exactly the
+    // trap that made an earlier version of this probe report success against unfixed code.
+    XCTAssertTrue([SendRawDataRequest(server.port, upload(@"ok", NO, @"/", NO)) hasPrefix:@"HTTP/1.1 200"], @"an ordinary upload stopped working");
+
+    NSString* badName = SendRawDataRequest(server.port, upload(@"evil", YES, @"/", NO));
+    XCTAssertTrue([badName hasPrefix:@"HTTP/1.1 403"], @"a NUL in the multipart filename: %@", [badName substringToIndex:MIN((NSUInteger)40, badName.length)]);
+
+    NSString* badPath = SendRawDataRequest(server.port, upload(@"ok2", NO, @"/sub", YES));
+    XCTAssertTrue([badPath hasPrefix:@"HTTP/1.1 400"], @"a NUL in the multipart path field: %@", [badPath substringToIndex:MIN((NSUInteger)40, badPath.length)]);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+- (void)testSymlinkResolvingToTheShareRootCannotDestroyIt {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+
+    NSString* (^fixture)(NSString*) = ^(NSString* name) {
+        NSString* root = [MakeTempDirectory() stringByAppendingPathComponent:name];
+        [fm createDirectoryAtPath:root withIntermediateDirectories:YES attributes:nil error:NULL];
+        for (NSUInteger i = 0; i < 4; i++) {
+            [[NSString stringWithFormat:@"build %lu", (unsigned long)i] writeToFile:[root stringByAppendingPathComponent:[NSString stringWithFormat:@"build%lu.txt", (unsigned long)i]] atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+        }
+        symlink(".", [[root stringByAppendingPathComponent:@"self"] fileSystemRepresentation]);
+        return root;
+    };
+    NSUInteger (^count)(NSString*) = ^(NSString* dir) {
+        return [[fm contentsOfDirectoryAtPath:dir error:NULL] count];
+    };
+
+    NSString* davRoot = fixture(@"dav");
+    WSKWebDAVServer* dav = [[WSKWebDAVServer alloc] initWithUploadDirectory:davRoot];
+    XCTAssertTrue([dav startWithOptions:options error:NULL]);
+    NSString* deleted = SendRawRequest(dav.port, @"DELETE /self HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 403"], @"DELETE through a self-referential link: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+    XCTAssertEqual(count(davRoot), (NSUInteger)5, @"the share was emptied by a DELETE through a link resolving to its root");
+
+    NSString* moved = SendRawRequest(dav.port, [NSString stringWithFormat:@"MOVE /build0.txt HTTP/1.1\r\nHost: localhost:%lu\r\nDestination: http://localhost:%lu/self\r\nOverwrite: T\r\n\r\n", (unsigned long)dav.port, (unsigned long)dav.port]);
+    XCTAssertTrue([moved hasPrefix:@"HTTP/1.1 403"], @"MOVE onto a self-referential link: %@", [moved substringToIndex:MIN((NSUInteger)40, moved.length)]);
+    XCTAssertEqual(count(davRoot), (NSUInteger)5, @"the share was replaced by a MOVE onto a link resolving to its root");
+
+    // The ordinary destructive operation must still work, or this has just disabled the feature.
+    XCTAssertTrue([SendRawRequest(dav.port, @"DELETE /build1.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 204"], @"an ordinary DELETE stopped working");
+    XCTAssertEqual(count(davRoot), (NSUInteger)4);
+    [dav stop];
+
+    NSString* upRoot = fixture(@"up");
+    WSKWebUploader* uploader = [[WSKWebUploader alloc] initWithUploadDirectory:upRoot];
+    XCTAssertTrue([uploader startWithOptions:options error:NULL]);
+    NSString* body = @"path=%2Fself";
+    NSString* reply = SendRawRequest(uploader.port, [NSString stringWithFormat:@"POST /delete HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: %lu\r\n\r\n%@", (unsigned long)body.length, body]);
+    XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 403"], @"the uploader deleted through a self-referential link: %@", [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+    XCTAssertEqual(count(upRoot), (NSUInteger)5, @"the share was emptied by /delete through a link resolving to its root");
+
+    // Listing the root by name is still an ordinary operation and must not be caught by this.
+    XCTAssertTrue([SendRawRequest(uploader.port, @"GET /list?path=/ HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 200"], @"listing the share root stopped working");
+    [uploader stop];
+}
+
+// -[WSKMIMEStreamParser initWithBoundary:...] returned nil for malformed input BEFORE running
+// [super init] and setting the fd sentinel. Under ARC a nil-returning initializer still
+// deallocates its receiver, so -dealloc ran on a zeroed object where _tmpFile is 0 — making its
+// close(_tmpFile) a close(0) of a descriptor the parser never owned. Once freed, that slot goes
+// to the next accept(), so a later malformed request tears down a live connection mid-serve.
+//
+// NOTE: against the unfixed source this closes the test process's own stdin. Read the executed
+// count, not the failure count.
+- (void)testMalformedMultipartBoundaryDoesNotCloseDescriptorZero {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    XCTAssertTrue(fcntl(0, F_GETFD) != -1, @"descriptor 0 should be open before the request");
+
+    NSString* body = @"--x\r\nContent-Disposition: form-data; name=\"f\"\r\n\r\nv\r\n--x--\r\n";
+    for (NSString* contentType in @[ @"multipart/form-data",
+                                     @"multipart/form-data; boundary=",
+                                     @"multipart/form-data; boundary=\u00e9\u00e9\u00e9" ]) {
+        SendRawRequest(server.port, [NSString stringWithFormat:@"POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Type: %@\r\nContent-Length: %lu\r\n\r\n%@", contentType, (unsigned long)body.length, body]);
+        XCTAssertTrue(fcntl(0, F_GETFD) != -1, @"\"%@\" closed descriptor 0", contentType);
+    }
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 - (void)testUploaderRefusesPathsContainingNULRatherThanTruncating {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* dir = MakeTempDirectory();

--- a/Sources/WebServerKit/Requests/WSKMultiPartFormRequest.m
+++ b/Sources/WebServerKit/Requests/WSKMultiPartFormRequest.m
@@ -187,6 +187,18 @@ static NSData *_dashNewlineData = nil;
 }
 
 - (instancetype)initWithBoundary:(NSString *_Nonnull)boundary defaultControlName:(NSString *_Nullable)name arguments:(NSMutableArray<WSKMultiPartArgument *> *_Nonnull)arguments files:(NSMutableArray<WSKMultiPartFile *> *_Nonnull)files depth:(NSUInteger)depth budget:(WSKMIMEStreamBudget *_Nonnull)budget {
+    // [super init] and the fd sentinel are established BEFORE any failure return. Under ARC a
+    // nil-returning initializer still deallocates its receiver, so -dealloc runs — and on a
+    // zeroed object `_tmpFile` is 0, making its `close(_tmpFile)` a close(0) of a descriptor
+    // this object never owned. Measured: one unauthenticated POST /upload with a non-ASCII
+    // boundary closed the process's descriptor 0, and once freed that slot is handed to the next
+    // accept(), so a later malformed request tears down a live connection mid-serve.
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _tmpFile = -1;  // fd 0 is legal, so -1 (not 0) is the "no temporary file" sentinel
+
     NSData *data = boundary.length ? [[NSString stringWithFormat:@"--%@", boundary] dataUsingEncoding:NSASCIIStringEncoding] : nil;
 
     if (data == nil) {
@@ -205,18 +217,15 @@ static NSData *_dashNewlineData = nil;
         return nil;
     }
 
-    if ((self = [super init])) {
-        _boundary = data;
-        _defaultcontrolName = name;
-        _arguments = arguments;
-        _files = files;
-        _data = [[NSMutableData alloc] initWithCapacity:kMultiPartBufferSize];
-        _tmpFile = -1;  // fd 0 is legal, so -1 (not 0) is the "no temporary file" sentinel
-        _state = kParserState_Start;
-        _depth = depth;
-        _budget = budget;
-        _workingReservation = [[WSKMemoryReservation alloc] init];
-    }
+    _boundary = data;
+    _defaultcontrolName = name;
+    _arguments = arguments;
+    _files = files;
+    _data = [[NSMutableData alloc] initWithCapacity:kMultiPartBufferSize];
+    _state = kParserState_Start;
+    _depth = depth;
+    _budget = budget;
+    _workingReservation = [[WSKMemoryReservation alloc] init];
 
     return self;
 }

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -194,6 +194,23 @@ NS_ASSUME_NONNULL_END
         return nil;
     }
 
+    // A symlink that resolves to the share root itself is never what the client meant, and
+    // acting on it is catastrophic: every "not the root directory" guard in this file is
+    // evaluated on the path the client *typed*, then this resolved path is substituted for it,
+    // so "DELETE /self" passed a guard about "/self" and then removed the whole share. Measured:
+    // one unauthenticated request destroyed every file served, through DAV DELETE, DAV
+    // COPY/MOVE and the uploader's /delete alike, each answering 204 or 200.
+    //
+    // Refused here rather than re-checked at each destructive call site, so a site added later
+    // cannot forget it. Asking for the root *directly* is still allowed — listing it and
+    // uploading into it are ordinary operations — because that is the client naming the root
+    // rather than a link quietly landing on it.
+    BOOL const askedForRoot = (normalizedPath.length == 0) || [normalizedPath isEqualToString:@"/"];
+
+    if ((resolvedRelativePath.length == 0) && !askedForRoot) {
+        return nil;
+    }
+
     if (outHidden && !_allowHiddenItems) {
         for (NSString *component in [normalizedPath pathComponents]) {
             if ([component hasPrefix:@"."]) {

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -978,6 +978,23 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
         return nil;
     }
 
+    // A symlink that resolves to the share root itself is never what the client meant, and
+    // acting on it is catastrophic: every "not the root directory" guard in this file is
+    // evaluated on the path the client *typed*, then this resolved path is substituted for it,
+    // so "DELETE /self" passed a guard about "/self" and then removed the whole share. Measured:
+    // one unauthenticated request destroyed every file served, through DAV DELETE, DAV
+    // COPY/MOVE and the uploader's /delete alike, each answering 204 or 200.
+    //
+    // Refused here rather than re-checked at each destructive call site, so a site added later
+    // cannot forget it. Asking for the root *directly* is still allowed — listing it and
+    // uploading into it are ordinary operations — because that is the client naming the root
+    // rather than a link quietly landing on it.
+    BOOL const askedForRoot = (normalizedPath.length == 0) || [normalizedPath isEqualToString:@"/"];
+
+    if ((resolvedRelativePath.length == 0) && !askedForRoot) {
+        return nil;
+    }
+
     if (outHidden && !_allowHiddenItems) {
         // Both spellings: what the client typed, and where the bytes actually live. The first
         // catches "/.git/config"; the second catches a symlink named "pub" pointing at ".git",
@@ -1255,12 +1272,24 @@ static NSString *_OriginAuthority(NSString *value) {
     // a single leaf component and reject the traversal specials.
     NSString *const fileName = [file.fileName lastPathComponent];
 
-    if ((fileName.length == 0) || [fileName isEqualToString:@"."] || [fileName isEqualToString:@".."] ||
+    // The NUL test belongs with the others: this value reaches -stringByAppendingPathComponent:,
+    // which returns nil for a NUL-bearing receiver, and nil then reaches a place that cannot take
+    // one. The same shape that made "/list?path=%00" terminate the process — the query and form
+    // fields were guarded then, this one was missed because it arrives through the multipart
+    // parser rather than the request arguments.
+    if ((fileName.length == 0) || WSKPathContainsNULByte(fileName) || [fileName isEqualToString:@"."] || [fileName isEqualToString:@".."] ||
         (!_allowHiddenItems && [fileName hasPrefix:@"."]) || ![self _checkFileExtension:fileName]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Uploaded file name \"%@\" is not allowed", file.fileName];
     }
 
     NSString *const relativePath = [[request firstArgumentForControlName:@"path"] string];
+
+    if (WSKPathContainsNULByte(relativePath)) {
+        // Same reason as the file name above, and the same reason as every other client path in
+        // this file: truncating at the NUL would place the upload in a directory the client did
+        // not name.
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Path contains a NUL byte"];
+    }
     // Vet the destination DIRECTORY once — the leaf is already reduced to a single validated
     // component above — and compose onto the resolved directory. The client-supplied "path" may
     // traverse a symlink out of the share, and a non-hidden file name is not enough on its own:


### PR DESCRIPTION
Found overnight by three techniques never applied here: mutational parser fuzzing, differential
testing against an independent HTTP implementation, and allocation-failure injection. **I
reproduced all three myself before acting on them.**

> ⚠️ The first one is a regression from `8edf9c6` — my resolve-once change from last night.

### 1. A symlink resolving to the share root destroyed everything served

The `"not the root directory"` guards are correct, but they are evaluated on the path the
**client typed**; the resolve-once work then substituted the **resolved** path — which *is* the
root — with no re-check. `DELETE /self` passed a guard about `/self` and removed the share.

| request | on `main` | share after |
|---|---|---|
| DAV `DELETE /self` | 204 No Content | **0 of 5 entries left** |
| DAV `MOVE /build0.txt → /self` | 409 | **0 of 5** |
| uploader `POST /delete path=/self` | 200 OK | **0 of 5** |

One unauthenticated request. For Puck that is every build vended; for iComics the user's whole
shared folder.

**The general form is worth stating, because it will recur:** resolving once and acting on the
resolved path is right, but *every rule stated about the unresolved path has to be restated about
the resolved one*. Refused in the resolver rather than at each destructive call site, so a site
added later cannot forget it. Naming the root **directly** is still allowed — listing it and
uploading into it are ordinary operations.

### 2. A malformed multipart boundary closed descriptor 0

`-[WSKMIMEStreamParser initWithBoundary:...]` returned nil *before* `[super init]` and before
`_tmpFile = -1`. Under ARC a nil-returning initializer still deallocates its receiver, so
`-dealloc` ran on a zeroed object and its `close(_tmpFile)` became **`close(0)`** — a descriptor
the parser never owned. Once freed, that slot goes to the next `accept()`, so a later malformed
request tears down a live connection mid-serve; the reporting agent measured that as a process
crash under concurrent load (5/5 Debug and Release).

The sentinel's own comment — *"fd 0 is legal, so -1 is the sentinel"* — shows the hazard was
understood. It was simply established too late. Reachable unauthenticated on the shipping
uploader's `POST /upload`.

### 3. A NUL in the multipart filename killed the process

The NUL guards added in #38 covered the query and form fields but missed the two values arriving
through the **multipart parser**. The filename reached `-stringByAppendingPathComponent:`, which
returns nil for a NUL-bearing receiver, and the nil then reached
`-[NSFileManager moveItemAtPath:toPath:error:]` as its destination.

That is the **fourth** appearance of this codebase's recurring shape, and the second time a fix
for it did not reach every site the value can arrive by.

### Verification

All three fail against `main` — the share test on an emptied directory, the descriptor test on
**all three** malformed content types, and the multipart test by aborting the process outright.
Both of the latter carry a note to read the executed count, since an aborted xctest run reports
*"0 failures"*.

Each test also asserts the **ordinary operation still works**. That caught a probe of mine that
was reporting success while never reaching the code path — it used the wrong multipart control
name, so every case returned 403 and looked fine.

Full harness green: **99 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`. A five-hour soak running alongside is at **7.5M requests / 6 TB**, descriptors
flat, aggregate reservation at zero.