### PR TITLE
Correct the If-Range record, and make its test test what it claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,8 +306,21 @@ affected — which is why the ETag control restarted correctly 4/4 while the dat
 the observation that ruled out a harness artefact. Costs a date-only client one second of
 caching; a future mtime is unsealed by the same test, which also stops the server advertising a
 `Last-Modified` newer than its own `Date`. Pinned by
-`testIfRangeRefusesADateMintedInsideItsOwnSecond`, which asserts both that no such date is
-issued and that one presented anyway is refused; it fails 2/2 against the sixth pass's code.
+`testIfRangeRefusesADateMintedInsideItsOwnSecond`, which fails 2/2 against the sixth pass's code.
+
+**⚠️ Correction (tenth pass): the redemption-time check is NOT a second line of defence, and this
+entry and the commit both said it was.** Withholding the date at issue time is the whole of the
+protection. The check that survives in the resume path is still evaluated when the resume
+*arrives*, so a resume landing even one second later sees a sealed timestamp and honours the
+date — measured 200 in the same second, 206 one second later, 206 two seconds later. That is the
+identical flaw this pass diagnosed in the sixth pass's fix, left in place and then described as a
+defence. It cannot be fixed: once the second closes the server *would* issue that date for the
+current bytes, so a date a client legitimately holds and one it fabricated are byte-identical,
+exactly as for a replacement that preserves mtime. What protects a conformant client is that no
+such date is ever issued while the second is open. The test now verifies the whole sequence lands
+inside one second rather than only the write — checking only up to the write made it pass locally
+and fail on a slower CI runner — and pins the closed-second behaviour so a later pass does not
+re-find it and churn.
 
 Not a regression — the pre-fix commit was built and measured and behaves identically. The
 defect was in the claim, not the code, which is the more dangerous kind in a file whose purpose

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -2741,6 +2741,7 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     // than asserted on if the sequence straddles a boundary, so this measures the intended
     // regime instead of racing the clock.
     NSString* resumed = nil;
+    time_t sealedSecond = 0;
     NSString* lastModified = nil;
     for (NSUInteger attempt = 0; attempt < 5; attempt++) {
         XCTAssertTrue([[@"" stringByPaddingToLength:4096 withString:@"A" startingAtIndex:0] writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
@@ -2765,13 +2766,36 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 
         // And a client presenting that date anyway — fabricated, or held from elsewhere — must
         // not be given a range against the *replacement*.
-        resumed = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /build.ipa HTTP/1.1\r\nHost: localhost\r\nRange: bytes=1024-2047\r\nIf-Range: %@\r\n\r\n", WSKFormatRFC822([NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)before])]);
+        NSString* const attempted = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /build.ipa HTTP/1.1\r\nHost: localhost\r\nRange: bytes=1024-2047\r\nIf-Range: %@\r\n\r\n", WSKFormatRFC822([NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)before])]);
+
+        // The clock has to be re-checked AFTER the resume, not only before it. The guard below is
+        // evaluated when the resume *arrives*, so a resume that lands in the next second sees a
+        // sealed timestamp and honours the date — which is correct behaviour (see the note at the
+        // end of this test) but is not the regime under test. Checking only up to the write made
+        // this test pass locally and fail on a slower CI runner.
+        if (time(NULL) != before) {
+            continue;
+        }
+
+        resumed = attempted;
+        sealedSecond = before;
         break;
     }
 
-    XCTAssertNotNil(resumed, @"could not land two writes inside one second in five attempts");
+    XCTAssertNotNil(resumed, @"could not land the whole sequence inside one second in five attempts");
     NSString* status = [[resumed componentsSeparatedByString:@"\r\n"] firstObject];
     XCTAssertTrue([status hasPrefix:@"HTTP/1.1 200"], @"a 206 spliced build B onto build A's prefix: %@", status);
+
+    // The inherent limit, pinned so a later pass does not re-find it and try to "fix" it. Once
+    // the second has closed, the server WOULD issue that date for the current bytes, so a date a
+    // client legitimately holds and one it fabricated are byte-identical — nothing derived from
+    // stat(2) can separate them, exactly as for a replacement that preserves mtime. What protects
+    // a conformant client is that no such date is ever issued while the second is open (asserted
+    // above); the redemption-time check is not a second line of defence and must not be described
+    // as one.
+    [NSThread sleepForTimeInterval:1.1];
+    NSString* afterTheSecondClosed = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /build.ipa HTTP/1.1\r\nHost: localhost\r\nRange: bytes=1024-2047\r\nIf-Range: %@\r\n\r\n", WSKFormatRFC822([NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)sealedSecond])]);
+    XCTAssertTrue([[[afterTheSecondClosed componentsSeparatedByString:@"\r\n"] firstObject] hasPrefix:@"HTTP/1.1 206"], @"a date naming a closed second is honoured; if this ever changes, the change is deliberate and this comment is wrong");
 
     [server stop];
     [fm removeItemAtPath:root error:NULL];


### PR DESCRIPTION
**CI failed on `main`** at the merge of #45 —
`testIfRangeRefusesADateMintedInsideItsOwnSecond` returned `206` where it asserts `200`.

It was **not a flake and not a regression from #45**. The test was non-deterministic, and the
property it asserted is not one the code can hold.

### What actually happens

The test checked that the two writes landed inside one wall-clock second — but not that the
**resume** did. The guard it exercises is evaluated when the resume *arrives*:

| resume sent | verdict |
|---|---|
| same second | 200 (correct) |
| 1s later | **206 splice** |
| 2s later | **206 splice** |

A fast local machine kept the whole sequence inside one second and passed. A slower CI runner did
not.

### The claim that was wrong

That guard is the redemption-time check the seventh pass kept after moving the real deduction to
issue time — and then described, in the commit **and in `CLAUDE.md`**, as *"a second line, since a
client may present a date this server never issued."*

It is not a second line. It is the **identical flaw that pass diagnosed in the sixth pass's fix**,
left in place and relabelled. Sixth time the record has claimed a property the code holds only
partly; third where the overstatement was mine.

### It cannot be fixed, and that is the point

Once the second closes, the server **would** issue that date for the current bytes — so a date a
client legitimately holds and one it fabricated are byte-identical. Nothing derived from `stat(2)`
separates them, exactly as for a replacement that preserves mtime.

What protects a conformant client is that **no such date is ever issued while the second is
open** — asserted, and it does hold. The `XCTAssertNil` for that passed on CI; only the
unachievable assertion failed.

### So: no code change

The test now re-checks the clock **after the resume** as well as after the write, making the
regime deterministic — 6 consecutive runs pass, including 3 with eight CPU hogs running to mimic a
loaded runner. It also **pins the closed-second behaviour**, so a later pass does not re-find it
and try to "fix" an inherent limit.

The `CLAUDE.md` correction sits next to the claim it corrects rather than quietly replacing it.

Full harness green: **103 tests**, all 8 trace suites, Release builds for all three platforms,
`swift build`.