### PR TITLE
Make gzip framing independent of segmentation, and the ETag identify the bytes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,83 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Ninth audit pass: fuzzing, differential testing, and a fix of mine that destroyed the share
+
+Run overnight, unattended, with three techniques this project had never applied: mutational and
+grammar-aware fuzzing straight at the body parsers, differential testing against an independent
+HTTP implementation, and allocation-failure injection. Plus randomized lifecycle churn. Agents
+ran in their own git worktrees with instructions to change nothing, and every finding was
+reproduced independently before being acted on.
+
+**⚠️ The eighth pass's own resolve-once fix turned a symlink into "destroy the whole share".**
+The `"not the root directory"` guards are correct, but they are evaluated on the path the client
+*typed*; the resolve-once work then substituted the resolved path — which is the root — with no
+re-check. One unauthenticated request emptied a five-entry share to zero through DAV `DELETE`,
+DAV `MOVE` and the uploader's `/delete` alike, answering 204, 409 and 200.
+
+The general form will recur and is the thing to remember: **resolving once and acting on the
+resolved path is right, but every rule stated about the unresolved path has to be restated about
+the resolved one.** It is refused in the resolver rather than at each destructive call site, so a
+site added later cannot forget it; naming the root *directly* is still allowed, because listing it
+and uploading into it are ordinary operations.
+
+**A malformed multipart boundary closed descriptor 0.** `-[WSKMIMEStreamParser
+initWithBoundary:...]` returned nil before `[super init]` and before `_tmpFile = -1`. Under ARC a
+nil-returning initializer still deallocates its receiver, so `-dealloc` ran on a zeroed object and
+its `close(_tmpFile)` became `close(0)` — a descriptor it never owned. Once freed, that slot goes
+to the next `accept()`, so a later malformed request tears down a live connection mid-serve;
+measured as a process crash under concurrent load. The sentinel's own comment showed the hazard
+was understood — it was established too late. Establish `[super init]` and any fd sentinel before
+the first failure return.
+
+**A NUL in the multipart filename killed the process** — it reached
+`-stringByAppendingPathComponent:`, which returns nil for a NUL-bearing receiver, and the nil
+reached `-[NSFileManager moveItemAtPath:toPath:error:]` as its destination. Fourth appearance of
+this codebase's recurring shape, and the second time a fix for it did not reach every site the
+value can arrive by: the eighth pass guarded the query and form fields and missed the two that
+arrive through the multipart parser.
+
+**A gzip body's verdict depended on TCP segmentation.** A concatenated second member sent in one
+write was silently dropped and answered 200 — handing the handler less data than the client
+sent — while the identical bytes split at the member boundary answered 500. The client chose
+which. The fifth pass fixed the later-read half and this file recorded the case as closed; the
+same-read half was still open, because `Z_STREAM_END` was accepted without checking whether
+`avail_in` still held bytes. **A split-invariance oracle found this automatically** — same
+request, different segmentation, different answer — a cheap property worth reusing.
+
+**The entity tag did not identify the bytes.** It was inode + mtime only, so a rewrite in place
+that restores the timestamp — `utimes(2)`, and what `rsync -a`, `cp -p` and `tar -x` all do —
+produced a byte-identical tag for different content. A 900-byte build replaced by a 916-byte one
+answered **304** to a revalidation (the client keeps the stale copy indefinitely) and **206** to a
+resume (the new build's bytes spliced onto the old one's prefix). That is precisely the failure
+the `If-Range` work exists to prevent, arriving through the *strong* validator rather than the
+weak one — and this file's own note that a preserved-mtime replacement is "undetectable by any
+date-based scheme" quietly implied the ETag handled it. Size is now part of the tag, as Apache
+does. Equal-length-and-equal-mtime remains undetectable, and nothing derived from `stat(2)` can
+close it.
+
+**Nothing accumulates over hours, and this is now measured rather than extrapolated.** A five-hour
+soak — 12 concurrent workers doing ranges, revalidation and abortive mid-transfer deaths while a
+writer rewrote the served file every 750 ms — ran **19,723,889 requests and 15.6 TB**. Descriptors
+ended *below* baseline; `+[WSKWebServer reservedInMemoryByteCount]` was **0 at every one-minute
+sample and at rest**. The previous evidence for Shape A's central assumption was 450 sequential
+requests. **Do not re-run this speculatively**; re-run it when the connection or response layer
+changes.
+
+Also genuinely clean, and worth not re-testing: allocation-failure injection found nothing across
+9,366 injected failures with zero descriptor leaks; randomized lifecycle churn found no hang,
+leak or unreclaimed port; and the differential comparison found this library *more* correct than
+the reference on Range arithmetic across 1,200 generated headers.
+
+**The record has now overstated the code four times**, and the pattern is worth naming: the sixth
+pass's `If-Range` claim, the hidden-item rule that covered two servers of three, the recursive
+delete that only the uploader vetted, and the gzip trailing-data case above. Every one was a
+sentence in this file describing a property the code held only partly. When a pass closes a class,
+check every site the class can occur at before writing that it is closed.
+
+**Still open:** nothing from this pass. The `//` status disagreement from the eighth pass remains
+deliberately unfixed.
+
 ### Eighth audit pass: property-testing the path rules, and a merged PR that never landed
 
 Narrow by design — aimed only at the path containment and hidden-item rules the seventh pass had

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1466,6 +1466,113 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// Whether a gzip body with a concatenated second member was accepted or refused depended only on
+// how the client split its writes: sent in one write the trailing member was silently dropped and
+// the request answered 200, handing the handler less data than was sent; split at the member
+// boundary the same bytes answered 500. The client chose which. The fifth pass fixed the
+// later-read half and this file recorded the case as closed; the same-read half was still open.
+- (void)testGZipTrailingDataIsRefusedRegardlessOfHowItIsSplit {
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    __block NSString* received = nil;
+    [server addHandlerForMethod:@"POST"
+                           path:@"/data"
+                   requestClass:[WSKDataRequest class]
+                   processBlock:^WSKResponse*(WSKDataRequest* request) {
+                       received = [[NSString alloc] initWithData:request.data encoding:NSUTF8StringEncoding];
+                       return [WSKDataResponse responseWithText:@"ok"];
+                   }];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSData* first = GZipCompress([@"AAAAAAAAAAAAAAAA" dataUsingEncoding:NSUTF8StringEncoding]);
+    NSData* second = GZipCompress([@"BBBBBBBBBBBBBBBB" dataUsingEncoding:NSUTF8StringEncoding]);
+    NSMutableData* twoMembers = [first mutableCopy];
+    [twoMembers appendData:second];
+
+    NSData* (^request)(NSData*) = ^(NSData* body) {
+        NSString* head = [NSString stringWithFormat:@"POST /data HTTP/1.1\r\nHost: localhost\r\nContent-Encoding: gzip\r\nContent-Type: text/plain\r\nContent-Length: %lu\r\n\r\n", (unsigned long)body.length];
+        NSMutableData* full = [[head dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+        [full appendData:body];
+        return (NSData*)full;
+    };
+
+    // A single well-formed member is the control: it must still be accepted and delivered whole.
+    received = nil;
+    XCTAssertTrue([SendRawDataRequest(server.port, request(first)) hasPrefix:@"HTTP/1.1 200"], @"a single gzip member stopped being accepted");
+    XCTAssertEqualObjects(received, @"AAAAAAAAAAAAAAAA", @"the handler did not receive the whole body");
+
+    // Two members in one write: previously 200 with the second silently dropped.
+    received = nil;
+    NSString* whole = SendRawDataRequest(server.port, request(twoMembers));
+    XCTAssertFalse([whole hasPrefix:@"HTTP/1.1 200"], @"a concatenated second member was accepted and silently dropped: handler got %@", received);
+
+    // And with trailing bytes that are not a member at all.
+    NSMutableData* withGarbage = [first mutableCopy];
+    [withGarbage appendBytes:"GARBAGE!" length:8];
+    received = nil;
+    XCTAssertFalse([SendRawDataRequest(server.port, request(withGarbage)) hasPrefix:@"HTTP/1.1 200"], @"trailing garbage after a gzip member was accepted");
+
+    [server stop];
+}
+
+// The entity tag was inode + mtime only, so a rewrite in place that restores the timestamp —
+// utimes(2), and what rsync -a, cp -p and tar -x all do — produced a byte-identical tag for
+// different bytes. Measured: a 900-byte build replaced by a 916-byte one answered 304 to a
+// revalidation (the client keeps the stale copy indefinitely) and 206 to a resume (the new
+// build's bytes spliced onto the old one's prefix), which is the exact failure the If-Range work
+// exists to prevent, arriving through the strong validator rather than the weak one.
+- (void)testETagChangesWhenContentChangesUnderAPreservedTimestamp {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    NSString* path = [root stringByAppendingPathComponent:@"build.bin"];
+
+    XCTAssertTrue([[@"" stringByPaddingToLength:900 withString:@"A" startingAtIndex:0] writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    struct timeval times[2];
+    times[0].tv_sec = 1600000000;
+    times[0].tv_usec = 123456;
+    times[1] = times[0];
+    XCTAssertEqual(utimes(path.fileSystemRepresentation, times), 0);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/f/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* (^etagOf)(NSString*) = ^(NSString* reply) {
+        for (NSString* line in [reply componentsSeparatedByString:@"\r\n"]) {
+            if ([line hasPrefix:@"Etag: "]) {
+                return [line substringFromIndex:6];
+            }
+        }
+        return (NSString*)nil;
+    };
+
+    NSString* oldETag = etagOf(SendRawRequest(server.port, @"HEAD /f/build.bin HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+    XCTAssertNotNil(oldETag);
+
+    // Same inode, different content and length, timestamp restored to the nanosecond.
+    XCTAssertTrue([[@"" stringByPaddingToLength:916 withString:@"B" startingAtIndex:0] writeToFile:path atomically:NO encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertEqual(utimes(path.fileSystemRepresentation, times), 0);
+
+    NSString* newETag = etagOf(SendRawRequest(server.port, @"HEAD /f/build.bin HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+    XCTAssertNotNil(newETag);
+    XCTAssertNotEqualObjects(oldETag, newETag, @"the entity tag did not move when the content did");
+
+    NSString* revalidated = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /f/build.bin HTTP/1.1\r\nHost: localhost\r\nIf-None-Match: %@\r\n\r\n", oldETag]);
+    XCTAssertFalse([revalidated hasPrefix:@"HTTP/1.1 304"], @"a stale validator was told Not Modified: %@", [revalidated substringToIndex:MIN((NSUInteger)40, revalidated.length)]);
+
+    NSString* resumed = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /f/build.bin HTTP/1.1\r\nHost: localhost\r\nRange: bytes=100-199\r\nIf-Range: %@\r\n\r\n", oldETag]);
+    XCTAssertFalse([resumed hasPrefix:@"HTTP/1.1 206"], @"a range was served against a changed representation: %@", [resumed substringToIndex:MIN((NSUInteger)40, resumed.length)]);
+
+    // Revalidating with the CURRENT tag must still produce a cheap 304, or this has simply
+    // disabled caching.
+    NSString* fresh = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /f/build.bin HTTP/1.1\r\nHost: localhost\r\nIf-None-Match: %@\r\n\r\n", newETag]);
+    XCTAssertTrue([fresh hasPrefix:@"HTTP/1.1 304"], @"an up-to-date validator no longer revalidates: %@", [fresh substringToIndex:MIN((NSUInteger)40, fresh.length)]);
+
+    [server stop];
+    [fm removeItemAtPath:root error:NULL];
+}
+
 - (void)testSymlinkResolvingToTheShareRootCannotDestroyIt {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};

--- a/Sources/WebServerKit/Core/WSKRequest.m
+++ b/Sources/WebServerKit/Core/WSKRequest.m
@@ -175,6 +175,23 @@ NSString *const WSKRequestAttribute_RegexCaptures = @"WSKRequestAttribute_RegexC
 
         if (_stream.avail_out > 0) {
             if (result == Z_STREAM_END) {
+                // Trailing bytes that arrive in the SAME read as the end of the member are the
+                // same error as trailing bytes in a later one, which the `_finished` guard above
+                // already refuses. Without this the verdict depends on how the client happened to
+                // split its writes: an identical two-member body answered 200 with the second
+                // member silently dropped when sent in one write, and 500 when split at the
+                // member boundary. The client chose which, and the handler was handed less data
+                // than was sent while the status said success.
+                if (_stream.avail_in > 0) {
+                    WSK_LOG_ERROR(@"Trailing data after the end of the gzip request body");
+
+                    if (error) {
+                        *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Trailing data after end of gzip request body"}];
+                    }
+
+                    return NO;
+                }
+
                 _finished = YES;
             }
 

--- a/Sources/WebServerKit/Responses/WSKFileResponse.m
+++ b/Sources/WebServerKit/Responses/WSKFileResponse.m
@@ -193,7 +193,19 @@ static NSString *_EscapeExtValue(NSString *string) {
     // Derive the validators here, from the same fstat the range decision uses, so If-Range
     // can be answered against the representation we are actually about to serve.
     NSDate *const lastModified = _NSDateFromTimeSpec(&info.st_mtimespec);
-    NSString *const entityTag = [NSString stringWithFormat:@"\"%llu/%li/%li\"", info.st_ino, info.st_mtimespec.tv_sec, info.st_mtimespec.tv_nsec];
+    // Size is part of the tag because inode and mtime alone do not identify the bytes: a rewrite
+    // in place that restores the timestamp — utimes(2), and what rsync -a, cp -p and tar -x all
+    // do — keeps the same inode and the same mtime down to the nanosecond, so the tag did not
+    // move. Measured: a 900-byte build replaced by a 916-byte one under the same validator
+    // answered 304 to a revalidation (the client keeps the stale copy indefinitely) and 206 to a
+    // resume (the new build's bytes spliced onto the old one's prefix). That is the failure the
+    // If-Range work exists to prevent, arriving through the strong validator instead of the weak
+    // one. Apache includes size for the same reason.
+    //
+    // It does not close a replacement of exactly equal length with a restored mtime, and nothing
+    // derived from stat(2) can. Changing the format costs every existing client one revalidation
+    // miss, once.
+    NSString *const entityTag = [NSString stringWithFormat:@"\"%llu/%lld/%li/%li\"", info.st_ino, (long long)info.st_size, info.st_mtimespec.tv_sec, info.st_mtimespec.tv_nsec];
 
     // A date validator may only be *issued* once the second it names has closed. While mtime
     // is still inside the current second the file can be written again without the timestamp


### PR DESCRIPTION
The last two findings from the overnight pass — both reproduced here before being acted on —
plus the ninth-pass record for `CLAUDE.md`.

### A gzip body's verdict depended on TCP segmentation

| same bytes, different writes | before | after |
|---|---|---|
| two members, **one** send | **200 OK**, second member silently dropped | 500 |
| two members, split at the boundary | 500 | 500 |
| member + garbage, **one** send | **200 OK**, garbage dropped | 500 |
| member + garbage, split before | 500 | 500 |
| single valid member (control) | 200, delivered whole | 200, delivered whole |

The client chose which answer it got, and on the 200 path the handler was given *less data than
was sent* with no way for either side to tell.

The fifth pass fixed the later-read half and **this file recorded the case as closed**; the
same-read half was still open, because `Z_STREAM_END` was accepted without checking whether
`avail_in` still held bytes. It now refuses either way, matching the guard that already existed
for the later read.

Found by a **split-invariance oracle** — same request, different segmentation, different answer.
Cheap property, worth reusing.

### The entity tag did not identify the bytes

It was inode + mtime only. A rewrite in place that restores the timestamp — `utimes(2)`, and what
`rsync -a`, `cp -p` and `tar -x` all do — produced a byte-identical tag for different content:

```
build A: etag="161391707/1600000000/123456000" len=900
build B: etag="161391707/1600000000/123456000" len=916   <-- unchanged
revalidate with A's etag -> 304 Not Modified      (client keeps stale bytes, indefinitely)
resume     with A's etag -> 206 Partial Content   (B's bytes spliced onto A's prefix)
```

That is exactly the failure the `If-Range` work exists to prevent, arriving through the **strong**
validator rather than the weak one — and this file's own note that a preserved-mtime replacement
is "undetectable by any date-based scheme" quietly implied the ETag handled it.

Size is now part of the tag, as Apache does. **Equal length with an equal timestamp stays
undetectable**, and nothing derived from `stat(2)` can close it. Existing clients pay one
revalidation miss, once.

### Verification

Both fail against `main` — the gzip one on a 200 with the member dropped, the ETag one on
identical tags either side of a content change. Both also assert what must keep working: a single
well-formed member is still accepted *and delivered whole*, and an up-to-date validator still
produces a cheap 304.

**All eight recorded trace suites pass**, which is what an ETag format change most risked.

Full harness green: **101 tests**, Release builds for all three platforms, `swift build`.

### The ninth-pass record

Also included: the three fixes merged overnight, these two, the five-hour soak
(**19,723,889 requests / 15.6 TB**, descriptors below baseline, aggregate reservation zero
throughout), and the genuinely clean results from allocation injection and lifecycle churn.

It names a pattern rather than another instance: **the record has now overstated the code four
times** — the sixth pass's `If-Range` claim, the hidden-item rule that covered two servers of
three, the recursive delete only the uploader vetted, and the gzip case above. Each was a sentence
describing a property the code held only partly. When a pass closes a class, check every site the
class can occur at before writing that it is closed.