### PR TITLE
Vet what an overwrite destroys, and stop an upload escaping through its filename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,123 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Tenth audit pass: the scan that was meant to end the programme, and did not
+
+This pass existed to *stop* the audit: the rule agreed beforehand was that if a scan aimed at the
+recurring classes found nothing new, the programme ends. **It found five things, and the run had
+to be done twice** — the first attempt was killed mid-sweep by a machine reboot.
+
+**Recovering the dead run was worth more than re-running it.** The journal recorded four agents
+`started` and no results, which reads as a total loss; `resumeFromRunId` is same-session only, so
+it was not available either. But the per-agent transcripts survive on disk, and one of them
+contained `**S6c is a hit.**` with the probe table under it. That lead became the first finding
+below. The relaunch was then told what was already known so the agents hunted *siblings* rather
+than re-deriving it — and three of them independently landed on the same defect from different
+directions anyway, which is the strongest evidence any pass here has produced that a finding is
+real.
+
+**A collection was again a spelling that skipped the allow-list — this time through MOVE and
+COPY.** The eighth pass closed the recursive `DELETE` and the design priorities at the top of this
+file then claimed the general property. `MOVE` and `COPY` destroy exactly as much through
+`Overwrite`, and nothing vetted what they were about to destroy. Both of `performCOPY:isMove:`'s
+extension checks are gated behind `!srcIsDirectory`, which opens *two* doors:
+
+- a **collection source** skips both checks outright, so `MOVE /Src` over a folder holding `id_rsa`
+  answered 204 and destroyed it;
+- a **file source** does run the destination check — and a collection named `Puck.app` or
+  `Backup.txt` *passes* it, because the check only ever judges a name. `COPY /Puck-1.2.ipa` with
+  `Destination: /Puck.app` needs no `Overwrite` header at all and took out `id_rsa`,
+  `embedded.mobileprovision` and `Frameworks/secret`.
+
+Both measured 5/5, in Debug and Release. The vetting is now one method,
+`-_firstUnvettableItemAtPath:isDirectory:`, used by `performDELETE` *and* by the overwrite — a
+second implementation of a rule beside the live one is the trap this file already names. Every
+other destructive site was then checked rather than assumed: `performPUT` refuses an existing
+collection with 405, and the uploader's `/upload` and `/move` route through `-_uniquePathForPath:`
+and so have no overwrite path at all. That asymmetry is deliberate and not a parity gap — only
+WebDAV implements RFC 4918 `Overwrite`.
+
+**`Overwrite: f` destroyed the destination.** The header was compared with `-isEqualToString:@"F"`,
+so that exact byte was the only spelling that meant "do not overwrite" and **every other one was
+taken as permission**: `f`, `False`, `no`, `0` and an empty value all answered 204 and clobbered,
+while `F` answered 412. RFC 4918 §1.4 adopts RFC 2616 ABNF, in which quoted literals are
+case-insensitive, so `f` is *conformant* — a client that explicitly said "do not overwrite" lost
+its data and was told it succeeded. This one fails **open**, which is what separates it from the
+identical shape in the `Depth: infinity` comparison, which fails closed and was merely an interop
+bug; both are case-folded now through one `_HeaderTokenIs` helper.
+
+**Deliberately not changed:** a `MOVE` with no `Overwrite` header at all still answers 412. RFC
+4918 §9.9.3 says an absent header means `T`, but conforming would make MOVE destructive by default,
+against this file's own "refuse rather than half-succeed" priority. Recorded rather than fixed.
+
+**An upload escaped the share through its filename.** `POST /upload` with `filename="/"` — no
+`path` field needed, no allow-list set, i.e. the **default configuration** — answered 200 and wrote
+the body *beside* the served directory. `[@"/" lastPathComponent]` is `@"/"`, the one input for
+which that does not yield a leaf; it then passes every guard, and
+`-stringByAppendingPathComponent:@"/"` collapses straight back to the upload directory, so
+`-_uniquePathForPath:` finds it already exists and renames **its own leaf in the parent** —
+`Share (1)`, repeatable and unbounded. Same class the eighth pass called the sharpest finding of
+any pass, arriving through the filename rather than a symlink.
+
+**⚠️ The fix the agent proposed for it would have broken every upload under `/var` or `/tmp`,** and
+its own skeptic caught that. The suggestion was `WSKPathIsInsideDirectory(desiredPath,
+_uploadDirectory)`, but `_uploadDirectory` is stored `-stringByStandardizingPath`'d (a share under
+`NSTemporaryDirectory()` stays `/var/…`) while `desiredPath` is composed onto a `realpath(3)`
+result (`/private/var/…`), so the comparison is false for every legitimate upload there — and
+`MakeTempDirectory()` uses exactly that base, so the suite would have gone red. What shipped
+rejects a separator in the reduced leaf *and* judges the composed path against **`resolvedDirectory`**.
+This is the second time a proposed fix, not the finding, was the dangerous part.
+
+**A content coding the server could not decode was stored as the entity.** `-prepareForWriting`
+installed the gzip decoder for the exact token `gzip` and had **no else branch**, so every other
+coding left the raw sink in place: `PUT` with `Content-Encoding: deflate` wrote the *compressed*
+octets to disk and answered 201. `x-gzip` — which RFC 9110 §8.4.1 defines as a synonym for `gzip`
+— was silently stored undecoded too. The rule this violates was already written down one screen
+away, in `_ParseTransferEncoding`: *storing the still-encoded bytes as if they were the body is
+worse than refusing.* Unsupported codings are now 415; `x-gzip` decodes, because refusing it would
+trade silent corruption for an interop bug.
+
+**Preconditions were evaluated after the write.** `If-Match` was not parsed anywhere in the tree,
+and `-overrideResponse:forRequest:` — the only place any precondition was evaluated — runs *after*
+the handler has produced its response, comparing against a `response.eTag` that a 201/204 does not
+carry. So no 412 could ever be produced and the lost-update protection a WebDAV client believes it
+has did not exist: two clients editing one file each silently overwrote the other. Now enforced
+before any destructive step for **PUT, DELETE, MOVE and COPY** rather than only for PUT where it
+was found, since "closed at one of the sites the rule applies to" is this codebase's most reliable
+defect shape. The tag is `WSKEntityTagForFileInfo`, extracted so `WSKFileResponse` and this check
+cannot drift — a second formatter would make every precondition fail rather than protect anything.
+
+**Class C came back genuinely clean, and the instruments were proved before the zeros were
+believed.** 67 failure scenarios × 250 iterations ended at exactly baseline descriptors (12 → 12);
+a 676,970-request soak ended 33 descriptors *below* baseline; `reservedInMemoryByteCount` was 0 at
+rest in every run, including after being driven to its ceiling and abandoned there 150 times with
+`SO_LINGER {1,0}`. The staging-swap failure path was forced with an immutable child: 30 COPY + 30
+MOVE left zero staging siblings and restored the source 30/30. An RSS creep of ~15 B/request was
+chased rather than waved away and proved to be allocator behaviour — `leaks(1)` reported zero, live
+bytes went *down* between samples, and a legitimate-traffic-only control showed the same slope.
+**Do not re-run this speculatively.**
+
+Also clean and worth not re-testing: 1,143 same-bytes-different-segmentation pairs plus 2,700
+randomized splits produced zero verdict differences, including the 256 KiB×2^k band where the ninth
+pass's gzip defect lived — the split-invariance oracle found nothing this time. HEAD/GET parity was
+exact across 79 header-by-header comparisons. The NUL guard was confirmed present at all 10
+client-path entry points by *driving* each one, not by grepping.
+
+**The one disagreement that was adjudicated rather than fixed:** listing a symlink-to-root answers
+200 from the base-path handler and 403 from the uploader and WebDAV. Not a defect, and measured
+rather than argued — the body of `GET /selfroot/` is byte-identical to `GET /`, so the permissive
+answer discloses nothing, and every composite through it is still refused exactly as its direct
+spelling is. The refusal in the other two is the resolver-level guard protecting their destructive
+verbs; the base-path handler has none to protect.
+
+**Still open:** the `MOVE`-without-`Overwrite` default above, deliberately. The `//` status
+disagreement from the eighth pass remains deliberately unfixed.
+
+**A note on running this again.** Two timing tests — `testConnectionIdleTimeoutSparesSlowHandler`
+and `testConnectionClosesSlowlorisHeaderDribble` — fail when parallel agents saturate the machine
+(observed at load average 169; both passed 3/3 in isolation immediately after). Do not read a
+`Run-Tests.sh` verdict while a fleet is building, and re-run a failure alone before believing it.
+
 ### Ninth audit pass: fuzzing, differential testing, and a fix of mine that destroyed the share
 
 Run overnight, unattended, with three techniques this project had never applied: mutational and

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1482,6 +1482,52 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// The multipart filename is reduced to a leaf with -lastPathComponent, and "/" is the one input
+// for which that does not yield a leaf: it returns "/" unchanged. The name then passes every
+// guard (non-empty, no NUL, not "." or "..", no leading dot, and an empty pathExtension is
+// allowed when no allow-list is set — the default), and
+// -[NSString stringByAppendingPathComponent:@"/"] collapses straight back to the upload
+// directory. -_uniquePathForPath: then sees that directory already exists and renames *its own
+// leaf* in its PARENT, so the body lands beside the share as "Share (1)". Measured before this:
+// 200 OK, repeatable and unbounded. Same class as the eighth pass's symlink write — a file
+// landing outside the shared directory — arriving through the filename instead.
+- (void)testUploaderRefusesAFileNameThatIsNotASingleComponent {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* parent = MakeTempDirectory();
+    NSString* share = [parent stringByAppendingPathComponent:@"Share"];
+    XCTAssertTrue([fm createDirectoryAtPath:share withIntermediateDirectories:YES attributes:nil error:NULL]);
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:share];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSData* (^upload)(NSString*) = ^(NSString* fileName) {
+        NSString* body = [NSString stringWithFormat:@"--B\r\nContent-Disposition: form-data; name=\"files[]\"; filename=\"%@\"\r\nContent-Type: text/plain\r\n\r\nESCAPED\r\n--B--\r\n", fileName];
+        NSString* head = [NSString stringWithFormat:@"POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: %lu\r\n\r\n", (unsigned long)[body lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
+        NSMutableData* request = [[head dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+        [request appendData:[body dataUsingEncoding:NSUTF8StringEncoding]];
+        return (NSData*)request;
+    };
+
+    // An ordinary upload must still work, or the refusals below prove nothing.
+    XCTAssertTrue([SendRawDataRequest(server.port, upload(@"ok.txt")) hasPrefix:@"HTTP/1.1 200"], @"an ordinary upload stopped working");
+    XCTAssertTrue([fm fileExistsAtPath:[share stringByAppendingPathComponent:@"ok.txt"]], @"the ordinary upload did not land in the share");
+
+    for (NSString* name in @[ @"/", @"//", @"///" ]) {
+        NSString* reply = SendRawDataRequest(server.port, upload(name));
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 403"], @"filename \"%@\" should be refused: %@", name, [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+
+        // The assertion that matters is not the status but that nothing appeared outside the
+        // served directory.
+        NSMutableArray* strays = [[fm contentsOfDirectoryAtPath:parent error:NULL] mutableCopy];
+        [strays removeObject:@"Share"];
+        XCTAssertEqual(strays.count, (NSUInteger)0, @"filename \"%@\" wrote outside the share: %@", name, [strays componentsJoinedByString:@", "]);
+    }
+
+    [server stop];
+    [fm removeItemAtPath:parent error:NULL];
+}
+
 // Whether a gzip body with a concatenated second member was accepted or refused depended only on
 // how the client split its writes: sent in one write the trailing member was silently dropped and
 // the request answered 200, handing the handler less data than was sent; split at the member
@@ -1820,6 +1866,279 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     NSString* allowed = SendRawRequest(server.port, @"DELETE /Ordinary HTTP/1.1\r\nHost: localhost\r\n\r\n");
     XCTAssertFalse([allowed hasPrefix:@"HTTP/1.1 403"], @"a .DS_Store must not make an ordinary folder undeletable: %@", [allowed substringToIndex:MIN((NSUInteger)40, allowed.length)]);
     XCTAssertFalse([fm fileExistsAtPath:ordinary], @"the deletable folder was not removed: %@", allowed);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// The eighth pass closed the recursive DELETE and this file's design priorities then claimed the
+// whole property — "a recursive delete refuses when it would destroy a file a direct delete would
+// have refused". MOVE and COPY destroy just as much through Overwrite, and their two extension
+// checks are both gated behind !srcIsDirectory, so a directory source skipped them entirely and
+// nothing vetted the destination being replaced. Measured before this, with
+// allowedFileExtensions=[txt] and 5/5 reproductions: MOVE and COPY of a directory over "Dst"
+// (holding id_rsa) and over "secret.pem" all answered 204 and destroyed the target — each of
+// which this same server refuses with 403 when addressed directly.
+//
+// The uploader needs no equivalent: -moveItem: routes around a collision with
+// -_uniquePathForPath: and never overwrites, so it has no destructive-overwrite path at all.
+- (void)testDAVOverwriteRespectsExtensionAllowList {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    server.allowedFileExtensions = @[ @"txt" ];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* (^overwrite)(NSString*, NSString*, NSString*) = ^(NSString* method, NSString* source, NSString* destination) {
+        return SendRawRequest(server.port, [NSString stringWithFormat:@"%@ %@ HTTP/1.1\r\nHost: localhost\r\nDestination: %@\r\nOverwrite: T\r\n\r\n", method, source, destination]);
+    };
+
+    NSString* source = [dir stringByAppendingPathComponent:@"Src"];
+    NSString* guarded = [dir stringByAppendingPathComponent:@"Dst"];
+    NSString* key = [guarded stringByAppendingPathComponent:@"id_rsa"];
+    NSString* secret = [dir stringByAppendingPathComponent:@"secret.pem"];
+
+    void (^rebuild)(void) = ^{
+        [fm removeItemAtPath:source error:NULL];
+        [fm removeItemAtPath:guarded error:NULL];
+        [fm removeItemAtPath:secret error:NULL];
+        XCTAssertTrue([fm createDirectoryAtPath:source withIntermediateDirectories:YES attributes:nil error:NULL]);
+        XCTAssertTrue([@"payload" writeToFile:[source stringByAppendingPathComponent:@"ok.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        XCTAssertTrue([fm createDirectoryAtPath:guarded withIntermediateDirectories:YES attributes:nil error:NULL]);
+        XCTAssertTrue([@"KEYDATA" writeToFile:key atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        XCTAssertTrue([@"KEYDATA" writeToFile:secret atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    };
+
+    // The controls: both targets are refused when addressed directly, so the overwrite forms must
+    // be refused too, or one request means two different things.
+    rebuild();
+    XCTAssertTrue([SendRawRequest(server.port, @"DELETE /secret.pem HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 403"], @"a direct delete of a disallowed file should be refused");
+    XCTAssertTrue([SendRawRequest(server.port, @"DELETE /Dst HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 403"], @"a recursive delete of a collection holding a disallowed file should be refused");
+
+    for (NSString* method in @[ @"MOVE", @"COPY" ]) {
+        rebuild();
+        NSString* ontoCollection = overwrite(method, @"/Src", @"/Dst");
+        XCTAssertTrue([ontoCollection hasPrefix:@"HTTP/1.1 403"], @"%@ over a collection holding a disallowed file should be refused: %@", method, [ontoCollection substringToIndex:MIN((NSUInteger)40, ontoCollection.length)]);
+        XCTAssertEqualObjects([NSString stringWithContentsOfFile:key encoding:NSUTF8StringEncoding error:NULL], @"KEYDATA", @"%@ destroyed a file a direct delete refuses", method);
+
+        rebuild();
+        NSString* ontoFile = overwrite(method, @"/Src", @"/secret.pem");
+        XCTAssertTrue([ontoFile hasPrefix:@"HTTP/1.1 403"], @"%@ over a disallowed file should be refused: %@", method, [ontoFile substringToIndex:MIN((NSUInteger)40, ontoFile.length)]);
+        // The path survives a rename-over as a *directory*, so assert the type as well as the
+        // bytes — merely existing does not mean the file is still there.
+        BOOL secretIsDirectory = NO;
+        XCTAssertTrue([fm fileExistsAtPath:secret isDirectory:&secretIsDirectory] && !secretIsDirectory, @"%@ replaced a disallowed file with a directory", method);
+        XCTAssertEqualObjects([NSString stringWithContentsOfFile:secret encoding:NSUTF8StringEncoding error:NULL], @"KEYDATA", @"%@ destroyed a file a direct delete refuses", method);
+    }
+
+    // The same hole with the checks the other way round: a *file* source does run the
+    // destination-name check, but a destination *collection* named "Backup.txt" passes it — and
+    // the collection being destroyed holds a file the allow-list refuses.
+    for (NSString* method in @[ @"MOVE", @"COPY" ]) {
+        rebuild();
+        NSString* backup = [dir stringByAppendingPathComponent:@"Backup.txt"];
+        XCTAssertTrue([fm createDirectoryAtPath:backup withIntermediateDirectories:YES attributes:nil error:NULL]);
+        XCTAssertTrue([@"KEYDATA" writeToFile:[backup stringByAppendingPathComponent:@"id_rsa"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+        NSString* ontoNamedCollection = overwrite(method, @"/Src/ok.txt", @"/Backup.txt");
+        XCTAssertTrue([ontoNamedCollection hasPrefix:@"HTTP/1.1 403"], @"%@ over a collection whose name passes the allow-list should be refused: %@", method, [ontoNamedCollection substringToIndex:MIN((NSUInteger)40, ontoNamedCollection.length)]);
+        XCTAssertEqualObjects([NSString stringWithContentsOfFile:[backup stringByAppendingPathComponent:@"id_rsa"] encoding:NSUTF8StringEncoding error:NULL], @"KEYDATA", @"%@ destroyed a file a direct delete refuses", method);
+        [fm removeItemAtPath:backup error:NULL];
+    }
+
+    // What must keep working. Moving a collection to a fresh name overwrites nothing, and a
+    // destination whose only extra entry is filesystem noise stays replaceable — the same two
+    // judgement calls the recursive DELETE makes, for the same reasons.
+    rebuild();
+    NSString* renamed = overwrite(@"MOVE", @"/Src", @"/Fresh");
+    XCTAssertTrue([renamed hasPrefix:@"HTTP/1.1 201"], @"moving a collection to an unused name stopped working: %@", [renamed substringToIndex:MIN((NSUInteger)40, renamed.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:@"Fresh/ok.txt"]], @"the moved collection did not arrive");
+    [fm removeItemAtPath:[dir stringByAppendingPathComponent:@"Fresh"] error:NULL];
+
+    rebuild();
+    XCTAssertTrue([@"junk" writeToFile:[guarded stringByAppendingPathComponent:@".DS_Store"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([fm removeItemAtPath:key error:NULL]);
+    NSString* ordinary = overwrite(@"MOVE", @"/Src", @"/Dst");
+    XCTAssertFalse([ordinary hasPrefix:@"HTTP/1.1 403"], @"a .DS_Store must not make an ordinary folder unreplaceable: %@", [ordinary substringToIndex:MIN((NSUInteger)40, ordinary.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:[guarded stringByAppendingPathComponent:@"ok.txt"]], @"the permitted overwrite did not happen: %@", ordinary);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// Preconditions were evaluated in exactly one place, -overrideResponse:forRequest:, which runs
+// AFTER the handler has produced its response — so for a write the file was already on disk. It
+// also compares against response.eTag, which a 201/204 does not carry, so _CompareResources
+// returned NO and no 412 was ever produced. If-Match was not parsed anywhere in the tree at all.
+// RFC 9110 §13.1.1 requires the origin NOT to perform the method when If-Match evaluates false;
+// the lost-update protection a WebDAV client believes it has therefore did not exist, and two
+// clients editing one file each silently overwrote the other.
+//
+// Enforced for every DAV verb that destroys or replaces the resource it addresses — PUT, DELETE,
+// MOVE and COPY — rather than only for PUT where it was found, because "closed at one of the
+// sites the rule applies to" is this codebase's most reliable defect shape.
+- (void)testDAVPreconditionsAreEnforcedBeforeTheWrite {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* target = [dir stringByAppendingPathComponent:@"f.txt"];
+    XCTAssertTrue([@"ORIGINAL" writeToFile:target atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    // The tag the client legitimately holds, taken from the server's own GET.
+    NSString* get = SendRawRequest(server.port, @"GET /f.txt HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    // CFHTTPMessage normalizes the field name, so it goes out as "Etag" — match it the way the
+    // wire defines it, case-insensitively, rather than the way the source spells it.
+    NSRange tagStart = [get rangeOfString:@"Etag: " options:NSCaseInsensitiveSearch];
+    XCTAssertNotEqual(tagStart.location, (NSUInteger)NSNotFound, @"the server did not send an ETag: %@", get);
+    NSString* rest = [get substringFromIndex:NSMaxRange(tagStart)];
+    NSString* eTag = [rest substringToIndex:[rest rangeOfString:@"\r\n"].location];
+    XCTAssertTrue(eTag.length > 2, @"unexpected ETag %@", eTag);
+
+    NSString* (^put)(NSString*, NSString*) = ^(NSString* name, NSString* precondition) {
+        NSString* body = @"REPLACEMENT";
+        NSString* head = [NSString stringWithFormat:@"PUT /%@ HTTP/1.1\r\nHost: localhost\r\n%@Content-Length: %lu\r\n\r\n%@", name, precondition, (unsigned long)body.length, body];
+        return SendRawRequest(server.port, head);
+    };
+    NSString* (^contents)(void) = ^{
+        return [NSString stringWithContentsOfFile:target encoding:NSUTF8StringEncoding error:NULL];
+    };
+
+    // A stale If-Match must refuse and must not write.
+    NSString* stale = put(@"f.txt", @"If-Match: \"0/0/0/0\"\r\n");
+    XCTAssertTrue([stale hasPrefix:@"HTTP/1.1 412"], @"a stale If-Match should be refused: %@", [stale substringToIndex:MIN((NSUInteger)40, stale.length)]);
+    XCTAssertEqualObjects(contents(), @"ORIGINAL", @"the write happened despite a failed If-Match");
+
+    // If-None-Match: * means "only if it does not exist".
+    NSString* exists = put(@"f.txt", @"If-None-Match: *\r\n");
+    XCTAssertTrue([exists hasPrefix:@"HTTP/1.1 412"], @"If-None-Match: * against an existing resource should be refused: %@", [exists substringToIndex:MIN((NSUInteger)40, exists.length)]);
+    XCTAssertEqualObjects(contents(), @"ORIGINAL", @"the write happened despite If-None-Match: *");
+
+    // DELETE, MOVE and COPY carry the same guarantee.
+    NSString* deleted = SendRawRequest(server.port, @"DELETE /f.txt HTTP/1.1\r\nHost: localhost\r\nIf-Match: \"0/0/0/0\"\r\n\r\n");
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 412"], @"a stale If-Match should refuse a DELETE: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:target], @"the delete happened despite a failed If-Match");
+
+    NSString* moved = SendRawRequest(server.port, @"MOVE /f.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /moved.txt\r\nIf-Match: \"0/0/0/0\"\r\n\r\n");
+    XCTAssertTrue([moved hasPrefix:@"HTTP/1.1 412"], @"a stale If-Match should refuse a MOVE: %@", [moved substringToIndex:MIN((NSUInteger)40, moved.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:target], @"the move happened despite a failed If-Match");
+
+    // What must keep working: the matching tag, and the absence of any precondition at all.
+    NSString* matching = put(@"f.txt", [NSString stringWithFormat:@"If-Match: %@\r\n", eTag]);
+    XCTAssertTrue([matching hasPrefix:@"HTTP/1.1 204"], @"a matching If-Match should be honoured: %@", [matching substringToIndex:MIN((NSUInteger)40, matching.length)]);
+    XCTAssertEqualObjects(contents(), @"REPLACEMENT", @"a matching If-Match did not write");
+
+    XCTAssertTrue([put(@"fresh.txt", @"If-None-Match: *\r\n") hasPrefix:@"HTTP/1.1 201"], @"If-None-Match: * should allow creating a new resource");
+    XCTAssertTrue([put(@"plain.txt", @"") hasPrefix:@"HTTP/1.1 201"], @"a PUT with no precondition stopped working");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// -prepareForWriting installed the gzip decoder for the exact token "gzip" and had no else
+// branch, so every OTHER content coding left the raw sink in place and the still-ENCODED octets
+// were stored as the entity — with a success status. The file on disk is then not what the
+// client sent and nothing says so, which is the half-succeed outcome the design priorities call
+// the worst one. This project already applies the opposite rule one screen up, in
+// _ParseTransferEncoding: "storing the still-encoded bytes as if they were the body is worse
+// than refusing."
+//
+// "x-gzip" must be ACCEPTED and decoded rather than refused: RFC 9110 §8.4.1 makes it equivalent
+// to "gzip", so refusing it would swap a silent-corruption bug for an interop one.
+- (void)testUnsupportedContentEncodingIsRefusedRatherThanStored {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSData* const plain = [@"THE-REAL-PAYLOAD" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData* const gzipped = GZipCompress(plain);
+    XCTAssertNotNil(gzipped);
+
+    NSString* (^put)(NSString*, NSString*, NSData*) = ^(NSString* name, NSString* encoding, NSData* body) {
+        NSString* head = [NSString stringWithFormat:@"PUT /%@ HTTP/1.1\r\nHost: localhost\r\n%@Content-Length: %lu\r\n\r\n", name, encoding.length ? [NSString stringWithFormat:@"Content-Encoding: %@\r\n", encoding] : @"", (unsigned long)body.length];
+        NSMutableData* request = [[head dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+        [request appendData:body];
+        return SendRawDataRequest(server.port, request);
+    };
+    NSData* (^stored)(NSString*) = ^(NSString* name) {
+        return [NSData dataWithContentsOfFile:[dir stringByAppendingPathComponent:name]];
+    };
+
+    // The codings that ARE supported must keep working, or the refusals below prove nothing.
+    XCTAssertTrue([put(@"plain.txt", nil, plain) hasPrefix:@"HTTP/1.1 201"], @"an unencoded PUT stopped working");
+    XCTAssertEqualObjects(stored(@"plain.txt"), plain, @"an unencoded PUT stored the wrong bytes");
+
+    XCTAssertTrue([put(@"gz.txt", @"gzip", gzipped) hasPrefix:@"HTTP/1.1 201"], @"a gzip PUT stopped working");
+    XCTAssertEqualObjects(stored(@"gz.txt"), plain, @"a gzip PUT did not decode");
+
+    XCTAssertTrue([put(@"xgz.txt", @"x-gzip", gzipped) hasPrefix:@"HTTP/1.1 201"], @"x-gzip is a synonym for gzip and must be accepted");
+    XCTAssertEqualObjects(stored(@"xgz.txt"), plain, @"x-gzip was not decoded");
+
+    // Anything we cannot decode must be refused, and must leave nothing behind.
+    for (NSString* coding in @[ @"deflate", @"br", @"gzip, gzip", @"bogus" ]) {
+        NSString* reply = put(@"bad.txt", coding, plain);
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 415"], @"Content-Encoding: %@ should be refused: %@", coding, [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+        XCTAssertFalse([fm fileExistsAtPath:[dir stringByAppendingPathComponent:@"bad.txt"]], @"Content-Encoding: %@ stored the encoded octets as the entity", coding);
+    }
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// "Overwrite" was compared with -isEqualToString:@"F", so only that exact byte meant "do not
+// overwrite" and EVERY other spelling was taken as permission to destroy the destination —
+// including "f", which RFC 4918 §10.6 makes a conformant spelling (its ABNF is RFC 2616 §2.1,
+// where quoted literals are case-insensitive). Measured before this: "F" gave 412 and preserved
+// the file, while "f", "False", "no", "0" and an empty value all gave 204 and clobbered it. A
+// client that explicitly said "do not overwrite" lost its data and was told it succeeded.
+//
+// The Depth comparison two methods up has the identical shape but fails CLOSED (an unrecognised
+// spelling refuses the request), so it is an interop nuisance rather than data loss; it is
+// case-folded here too, in the same edit, because leaving one of a matched pair is how the next
+// pass finds it.
+- (void)testDAVOverwriteAndDepthAreCaseInsensitive {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* destination = [dir stringByAppendingPathComponent:@"dst.txt"];
+    void (^rebuild)(void) = ^{
+        XCTAssertTrue([@"SOURCE" writeToFile:[dir stringByAppendingPathComponent:@"src.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        XCTAssertTrue([@"ORIGINAL" writeToFile:destination atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    };
+
+    // Both spellings of "do not overwrite" must refuse and leave the destination alone.
+    for (NSString* no in @[ @"F", @"f" ]) {
+        rebuild();
+        NSString* reply = SendRawRequest(server.port, [NSString stringWithFormat:@"COPY /src.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /dst.txt\r\nOverwrite: %@\r\n\r\n", no]);
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 412"], @"Overwrite: %@ should refuse: %@", no, [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+        XCTAssertEqualObjects([NSString stringWithContentsOfFile:destination encoding:NSUTF8StringEncoding error:NULL], @"ORIGINAL", @"Overwrite: %@ clobbered the destination", no);
+    }
+
+    // Both spellings of "overwrite" must still work, or this becomes an over-refusal.
+    for (NSString* yes in @[ @"T", @"t" ]) {
+        rebuild();
+        NSString* reply = SendRawRequest(server.port, [NSString stringWithFormat:@"MOVE /src.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /dst.txt\r\nOverwrite: %@\r\n\r\n", yes]);
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 204"], @"Overwrite: %@ should replace: %@", yes, [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+        XCTAssertEqualObjects([NSString stringWithContentsOfFile:destination encoding:NSUTF8StringEncoding error:NULL], @"SOURCE", @"Overwrite: %@ did not replace the destination", yes);
+    }
+
+    // Depth: the RFC's own spelling with a capital I must be accepted, not refused.
+    rebuild();
+    XCTAssertTrue([fm createDirectoryAtPath:[dir stringByAppendingPathComponent:@"Coll"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+    NSString* deleted = SendRawRequest(server.port, @"DELETE /Coll HTTP/1.1\r\nHost: localhost\r\nDepth: Infinity\r\n\r\n");
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 204"], @"Depth: Infinity should be accepted: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
 
     [server stop];
     [fm removeItemAtPath:dir error:NULL];

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -660,7 +660,17 @@ static NSString *_WithoutRootLabel(NSString *host) {
                                 return;
                             }
 
-                            [self->_request prepareForWriting];
+                            // A content coding we cannot undo has to be refused here, before a
+                            // byte of it is accepted. Preparing the writer is what decides that:
+                            // an unknown coding used to leave the raw sink in place, so the
+                            // still-encoded octets were stored as the entity and answered with a
+                            // success status. Same rule, and same reason, as an unsupported
+                            // Transfer-Encoding.
+                            if (![self->_request prepareForWriting]) {
+                                self->_requestReceived = YES;  // Nothing further is read from this socket
+                                [self _finishProcessingRequest:[WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_UnsupportedMediaType message:@"Unsupported 'Content-Encoding' header: %@", requestHeaders[@"Content-Encoding"]]];
+                                return;
+                            }
 
                             if (self->_request.usesChunkedTransferEncoding || (extraData.length <= self->_request.contentLength)) {
                                 NSString *const expectHeader = requestHeaders[@"Expect"];

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -27,6 +27,8 @@
 
 #import <Foundation/Foundation.h>
 
+#include <sys/stat.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 #ifdef __cplusplus
@@ -195,6 +197,20 @@ NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString 
  *  business, and reporting it as "hidden" here would mislabel an escape attempt.
  */
 BOOL WSKResolvedPathHasHiddenComponent(NSString *path, NSString *directory);
+
+/**
+ *  Returns the strong entity tag this server issues for a file, derived from `stat(2)` fields.
+ *
+ *  There is exactly one of these because a validator only works if every path agrees on it: the
+ *  tag a client is handed by a GET is the tag it presents back in `If-Match`, so a second
+ *  implementation that formatted the same fields differently would make every precondition fail
+ *  and every revalidation miss.
+ *
+ *  Size is part of the tag deliberately — inode and mtime alone do not identify the bytes, since
+ *  a rewrite in place that restores the timestamp keeps both. See `WSKFileResponse` for the
+ *  measurement behind that.
+ */
+NSString *WSKEntityTagForFileInfo(const struct stat *info);
 
 #ifdef __cplusplus
 }

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -631,3 +631,7 @@ BOOL WSKResolvedPathHasHiddenComponent(NSString *path, NSString *directory) {
 
     return NO;
 }
+
+NSString *WSKEntityTagForFileInfo(const struct stat *info) {
+    return [NSString stringWithFormat:@"\"%llu/%lld/%li/%li\"", info->st_ino, (long long)info->st_size, info->st_mtimespec.tv_sec, info->st_mtimespec.tv_nsec];
+}

--- a/Sources/WebServerKit/Core/WSKPrivate.h
+++ b/Sources/WebServerKit/Core/WSKPrivate.h
@@ -291,7 +291,7 @@ extern NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL include
 @property (nonatomic, getter=isVirtualHEAD) BOOL virtualHEAD;
 @property (nonatomic) NSData *localAddressData;
 @property (nonatomic) NSData *remoteAddressData;
-- (void)prepareForWriting;
+- (BOOL)prepareForWriting;
 - (BOOL)performOpen:(NSError **)error;
 - (BOOL)performWriteData:(NSData *)data error:(NSError **)error;
 - (BOOL)performClose:(NSError **)error;

--- a/Sources/WebServerKit/Core/WSKRequest.m
+++ b/Sources/WebServerKit/Core/WSKRequest.m
@@ -356,6 +356,54 @@ static BOOL _ParseTransferEncoding(NSString *header, BOOL *outRejected) {
     return NO;
 }
 
+// Parse a "Content-Encoding" list (RFC 9110 §8.4). Returns NO when the coding cannot be undone,
+// in which case the caller MUST refuse the request.
+//
+// The installer above used to test for the exact token "gzip" and had no else branch, so every
+// other coding silently left the raw sink in place and the still-ENCODED octets were stored as
+// the entity — answered 201/204, with nothing to say the bytes on disk are not the bytes the
+// client sent. That is the same defect _ParseTransferEncoding exists to prevent, and its comment
+// already states the rule: storing the still-encoded bytes as if they were the body is worse
+// than refusing.
+//
+// "x-gzip" is decoded rather than refused: RFC 9110 §8.4.1 makes it equivalent to "gzip", so
+// treating it as unknown would trade a silent-corruption bug for an interop one. More than one
+// coding is refused because only a single gzip member can be undone here.
+static BOOL _ParseContentEncoding(NSString *header, BOOL *outGZip) {
+    *outGZip = NO;
+
+    if (header == nil) {
+        return YES;
+    }
+
+    NSMutableArray<NSString *> *const codings = [[NSMutableArray alloc] init];
+
+    for (NSString *coding in [header componentsSeparatedByString:@","]) {
+        NSString *const token = [[coding stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] lowercaseString];
+
+        if (token.length) {
+            [codings addObject:token];
+        }
+    }
+
+    if (codings.count == 0) {
+        return YES;  // A present but empty value is no coding at all
+    }
+
+    if (codings.count > 1) {
+        return NO;
+    }
+
+    NSString *const coding = codings.firstObject;
+
+    if ([coding isEqualToString:@"gzip"] || [coding isEqualToString:@"x-gzip"]) {
+        *outGZip = YES;
+        return YES;
+    }
+
+    return [coding isEqualToString:@"identity"];
+}
+
 @implementation WSKRequest {
     BOOL _opened;
     NSMutableArray<WSKBodyDecoder *> *_decoders;
@@ -502,14 +550,22 @@ static BOOL _ParseTransferEncoding(NSString *header, BOOL *outRejected) {
     return YES;
 }
 
-- (void)prepareForWriting {
+- (BOOL)prepareForWriting {
     _writer = self;
 
-    if ([WSKNormalizeHeaderValue(self.headers[@"Content-Encoding"]) isEqualToString:@"gzip"]) {
+    BOOL gzip = NO;
+
+    if (!_ParseContentEncoding(self.headers[@"Content-Encoding"], &gzip)) {
+        return NO;
+    }
+
+    if (gzip) {
         WSKGZipDecoder *const decoder = [[WSKGZipDecoder alloc] initWithRequest:self writer:_writer];
         [_decoders addObject:decoder];
         _writer = decoder;
     }
+
+    return YES;
 }
 
 - (BOOL)performOpen:(NSError **)error {

--- a/Sources/WebServerKit/Responses/WSKFileResponse.m
+++ b/Sources/WebServerKit/Responses/WSKFileResponse.m
@@ -205,7 +205,10 @@ static NSString *_EscapeExtValue(NSString *string) {
     // It does not close a replacement of exactly equal length with a restored mtime, and nothing
     // derived from stat(2) can. Changing the format costs every existing client one revalidation
     // miss, once.
-    NSString *const entityTag = [NSString stringWithFormat:@"\"%llu/%lld/%li/%li\"", info.st_ino, (long long)info.st_size, info.st_mtimespec.tv_sec, info.st_mtimespec.tv_nsec];
+    // Formatted by WSKEntityTagForFileInfo so this and the WebDAV precondition check cannot
+    // drift: the tag issued here is the one a client presents back in If-Match, and two
+    // formatters would make every precondition fail.
+    NSString *const entityTag = WSKEntityTagForFileInfo(&info);
 
     // A date validator may only be *issued* once the second it names has closed. While mtime
     // is still inside the current second the file can be written again without the timestamp

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -166,12 +166,137 @@ NS_ASSUME_NONNULL_END
 
 @implementation WSKWebDAVServer (Methods)
 
+// RFC 4918 §1.4 adopts the ABNF of RFC 2616 §2.1, in which a quoted literal is case-insensitive.
+// "T", "F" and "infinity" are all such literals, so "f" and "Infinity" are conformant spellings
+// and must mean what the client meant. Comparing them with -isEqualToString: made the exact byte
+// "F" the ONLY spelling that meant "do not overwrite", and every other one — "f", "False", "no",
+// an empty value — permission to destroy the destination, answered 204. That direction fails
+// OPEN, which is why it mattered; the Depth pair has the identical shape and fails closed.
+static inline BOOL _HeaderTokenIs(NSString *value, NSString *token) {
+    return (value != nil) && ([value caseInsensitiveCompare:token] == NSOrderedSame);
+}
+
+// "*" matches any existing representation. Otherwise the list is compared entry by entry.
+// If-Match requires the STRONG comparison (RFC 9110 §13.1.1), where a "W/" tag can never match;
+// If-None-Match uses the weak one, where the prefix is stripped from both sides. Tags this
+// server issues are always strong, so only the client's side can carry the prefix.
+static BOOL _EntityTagMatchesList(NSString *currentTag, NSString *list, BOOL strong) {
+    NSString *const trimmed = [list stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+    if ([trimmed isEqualToString:@"*"]) {
+        return (currentTag != nil);
+    }
+
+    if (currentTag == nil) {
+        return NO;
+    }
+
+    for (NSString *candidate in [trimmed componentsSeparatedByString:@","]) {
+        NSString *value = [candidate stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+        if ([value hasPrefix:@"W/"]) {
+            if (strong) {
+                continue;
+            }
+
+            value = [value substringFromIndex:2];
+        }
+
+        if ([value isEqualToString:currentTag]) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+// RFC 9110 §13.1.1 requires an origin server NOT to perform the method when If-Match evaluates
+// false. Nothing here did: preconditions were evaluated only in -overrideResponse:forRequest:,
+// which runs AFTER the handler has already written, and compares against a response ETag that a
+// 201/204 does not carry — so no 412 could ever be produced. If-Match was not parsed anywhere in
+// the tree at all. The lost-update protection a WebDAV client believes it has did not exist, so
+// two clients editing one file each silently overwrote the other.
+//
+// Called from every verb that replaces or destroys the resource it addresses — PUT, DELETE, MOVE
+// and COPY — rather than only from PUT where it was found. Evaluated against the resource as it
+// is on disk, before any destructive step, and against the same tag WSKFileResponse issues.
+- (nullable WSKResponse *)_preconditionFailureForRequest:(WSKRequest *)request atPath:(NSString *)absolutePath {
+    NSString *const ifMatch = request.headers[@"If-Match"];
+    NSString *const ifNoneMatch = request.headers[@"If-None-Match"];
+
+    if ((ifMatch == nil) && (ifNoneMatch == nil)) {
+        return nil;
+    }
+
+    struct stat info;
+    BOOL const exists = (stat([absolutePath fileSystemRepresentation], &info) == 0) && ((info.st_mode & S_IFMT) == S_IFREG);
+    NSString *const currentTag = exists ? WSKEntityTagForFileInfo(&info) : nil;
+
+    // If-Match takes precedence; If-None-Match is only consulted in its absence (§13.2.2).
+    if (ifMatch != nil) {
+        if (!_EntityTagMatchesList(currentTag, ifMatch, YES)) {
+            return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"\"If-Match\" precondition failed for \"%@\"", request.path];
+        }
+    } else if (_EntityTagMatchesList(currentTag, ifNoneMatch, NO)) {
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"\"If-None-Match\" precondition failed for \"%@\"", request.path];
+    }
+
+    return nil;
+}
+
 - (BOOL)_checkFileExtension:(NSString *)fileName {
     if (_allowedFileExtensions && ![_allowedFileExtensions containsObject:[[fileName pathExtension] lowercaseString]]) {
         return NO;
     }
 
     return YES;
+}
+
+// Whatever an operation is about to destroy has to be something the client could have destroyed
+// by naming it directly, or one request means two different things. Returns the first item that
+// fails the allow-list — the item itself for a file, or the offending subpath for a collection —
+// and nil when the whole thing may go.
+//
+// Both destructive shapes go through here, because each has been a hole in turn. DELETE of a
+// collection removes its whole subtree, and a folder was a spelling that bypassed the allow-list
+// entirely (measured: with an allow-list of "txt", DELETE /Folder answered 204 and destroyed both
+// "id_rsa" and ".env"). MOVE and COPY destroy exactly as much through Overwrite, and their two
+// extension checks are both gated behind !srcIsDirectory, so a collection source skipped them
+// altogether — and a collection *destination* named "Backup.txt" satisfies the file-source form.
+// Measured before this, 5/5: all four spellings answered 204 and destroyed the target.
+//
+// This mirrors -[WSKWebUploader deleteItem:], deliberately including its two judgement calls.
+// Dot-names and everything under them are skipped whatever -allowHiddenItems says: they are
+// incidental metadata rather than content the allow-list protects, and a ".DS_Store" sits in
+// every macOS folder with an empty pathExtension that is in no allow-list, so vetting them would
+// make ordinary folders permanently undeletable. And an extensionless file ("README") is vetted
+// like any other, because addressing it directly is already refused.
+- (nullable NSString *)_firstUnvettableItemAtPath:(NSString *)absolutePath isDirectory:(BOOL)isDirectory {
+    if (_allowedFileExtensions == nil) {
+        return nil;
+    }
+
+    if (!isDirectory) {
+        NSString *const itemName = [absolutePath lastPathComponent];
+        return [self _checkFileExtension:itemName] ? nil : itemName;
+    }
+
+    NSDirectoryEnumerator<NSString *> *const enumerator = [[NSFileManager defaultManager] enumeratorAtPath:absolutePath];
+
+    for (NSString *subpath in enumerator) {
+        if ([[subpath lastPathComponent] hasPrefix:@"."]) {
+            [enumerator skipDescendants];
+            continue;
+        }
+
+        NSString *const subpathType = [enumerator fileAttributes][NSFileType];
+
+        if ([subpathType isEqualToString:NSFileTypeRegular] && ![self _checkFileExtension:subpath]) {
+            return subpath;
+        }
+    }
+
+    return nil;
 }
 
 // Hidden-item protection has to cover every component of the path, not only the leaf:
@@ -445,6 +570,12 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Uploading to \"%@\" is not allowed", relativePath];
     }
 
+    WSKResponse *const preconditionFailure = [self _preconditionFailureForRequest:request atPath:absolutePath];
+
+    if (preconditionFailure) {
+        return preconditionFailure;
+    }
+
     if (![self shouldUploadFileAtPath:absolutePath withTemporaryFile:request.temporaryPath]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Uploading file to \"%@\" is not permitted", relativePath];
     }
@@ -479,7 +610,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
 - (WSKResponse *)performDELETE:(WSKRequest *)request {
     NSString *const depthHeader = request.headers[@"Depth"];
 
-    if (depthHeader && ![depthHeader isEqualToString:@"infinity"]) {
+    if (depthHeader && !_HeaderTokenIs(depthHeader, @"infinity")) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
     }
 
@@ -508,41 +639,24 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
     }
 
-    NSString *const itemName = [absolutePath lastPathComponent];
-
-    if (isHidden || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    if (isHidden) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed", relativePath];
     }
 
-    // Deleting a collection removes its whole subtree, which must not become a way to destroy
-    // files a direct DELETE would refuse — the extension check above applies only to files, so a
-    // folder was a spelling that bypassed it entirely. Measured before this: with an allow-list
-    // of "txt", DELETE /Folder answered 204 and destroyed both "id_rsa" and ".env", each of
-    // which this same server refuses with 403 when addressed directly.
-    //
-    // This mirrors -[WSKWebUploader deleteItem:], deliberately including its two judgement
-    // calls. Dot-names and everything under them are skipped whatever -allowHiddenItems says:
-    // they are incidental metadata rather than content the allow-list protects, and a
-    // ".DS_Store" sits in every macOS folder with an empty pathExtension that is in no
-    // allow-list, so vetting them would make ordinary folders permanently undeletable. And an
-    // extensionless file ("README") is vetted like any other, because a direct DELETE of it is
-    // already refused and letting the recursive form through would make one request mean two
-    // different things.
-    if (isDirectory && _allowedFileExtensions) {
-        NSDirectoryEnumerator<NSString *> *const enumerator = [[NSFileManager defaultManager] enumeratorAtPath:absolutePath];
+    NSString *const undeletable = [self _firstUnvettableItemAtPath:absolutePath isDirectory:isDirectory];
 
-        for (NSString *subpath in enumerator) {
-            if ([[subpath lastPathComponent] hasPrefix:@"."]) {
-                [enumerator skipDescendants];
-                continue;
-            }
-
-            NSString *const subpathType = [enumerator fileAttributes][NSFileType];
-
-            if ([subpathType isEqualToString:NSFileTypeRegular] && ![self _checkFileExtension:subpath]) {
-                return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed: it contains \"%@\"", relativePath, subpath];
-            }
+    if (undeletable) {
+        if (isDirectory) {
+            return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed: it contains \"%@\"", relativePath, undeletable];
         }
+
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed", relativePath];
+    }
+
+    WSKResponse *const preconditionFailure = [self _preconditionFailureForRequest:request atPath:absolutePath];
+
+    if (preconditionFailure) {
+        return preconditionFailure;
     }
 
     if (![self shouldDeleteItemAtPath:absolutePath]) {
@@ -645,7 +759,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     if (!isMove) {
         NSString *const depthHeader = request.headers[@"Depth"];  // TODO: Support "Depth: 0"
 
-        if (depthHeader && ![depthHeader isEqualToString:@"infinity"]) {
+        if (depthHeader && !_HeaderTokenIs(depthHeader, @"infinity")) {
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
         }
     }
@@ -736,11 +850,32 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"%@ to \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", dstRelativePath];
     }
 
-    NSString *const overwriteHeader = request.headers[@"Overwrite"];
-    BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:dstAbsolutePath];
+    // The precondition names the resource the Request-URI addresses, i.e. the SOURCE.
+    WSKResponse *const preconditionFailure = [self _preconditionFailureForRequest:request atPath:srcAbsolutePath];
 
-    if (existing && ((isMove && ![overwriteHeader isEqualToString:@"T"]) || (!isMove && [overwriteHeader isEqualToString:@"F"]))) {
+    if (preconditionFailure) {
+        return preconditionFailure;
+    }
+
+    NSString *const overwriteHeader = request.headers[@"Overwrite"];
+    BOOL dstIsDirectory = NO;
+    BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:dstAbsolutePath isDirectory:&dstIsDirectory];
+
+    if (existing && ((isMove && !_HeaderTokenIs(overwriteHeader, @"T")) || (!isMove && _HeaderTokenIs(overwriteHeader, @"F")))) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"Destination \"%@\" already exists", dstRelativePath];
+    }
+
+    // An overwrite destroys the destination just as a DELETE would, so it has to clear the same
+    // bar. The two extension checks above cannot stand in for this: both are skipped when the
+    // source is a collection, and the destination form only ever judges a *name*, which says
+    // nothing about what a collection named "Backup.txt" contains. Checked here, before any
+    // filesystem work, so a refusal leaves the destination exactly as it was.
+    if (existing) {
+        NSString *const undeletable = [self _firstUnvettableItemAtPath:dstAbsolutePath isDirectory:dstIsDirectory];
+
+        if (undeletable) {
+            return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"%@ to \"%@\" is not allowed: it would destroy \"%@\"", isMove ? @"Moving" : @"Copying", dstRelativePath, undeletable];
+        }
     }
 
     if (isMove) {

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -1270,6 +1270,15 @@ static NSString *_OriginAuthority(NSString *value) {
     // separators or "..", which -stringByAppendingPathComponent: does NOT resolve,
     // so an unsanitized name lets a move escape the upload directory. Reduce it to
     // a single leaf component and reject the traversal specials.
+    //
+    // "/" is the one input for which -lastPathComponent does not return a leaf: it returns "/"
+    // unchanged (as does "//" and any run of slashes). That name passed every guard below, and
+    // -stringByAppendingPathComponent: then collapsed it straight back to the upload directory,
+    // so -_uniquePathForPath: found that directory already existing and renamed *its own leaf*
+    // in the PARENT — landing the body beside the share as "Share (1)", answered 200. So the
+    // separator is rejected outright afterwards: the requirement is that the name be a single
+    // path component, and testing for that directly is what makes it true, rather than trusting
+    // the reduction to have produced one.
     NSString *const fileName = [file.fileName lastPathComponent];
 
     // The NUL test belongs with the others: this value reaches -stringByAppendingPathComponent:,
@@ -1277,7 +1286,7 @@ static NSString *_OriginAuthority(NSString *value) {
     // one. The same shape that made "/list?path=%00" terminate the process — the query and form
     // fields were guarded then, this one was missed because it arrives through the multipart
     // parser rather than the request arguments.
-    if ((fileName.length == 0) || WSKPathContainsNULByte(fileName) || [fileName isEqualToString:@"."] || [fileName isEqualToString:@".."] ||
+    if ((fileName.length == 0) || [fileName containsString:@"/"] || WSKPathContainsNULByte(fileName) || [fileName isEqualToString:@"."] || [fileName isEqualToString:@".."] ||
         (!_allowHiddenItems && [fileName hasPrefix:@"."]) || ![self _checkFileExtension:fileName]) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Uploaded file name \"%@\" is not allowed", file.fileName];
     }
@@ -1306,6 +1315,20 @@ static NSString *_OriginAuthority(NSString *value) {
     }
 
     NSString *const desiredPath = [resolvedDirectory stringByAppendingPathComponent:fileName];
+
+    // /upload was the only one of the uploader's three write endpoints with no containment check
+    // on the *composed* path — /move, /delete and /create all have one — and that is what let a
+    // leaf of "/" collapse the composition back onto the directory itself. The leaf guard above
+    // closes that spelling; this judges the result, so a future way for the leaf to collapse is
+    // caught without anyone having to think of it first.
+    //
+    // Compared against resolvedDirectory, NOT _uploadDirectory: the latter is stored
+    // -stringByStandardizingPath'd (so a share under NSTemporaryDirectory() stays "/var/..."),
+    // while desiredPath is composed onto a realpath(3) result ("/private/var/..."). Comparing
+    // the two would refuse every legitimate upload for any share under /var or /tmp.
+    if (!WSKPathIsInsideDirectory(desiredPath, resolvedDirectory)) {
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Uploaded file name \"%@\" is not allowed", file.fileName];
+    }
 
     // Resolving a unique name and moving the uploaded file into place must be
     // atomic against concurrent requests, otherwise two uploads of the same


### PR DESCRIPTION
The tenth pass was supposed to **end** the audit programme — the rule agreed beforehand was that a
scan aimed at the recurring defect classes ends it if nothing new turns up. Five findings turned
up, and **three separate agents reached the same WebDAV defect from different directions**, which
is the strongest corroboration any pass here has produced.

Every finding was reproduced independently before being acted on, and each of the five new tests
was run against the unfixed source first and confirmed to fail on the intended assertion.

### What was wrong

| | Defect | Default config? |
|---|---|---|
| 1 | `MOVE`/`COPY` overwrite destroyed files the same server refuses to delete — **two** entry paths | needs `allowedFileExtensions` |
| 2 | `POST /upload` with `filename="/"` wrote **outside the share**, 200 OK | **yes** |
| 3 | `Overwrite: f` read as *permission to destroy* — fails **open** | **yes** |
| 4 | `Depth: Infinity` refused (same shape, fails closed) | interop only |
| 5 | Undecodable `Content-Encoding` stored as the entity, incl. `x-gzip` | **yes** |
| 6 | `If-Match`/`If-None-Match` never enforced — evaluated *after* the write | yes |

**A collection was again a spelling that skipped the allow-list.** The eighth pass closed the
recursive `DELETE`, and the design priorities then claimed the general property. Both extension
checks in `performCOPY:isMove:` are gated behind `!srcIsDirectory`, which opens two doors:

- a **collection source** skips both outright — `MOVE /Src` over a folder holding `id_rsa` → 204, destroyed;
- a **file source** *does* run the destination check, but a collection named `Puck.app` passes it,
  because that check only judges a *name*. `COPY /Puck-1.2.ipa` with `Destination: /Puck.app` needs
  no `Overwrite` header at all and took out `id_rsa`, `embedded.mobileprovision` and `Frameworks/secret`.

Both 5/5, Debug and Release. Now one shared vetting method — a second implementation of a rule
beside the live one is the trap this codebase keeps falling into. Every other destructive site was
checked rather than assumed: `performPUT` refuses an existing collection with 405, and the
uploader uniques around collisions so it has no overwrite path at all.

**`Overwrite: f` destroyed the destination.** Only the exact byte `F` meant "do not overwrite":

| value | before |
|---|---|
| `F` | 412, preserved |
| `f` `False` `no` `0` *(empty)* | **204, clobbered** |

RFC 4918 §1.4 adopts RFC 2616 ABNF, where quoted literals are case-insensitive — so `f` is
*conformant*, and a client that explicitly said "do not overwrite" lost its data and was told it
succeeded. This fails **open**, unlike the identical shape in `Depth: infinity`, which fails
closed; both are case-folded now.

**An upload escaped the share through its filename, in the default configuration.**
`[@"/" lastPathComponent]` is `@"/"` — the one input for which it doesn't yield a leaf — so it
passes every guard, `stringByAppendingPathComponent:` collapses back onto the upload directory,
and `-_uniquePathForPath:` renames *its own leaf in the parent*: `Share (1)`, repeatable and
unbounded.

**Preconditions ran after the write.** `If-Match` was not parsed anywhere in the tree, and the one
place preconditions were evaluated runs *after* the handler, against a `response.eTag` a 201/204
does not carry — so no 412 was reachable. Enforced now for **PUT, DELETE, MOVE and COPY** rather
than only PUT where it was found.

### Two notes worth keeping

**⚠️ The fix originally proposed for #2 would have broken every upload under `/var` or `/tmp`,** and
its own skeptic caught it. `_uploadDirectory` is stored `-stringByStandardizingPath`'d (`/var/…`)
while the composed path comes from `realpath(3)` (`/private/var/…`), so the suggested containment
check is false for every legitimate upload there — and `MakeTempDirectory()` uses exactly that
base, so the suite would have gone red. What shipped compares against the **resolved** directory.
Second time the proposed fix, not the finding, was the dangerous part.

**Deliberately not changed:** a `MOVE` with no `Overwrite` header still answers 412. RFC 4918
§9.9.3 makes an absent header mean `T`, but conforming would make MOVE destructive by default,
against this library's preference for refusing over half-succeeding. Recorded as a deviation
rather than silently changed.

### Verification

Full harness green on an idle machine: **108 tests**, all eight trace suites (including the three
recorded WebDAV client corpora), Release builds for all three platforms. Zero new warnings under
`-Weverything`. No trace sets `allowedFileExtensions` or sends `Content-Encoding`, so the new
refusals are inert for every recorded client.

Class C (resources not returned on failure paths) came back **genuinely clean** on proved
instruments — 67 failure scenarios × 250 iterations at exactly baseline descriptors, a
676,970-request soak ending 33 descriptors *below* baseline, and a ~15 B/request RSS creep chased
down to allocator behaviour rather than waved away. That axis is spent; don't re-run it.

`testConnectionIdleTimeoutSparesSlowHandler` and `testConnectionClosesSlowlorisHeaderDribble`
assert on wall-clock behaviour and fail under heavy parallel load (observed at load average 169);
both pass 3/3 in isolation. Don't take a `Run-Tests.sh` verdict while a fleet is building.
