### PR TITLE
Close the NUL class in the two servers it was never closed in, and stop refusing valid gzip bodies

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -199,6 +199,22 @@ static NSString* SendRawRequest(NSUInteger port, NSString* request) {
     return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 
+// As SendRawDataRequest, but split into two writes with a pause, so the tail arrives in a
+// separate socket read. Used to prove a verdict does not depend on how the client segmented.
+static NSString* SendRawDataRequestSplit(NSUInteger port, NSData* request, NSUInteger splitAt) {
+    int fd = ConnectToLocalhostPort(port);
+    if (fd < 0) {
+        return nil;
+    }
+    send(fd, request.bytes, splitAt, 0);
+    usleep(150000);
+    send(fd, (const char*)request.bytes + splitAt, request.length - splitAt, 0);
+    BOOL sawEOF = NO;
+    NSData* data = ReadToEOF(fd, &sawEOF);
+    close(fd);
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
 // As SendRawRequest, but for a request whose body is not valid UTF-8 (e.g. gzip).
 static NSString* SendRawDataRequest(NSUInteger port, NSData* request) {
     int fd = ConnectToLocalhostPort(port);
@@ -1647,6 +1663,93 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 
     [server stop];
     [fm removeItemAtPath:dir error:NULL];
+}
+
+// The eighth pass closed this in the uploader and the record said the class was closed. It was
+// not: WebDAV had no NUL guard at all, and the base-path handler served through one. All three
+// servers must agree, because a client that gets a different answer per server is exactly how
+// this class survived four sweeps.
+- (void)testAllServersRefusePathsContainingNUL {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    NSString* victim = [root stringByAppendingPathComponent:@"Victim"];
+    XCTAssertTrue([fm createDirectoryAtPath:victim withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"precious" writeToFile:[victim stringByAppendingPathComponent:@"data.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"SECRETBUILD" writeToFile:[root stringByAppendingPathComponent:@"build.ipa"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+
+    // WebDAV: a destructive request must never be honoured against the truncated prefix.
+    WSKWebDAVServer* dav = [[WSKWebDAVServer alloc] initWithUploadDirectory:root];
+    XCTAssertTrue([dav startWithOptions:options error:NULL]);
+    NSString* deleted = SendRawRequest(dav.port, @"DELETE /Victim%00/does-not-exist HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertFalse([deleted hasPrefix:@"HTTP/1.1 204"], @"a NUL-bearing DELETE was honoured: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:victim], @"WebDAV destroyed the truncated prefix instead of refusing");
+
+    NSString* put = SendRawRequest(dav.port, @"PUT /new%00.exe HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\ndata");
+    XCTAssertFalse([put hasPrefix:@"HTTP/1.1 201"], @"a NUL-bearing PUT created a file: %@", [put substringToIndex:MIN((NSUInteger)40, put.length)]);
+    XCTAssertFalse([fm fileExistsAtPath:[root stringByAppendingPathComponent:@"new"]], @"WebDAV wrote to the truncated prefix");
+
+    // ...and the ordinary requests must be untouched by all of this.
+    XCTAssertTrue([SendRawRequest(dav.port, @"GET /build.ipa HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"SECRETBUILD"], @"an ordinary WebDAV GET stopped working");
+    XCTAssertTrue([SendRawRequest(dav.port, @"PROPFIND / HTTP/1.1\r\nHost: localhost\r\nDepth: 1\r\nContent-Length: 0\r\n\r\n") hasPrefix:@"HTTP/1.1 207"], @"PROPFIND stopped working");
+    [dav stop];
+
+    // The base-path handler: read-only, but serving "build.ipa\0.txt" is the extension confusion
+    // the truncation exists to prevent.
+    WSKWebServer* basePath = [[WSKWebServer alloc] init];
+    [basePath addGETHandlerForBasePath:@"/f/" directoryPath:root indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    XCTAssertTrue([basePath startWithOptions:options error:NULL]);
+    XCTAssertFalse([SendRawRequest(basePath.port, @"GET /f/build.ipa%00.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"SECRETBUILD"], @"the base-path handler served a file through a NUL");
+    XCTAssertTrue([SendRawRequest(basePath.port, @"GET /f/build.ipa HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"SECRETBUILD"], @"an ordinary base-path GET stopped working");
+    [basePath stop];
+
+    [fm removeItemAtPath:root error:NULL];
+}
+
+// A well-formed single-member gzip body whose inflated length exactly fills the decoder's buffer
+// (256 KiB * 2^k) was refused with 500 whenever the 8-byte trailer arrived in a later read: at
+// exact fill avail_out is 0, so the loop grew the buffer and called inflate() again with no input
+// left, which returns Z_BUF_ERROR. Reachable by any chunked streaming client using those block
+// sizes. The ninth pass's own commit claimed the gzip verdict no longer depends on segmentation;
+// for valid bodies at these sizes it still did.
+- (void)testValidGZipBodyIsAcceptedWhateverItsInflatedSize {
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    __block NSUInteger receivedLength = 0;
+    [server addHandlerForMethod:@"POST"
+                           path:@"/data"
+                   requestClass:[WSKDataRequest class]
+                   processBlock:^WSKResponse*(WSKDataRequest* request) {
+                       receivedLength = request.data.length;
+                       return [WSKDataResponse responseWithText:@"ok"];
+                   }];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // Either side of the initial buffer size, and two doublings past it.
+    for (NSNumber* size in @[ @261120, @262144, @263168, @524288, @1048576 ]) {
+        NSUInteger const length = size.unsignedIntegerValue;
+        NSMutableData* payload = [NSMutableData dataWithLength:length];
+        memset(payload.mutableBytes, 'Z', length);
+        NSData* body = GZipCompress(payload);
+
+        NSString* head = [NSString stringWithFormat:@"POST /data HTTP/1.1\r\nHost: localhost\r\nContent-Encoding: gzip\r\nContent-Type: application/octet-stream\r\nContent-Length: %lu\r\n\r\n", (unsigned long)body.length];
+        NSMutableData* whole = [[head dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+        [whole appendData:body];
+
+        receivedLength = 0;
+        XCTAssertTrue([SendRawDataRequest(server.port, whole) hasPrefix:@"HTTP/1.1 200"], @"a valid %lu-byte body was refused when sent whole", (unsigned long)length);
+        XCTAssertEqual(receivedLength, length, @"the handler received the wrong length for a %lu-byte body", (unsigned long)length);
+
+        // The same bytes with the trailer in a later read must give the same answer — that
+        // invariance is the whole point, and it has to hold for VALID bodies too.
+        receivedLength = 0;
+        NSString* split = SendRawDataRequestSplit(server.port, whole, whole.length - 4);
+        XCTAssertTrue([split hasPrefix:@"HTTP/1.1 200"], @"a valid %lu-byte body was refused when its trailer arrived in a later read: %@", (unsigned long)length, [split substringToIndex:MIN((NSUInteger)40, split.length)]);
+        XCTAssertEqual(receivedLength, length, @"the split send delivered the wrong length for %lu bytes", (unsigned long)length);
+    }
+
+    [server stop];
 }
 
 - (void)testUploaderRefusesPathsContainingNULRatherThanTruncating {

--- a/Sources/WebServerKit/Core/WSKRequest.m
+++ b/Sources/WebServerKit/Core/WSKRequest.m
@@ -173,7 +173,15 @@ NSString *const WSKRequestAttribute_RegexCaptures = @"WSKRequestAttribute_RegexC
             return NO;
         }
 
-        if (_stream.avail_out > 0) {
+        // End the pass when zlib has finished the member, when it left output room (so it had
+        // nothing more to write), OR when it has consumed all the input it was given. That last
+        // clause matters: when the inflated output exactly fills the buffer, avail_out is 0 even
+        // though zlib is done with this input, so the loop grew the buffer and called inflate()
+        // again with avail_in == 0 — which can make no progress and returns Z_BUF_ERROR, refusing
+        // a perfectly valid body. It bit only at exact multiples of the initial buffer size
+        // (256 KiB * 2^k) and only when the trailer arrived in a later read, so a streaming client
+        // chunking at 256 KiB, 512 KiB or 1 MiB was refused while 64 KiB and 128 KiB worked.
+        if ((result == Z_STREAM_END) || (_stream.avail_out > 0) || (_stream.avail_in == 0)) {
             if (result == Z_STREAM_END) {
                 // Trailing bytes that arrive in the SAME read as the end of the member are the
                 // same error as trailing bytes in a later one, which the `_finished` guard above

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1585,7 +1585,19 @@ static NSString *_EscapeHTMLString(NSString *string) {
             }
             processBlock:^WSKResponse *(WSKRequest *request) {
                 WSKResponse *response = nil;
-                NSString *const relativePath = WSKNormalizePath([request.path substringFromIndex:basePath.length]);
+                NSString *const requestedRelativePath = [request.path substringFromIndex:basePath.length];
+
+                // Truncating at a NUL and then serving the prefix means answering a request the
+                // client did not make: "/build.ipa\0.txt" served build.ipa, which is the very
+                // extension confusion the truncation exists to prevent. Read-only here, so
+                // nothing is destroyed — but the uploader and WebDAV both refuse this shape, and
+                // one server quietly disagreeing is how this class has survived four sweeps.
+                if (WSKPathContainsNULByte(requestedRelativePath)) {
+                    WSK_LOG_WARNING(@"Refusing to serve a path containing a NUL byte");
+                    return [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_BadRequest];
+                }
+
+                NSString *const relativePath = WSKNormalizePath(requestedRelativePath);
 
                 // The directory listing below deliberately omits every dot-entry, so without
                 // this the browsable index actively advertises a *smaller* tree than the one

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -182,6 +182,20 @@ NS_ASSUME_NONNULL_END
 // retargeted between two independent resolutions served content from outside the share and
 // landed a PUT outside it.
 - (nullable NSString *)_resolvedPathForRelativePath:(NSString *)relativePath hidden:(BOOL *)outHidden {
+    // WSKNormalizePath truncates at an embedded NUL — deliberately, because the filesystem's
+    // C-string APIs do and the mismatch is otherwise exploitable. But truncating does not make
+    // the request mean what the client wrote, and acting on the prefix is how
+    // "DELETE /Victim\0/does-not-exist" answered 204 and destroyed /Victim, and how a MOVE with a
+    // NUL-bearing Destination replaced a whole directory with the moved file. The uploader has
+    // refused this since the eighth pass; this server was never swept for it.
+    //
+    // Refused here, at the one point every path-taking verb goes through, so a verb added later
+    // cannot forget it. Normalization keeps truncating as the second line, so the
+    // "secret.dat\0.png" extension-allow-list bypass stays closed.
+    if (WSKPathContainsNULByte(relativePath)) {
+        return nil;
+    }
+
     NSString *const normalizedPath = WSKNormalizePath(relativePath);
     NSString *resolvedRelativePath = nil;
     NSString *const resolvedPath = WSKResolveWithinDirectory([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory, &resolvedRelativePath);


### PR DESCRIPTION
Two findings from auditing the 137 unaudited lines PRs #43 and #44 added. **Both are pre-existing**
— established by building `0b41eaa` and measuring, not by reading — but both falsify something
`CLAUDE.md` claims.

### 1. WebDAV honoured destructive requests against a NUL-truncated path

`WSKPathContainsNULByte` appeared **8 times in the uploader and 0 times in WebDAV**.

| request | before | effect |
|---|---|---|
| `DELETE /Victim%00/does-not-exist` | 204 | `/Victim` **and its subtree destroyed** |
| `MOVE → /Target%00/does-not-exist` | 204 | `/Target` directory **replaced by the moved file** |
| `GET /visible.txt%00.png` | 200 | serves `visible.txt` |
| `PUT /new%00.exe` | 201 | creates `/new` |

The client names a path that exists nowhere and the server destroys something else. The eighth
pass fixed exactly this shape in the uploader and **this file recorded the class as closed** — it
was closed in one server of three.

### 2. The base-path handler had the read-only half

`GET /f/build.ipa%00.txt` → **200, serving `build.ipa`** — the extension confusion the NUL
truncation exists to prevent. Nothing is destroyed, but one server quietly disagreeing with the
other two is how this class survived four sweeps, so it is closed here rather than filed as a
known difference.

Both are refused at the single point every path-taking verb passes through, so a verb added later
cannot forget it. Normalization keeps truncating as the second line, so the `secret.dat\0.png`
allow-list bypass stays closed.

### 3. Valid gzip bodies were refused at exact buffer-fill sizes

A well-formed **single-member** body whose inflated length exactly filled the decoder's buffer was
refused with `500` whenever the trailer arrived in a later read:

```
inflates to   one write   trailer in later read
   261120        200            200
   262144        200            500   <<< VALID BODY REFUSED
   263168        200            200
   524288        200            500   <<<
  1048576        200            500   <<<
  2097152        200            500   <<<
```

At exact fill `avail_out` is 0, so the `Z_STREAM_END` branch was skipped, the loop grew the buffer
and called `inflate()` again with no input left, and zlib's `Z_BUF_ERROR` became a decode failure.
It bites at 256 KiB·2^k and nowhere else — **reachable by any chunked streaming client using those
block sizes**.

**This one matters beyond its severity.** Yesterday's commit and `CLAUDE.md` both say the gzip
verdict no longer depends on how the client split its writes. For valid bodies at those sizes it
still did. That is the **fifth** time the record has described a property the code held only
partly, and the first where the overstatement was mine and one day old.

### Verification

Both tests fail against `main` — the NUL one on a `204` with the directory destroyed, the gzip one
on a `500` for a valid body.

Both assert the ordinary cases keep working: WebDAV `GET` and `PROPFIND`, a base-path `GET`, and
every gzip body delivered **byte-for-byte at its correct length**. The four trailing-data refusals
that loosening the loop could have reopened were re-measured and all still refuse.

Full harness green: **103 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.

### What the audit found clean

Worth recording so it is not re-tested: the root guard holds (every root spelling reaches the
root, every ordinary root operation succeeds, the web UI works end to end); the `avail_in` check
does **not** over-refuse across 2,610 well-formed bodies from 29 producers; nothing parses the
ETag, so the format change cannot break a consumer; and the multipart initializer reorder is
complete — both early returns are downstream of the sentinel.