### PR TITLE
Stop a refused COPY destroying what it never created, and a rewrite mid-body being served as one build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,13 @@ What each shape depends on:
   builds together into an IPA that installs and then crashes. Note also that Puck rewrites
   builds while they may be downloading — `WSKFileResponse` opening once and deriving
   everything from `fstat` on that descriptor is what keeps an in-flight download consistent.
+  **That is true only for an ATOMIC replacement** (`rename(2)`, `ditto`, `mv`), which gives the new
+  content a new inode the held descriptor never sees. A rewrite *in place* — `cp` and `cat >`, both
+  of which open `O_TRUNC` — reuses the inode, so the descriptor starts yielding the new build's
+  bytes mid-body; the eleventh pass measured a 48 MB response of which 49.5 MB of body bytes came
+  from the replacement, under one 200 OK with a matching `Content-Length`. Each chunk is now
+  verified against the size and mtime the response promised. **Publish atomically anyway** — the
+  check refuses the transfer, it cannot make a torn read whole.
 - **Shape B depends on start/stop correctness**, because it happens constantly. Lifecycle
   races a daemon meets once in its life, this meets every time it wakes.
 - **Both depend on refusing clearly rather than half-succeeding.** A request the server cannot
@@ -79,6 +86,96 @@ MagicDNS name (`<node>.<tailnet>.ts.net`). The Host allow-list admits localhost,
 and the Bonjour/`.local` name only, so without it every request is refused with 421.
 
 ## Recent Changes
+
+### Eleventh audit pass: four techniques never used here, and a proposed fix that was worse than the bug
+
+The tenth pass exhausted the technique list, so this one used four lenses the project had never
+applied: **stateful model-based sequence testing**, **concurrent mutating operations**,
+**metamorphic relations on the served bytes**, and **the host-app API surface**. Every one of them
+found something the request-at-a-time lenses could not, which is the argument for changing
+technique rather than repeating a sweep.
+
+**A refused COPY destroyed what another client had just created.** `performCOPY:isMove:` derived a
+staging path *only when the destination already existed*; when it looked absent, `writePath` WAS
+the destination, so the cleanup written for "a failed tree copy leaves a partial tree behind"
+recursively removed whatever occupied that name by the time the copy failed. A `COPY` racing a
+`MKCOL` destroyed **209 of 483** collections the other client had just been told it created (201),
+while the destroying client got 403. Default configuration, no allow-list, no external actor. It
+also defeated the tenth pass's own overwrite vetting, which is gated behind `if (existing)` and so
+never ran on this path. Pre-existing since the fourth pass; measured identically on the parent
+commit.
+
+**⚠️ The proposed fix made it worse, and the suite stayed green through it — fourth time a proposed
+fix has been the dangerous part.** "Stage unconditionally and always swap" moves the destruction
+from the copy-failure cleanup into `-_replaceItemAtPath:`'s `rename` fallback, which is a recursive
+delete — measured at **83/144 destroyed, answered 201 Created** against 25/95 unfixed, i.e. more
+destruction reported as success. The one-line variant (only remove the staging path) closes the
+destruction but strands a partial tree, trading a rare race for a routine residue class. What
+shipped does both: stage unconditionally *and* make the swap **exclusive** (`renamex_np` with
+`RENAME_EXCL`) when nothing was vetted, so an item that appears in the window survives and the
+request refuses. `existing` is unchanged, so a dangling symlink at the destination — which
+`-fileExistsAtPath:` reports as absent because it follows links, and which the old cleanup
+unlinked while answering 403 — now simply makes the swap fail and the link survives.
+
+**The swap removed whatever was at the path, not what had been vetted.** `-_replaceItemAtPath:`
+falls back to `removeItemAtPath:` when `rename(2)` refuses, and `rename(2)` refuses here only when
+the destination has become a directory. `performPUT:` clears the destination at line 561 (405 if it
+is a collection) and then, thirty lines later, destroyed a collection that arrived in between —
+answering **204 No Content**. The swap now carries the `dev`+`ino` the caller vetted and refuses to
+remove anything else. Note the tenth-pass sentence this falsifies: *"Every other destructive site
+was then checked rather than assumed: `performPUT` refuses an existing collection with 405."* True
+at check time, false at swap time — **the seventh time this file has claimed a property the code
+held only partly**, and the sweep that was meant to close the class stopped at the check.
+
+**A build rewritten in place spliced two representations into one 200 OK.** See the corrected
+design-priorities note above. The fix verifies size and mtime **on every chunk, before that chunk
+is handed over** — verifying only at end-of-body, which is what was proposed, detects the change
+*after* the bytes are on the wire under a satisfied `Content-Length`, so the client still receives
+a complete, well-formed, wrong response. That distinction was caught by the regression test failing
+against the first attempt at the fix.
+
+**`+responseWithJSONObject:` killed the process.** It is declared `nullable` and even had a
+`data == nil` guard — but `+[NSJSONSerialization dataWithJSONObject:]` *raises* for an
+unserialisable object rather than returning nil, so the guard was dead code. A host-app handler
+returning `[WSKDataResponse responseWithJSONObject:dict]` with an `NSDate`, `NSURL` or `NAN` in the
+dictionary terminated the process, Debug and Release alike, and `resp ?: fallback` did not help
+because the raise happens first. It asks `+isValidJSONObject:` first now, exactly as
+`-initWithText:` does for a string it cannot encode.
+
+**Still open — one finding, deliberately not taken, and it needs a decision.** `DELETE /latest`
+where `latest -> build-2026-07-30` answers **204** and removes the whole *target directory*, leaving
+the link behind as a dangling entry; `rm latest` behaves the opposite way. MOVE does the same. It
+follows from the eighth pass's resolve-once design handing every verb a `realpath`'d path. It was
+**not** fixed because the obvious fix is dangerous in three separate ways, all measured: it relaxes
+the extension allow-list (a link whose own name is allow-listed but whose target's is not goes from
+403 to 204); it resolves *twice*, which re-opens exactly the two-observations class the eighth pass
+closed and this file names as the general form that will recur; and it is incomplete, because the
+destination side (`MOVE /new.txt` with `Destination: /latest`) is untouched and still replaces the
+whole build directory with a 3-byte file. A green suite is not evidence here — the dangerous
+version passed all 112 tests and the full trace corpus. Source and destination semantics have to be
+decided together, and that is a judgement call about what the library should mean, not a defect fix.
+
+**Verified clean, and worth not re-testing.** The "a refused operation changes nothing" invariant
+held across **22,820 operations in 120 sequences**, firing only on the COPY case above, with the
+checker proved sensitive by injection first. The three listings (DAV `PROPFIND`, uploader `/list`,
+base-path index) never disagreed across 431,151 requests. Range arithmetic is exact across 1,008
+header spellings and ~5,000 generated partitions on files from 0 B to 128 MiB; 40 interrupted-and-
+resumed 128 MiB transfers reassembled byte-perfectly. **Torn writes do not happen** — 240 concurrent
+128 KiB PUTs and 90 concurrent 4 MiB PUTs produced zero mixed files, because the body always lands
+in a temp file first. Atomic replacement under load is genuinely safe (915 `rename(2)` replacements,
+47.7 GB, zero splices — and the oracle is provably sensitive, since the same harness reported 1,584
+splices the moment the writer switched to `O_TRUNC`). All 11 delegate methods arrive on the main
+thread with no null-contract violations, all 21 wrong-typed option values are refused with a named
+diagnostic, and 21 lifecycle sequences (including 8 threads × 60 concurrent start/stop) produced no
+hang or deadlock.
+
+**Known and still open, from the host-app sweep, all low:** creating a server off the main thread
+aborts a Debug build inside `WSKInitializeFunctions` (and `+initialize` is inherited, so warming up
+`WSKWebServer` first does not protect a subclass); `-stop` after a *failed* start aborts a Debug
+build, with no public way to tell that state from a stoppable one; and
+`-startWithOptions:error:` returns NO without setting `*error` when the server is already running.
+Also carried forward and re-confirmed 10/10: `WSKFormatRFC822` before any server exists still
+crashes.
 
 ### Tenth audit pass: the scan that was meant to end the programme, and did not
 

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1968,6 +1968,223 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// CLAUDE.md's design priorities say "Puck rewrites builds while they may be downloading —
+// WSKFileResponse opening once and deriving everything from fstat on that descriptor is what keeps
+// an in-flight download consistent". That is true for a REPLACEMENT and false for a rewrite in
+// place: rename(2) gives the new content a new inode and the held descriptor keeps reading the old
+// bytes, but cp(1) and `cat >` open the destination O_TRUNC and write through the SAME inode, so
+// the descriptor starts yielding the new build's bytes mid-body. Measured before this: one 200 OK,
+// one ETag naming the old build, a Content-Length that matched exactly, and a body that was half
+// one build and half another — undetectable by any client.
+//
+// The byte at offset i is (i & 0x7f) | (rep ? 0x80 : 0), so the low seven bits pin the absolute
+// offset and the top bit names which representation each byte came from.
+- (void)testFileResponseRefusesToSpliceAFileRewrittenInPlace {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    NSString* path = [dir stringByAppendingPathComponent:@"build.bin"];
+    const NSUInteger kSize = 48 * 1024 * 1024;  // Must exceed the socket buffer, or the whole body is sent before the client can stall
+
+    NSMutableData* (^representation)(BOOL) = ^(BOOL second) {
+        NSMutableData* d = [NSMutableData dataWithLength:kSize];
+        uint8_t* b = d.mutableBytes;
+        for (NSUInteger i = 0; i < kSize; i++) {
+            b[i] = (uint8_t)((i & 0x7f) | (second ? 0x80 : 0x00));
+        }
+        return d;
+    };
+
+    XCTAssertTrue([representation(NO) writeToFile:path atomically:YES]);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/f/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    int socket = ConnectToLocalhostPort(server.port);
+    XCTAssertGreaterThan(socket, 0);
+    NSString* request = @"GET /f/build.bin HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    XCTAssertGreaterThan(write(socket, request.UTF8String, strlen(request.UTF8String)), 0);
+
+    // Drain a little, then stall — an ordinary slow client — and rewrite the file IN PLACE,
+    // keeping the inode, exactly as cp(1) does.
+    NSMutableData* received = [NSMutableData data];
+    uint8_t buffer[64 * 1024];
+    while (received.length < 128 * 1024) {
+        ssize_t n = read(socket, buffer, sizeof(buffer));
+        if (n <= 0) {
+            break;
+        }
+        [received appendBytes:buffer length:(NSUInteger)n];
+    }
+    XCTAssertGreaterThan(received.length, (NSUInteger)0, @"the server sent nothing at all");
+
+    usleep(300 * 1000);  // Let the server park with the body unfinished.
+
+    int rewrite = open(path.fileSystemRepresentation, O_WRONLY | O_TRUNC);
+    XCTAssertGreaterThanOrEqual(rewrite, 0, @"could not reopen the file for an in-place rewrite");
+    NSData* second = representation(YES);
+    XCTAssertEqual(write(rewrite, second.bytes, second.length), (ssize_t)second.length);
+    close(rewrite);
+
+    ssize_t n;
+    while ((n = read(socket, buffer, sizeof(buffer))) > 0) {
+        [received appendBytes:buffer length:(NSUInteger)n];
+    }
+    close(socket);
+
+    // Find the body and check every byte came from ONE representation.
+    NSData* marker = [@"\r\n\r\n" dataUsingEncoding:NSASCIIStringEncoding];
+    NSRange headerEnd = [received rangeOfData:marker options:0 range:NSMakeRange(0, received.length)];
+    XCTAssertNotEqual(headerEnd.location, (NSUInteger)NSNotFound, @"no header terminator in the reply");
+
+    const uint8_t* body = (const uint8_t*)received.bytes + NSMaxRange(headerEnd);
+    NSUInteger bodyLength = received.length - NSMaxRange(headerEnd);
+    NSUInteger spliced = 0;
+    for (NSUInteger i = 0; i < bodyLength; i++) {
+        if ((body[i] & 0x80) != 0) {
+            spliced++;
+        }
+    }
+
+    // Either the whole body is the representation that was promised, or the response was cut
+    // short — both are honest. What must never happen is delivering the new build's bytes under
+    // the old build's ETag and Content-Length.
+    XCTAssertEqual(spliced, (NSUInteger)0, @"%lu of %lu body bytes came from the replacement representation — two builds were spliced into one response", (unsigned long)spliced, (unsigned long)bodyLength);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// performCOPY: derived its staging path only when the destination already existed, so when the
+// destination looked absent `writePath` WAS the destination — and the cleanup written for "a
+// failed tree copy leaves a partial tree behind" then recursively removed whatever occupied that
+// name by the time the copy failed, i.e. an item this request never created.
+//
+// The deterministic form: -fileExistsAtPath: FOLLOWS symlinks, so a dangling link at the
+// destination reads as absent while -copyItemAtPath: (which lstats) refuses because the name is
+// taken. The cleanup then unlinked the client's link and the request answered 403 — a refusal
+// that mutates the tree, which the design priorities forbid outright.
+- (void)testDAVCopyOntoADanglingSymlinkRefusesWithoutRemovingIt {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    XCTAssertTrue([@"PAYLOAD" writeToFile:[dir stringByAppendingPathComponent:@"src.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    NSString* link = [dir stringByAppendingPathComponent:@"latest"];
+    XCTAssertTrue([fm createSymbolicLinkAtPath:link withDestinationPath:@"builds/current" error:NULL], @"could not create the dangling link");
+
+    NSString* reply = SendRawRequest(server.port, @"COPY /src.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /latest\r\n\r\n");
+    XCTAssertFalse([reply hasPrefix:@"HTTP/1.1 2"], @"a COPY onto an occupied name should refuse: %@", [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+
+    // The assertion that matters: the refusal left the tree exactly as it was. -fileExistsAtPath:
+    // follows the link and would report NO for a link that is still there, so ask lstat.
+    struct stat info;
+    XCTAssertEqual(lstat(link.fileSystemRepresentation, &info), 0, @"the refused COPY unlinked a pre-existing symlink it was never asked to remove");
+
+    // A COPY onto a genuinely free name must still work, or the assertion above is satisfied by a
+    // server that refuses everything.
+    NSString* ok = SendRawRequest(server.port, @"COPY /src.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /copy.txt\r\n\r\n");
+    XCTAssertTrue([ok hasPrefix:@"HTTP/1.1 201"], @"an ordinary COPY stopped working: %@", [ok substringToIndex:MIN((NSUInteger)40, ok.length)]);
+    XCTAssertEqualObjects([NSString stringWithContentsOfFile:[dir stringByAppendingPathComponent:@"copy.txt"] encoding:NSUTF8StringEncoding error:NULL], @"PAYLOAD");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// The racing form of the same defect: a COPY whose destination is created by someone else between
+// the existence check and the copy destroyed the newcomer and answered 403, while the creating
+// client was told 201. Measured before the fix at 209 of 483 collections destroyed.
+//
+// This asserts a SAFETY property — nothing that was created is ever destroyed — so a machine too
+// slow to produce the interleaving yields a false negative, never a false failure. That matters
+// because two wall-clock-sensitive tests in this suite already fail under parallel load.
+- (void)testDAVCopyRacingACreationNeverDestroysTheWinner {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+    XCTAssertTrue([@"PAYLOAD" writeToFile:[dir stringByAppendingPathComponent:@"src.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    NSUInteger port = server.port;
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    NSUInteger destroyed = 0;
+    NSUInteger created = 0;
+
+    for (NSUInteger round = 0; round < 60; round++) {
+        NSString* name = [NSString stringWithFormat:@"Target-%lu", (unsigned long)round];
+        __block NSString* copyReply = nil;
+        __block NSString* mkcolReply = nil;
+
+        dispatch_group_t group = dispatch_group_create();
+        dispatch_group_async(group, queue, ^{
+            copyReply = SendRawRequest(port, [NSString stringWithFormat:@"COPY /src.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /%@\r\n\r\n", name]);
+        });
+        dispatch_group_async(group, queue, ^{
+            mkcolReply = SendRawRequest(port, [NSString stringWithFormat:@"MKCOL /%@ HTTP/1.1\r\nHost: localhost\r\n\r\n", name]);
+        });
+        dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+
+        // Whichever of the two was told it succeeded must still be there afterwards. Only the
+        // MKCOL is checked, because a 201 from it names a collection nobody asked to remove.
+        if ([mkcolReply hasPrefix:@"HTTP/1.1 201"]) {
+            created++;
+            if (![fm fileExistsAtPath:[dir stringByAppendingPathComponent:name]]) {
+                destroyed++;
+            }
+        }
+    }
+
+    XCTAssertGreaterThan(created, (NSUInteger)0, @"no MKCOL ever succeeded — the probe proved nothing");
+    XCTAssertEqual(destroyed, (NSUInteger)0, @"%lu of %lu collections created with 201 were destroyed by a racing COPY", (unsigned long)destroyed, (unsigned long)created);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// +responseWithJSONObject: is declared `nullable`, and -initWithJSONObject:contentType: even had a
+// `data == nil` guard for the failure — but +[NSJSONSerialization dataWithJSONObject:] RAISES
+// NSInvalidArgumentException for an object that is not JSON-serialisable rather than returning
+// nil, so the guard was dead code and the exception escaped. There is no @try/@catch anywhere in
+// Sources/, so a host-app handler doing the obvious `return [WSKDataResponse responseWithJSONObject:
+// dict]` with an NSDate in the dictionary terminated the process — Debug and Release alike, and
+// `resp ?: fallback` did not save it because the raise happens first.
+//
+// NOTE: against the unfixed source this does not fail, it TERMINATES the test process. Read the
+// executed count.
+- (void)testJSONResponseRefusesAnInvalidObjectInsteadOfRaising {
+    // The shapes a host app actually hits: dates and URLs out of a model object, a NAN from a
+    // division, a non-string key, and raw bytes.
+    NSArray* invalid = @[
+        @{@"created" : [NSDate date]},
+        @{@"url" : [NSURL URLWithString:@"http://example.com"]},
+        @{@"n" : @(NAN)},
+        @{@"n" : @(INFINITY)},
+        @{@42 : @"v"},
+        @{@"data" : [NSData data]},
+        @{@"nested" : @{@"when" : [NSDate date]}},
+    ];
+
+    for (id object in invalid) {
+        XCTAssertNil([WSKDataResponse responseWithJSONObject:object], @"an unserialisable object must return nil, not raise: %@", object);
+    }
+
+    // What must keep working, or the assertions above are satisfied by a method that always fails.
+    WSKDataResponse* valid = [WSKDataResponse responseWithJSONObject:@{@"a" : @1, @"b" : @[ @"x" ]}];
+    XCTAssertNotNil(valid, @"a valid JSON object stopped working");
+    XCTAssertEqualObjects(valid.contentType, @"application/json");
+
+    WSKDataResponse* custom = [WSKDataResponse responseWithJSONObject:@[ @1, @2 ] contentType:@"application/vnd.x+json"];
+    XCTAssertNotNil(custom, @"a valid top-level array stopped working");
+    XCTAssertEqualObjects(custom.contentType, @"application/vnd.x+json");
+}
+
 // Preconditions were evaluated in exactly one place, -overrideResponse:forRequest:, which runs
 // AFTER the handler has produced its response — so for a write the file was already on disk. It
 // also compares against response.eTag, which a 201/204 does not carry, so _CompareResources

--- a/Sources/WebServerKit/Responses/WSKDataResponse.m
+++ b/Sources/WebServerKit/Responses/WSKDataResponse.m
@@ -145,10 +145,22 @@
 }
 
 - (instancetype)initWithJSONObject:(id)object contentType:(NSString *)type {
+    // +dataWithJSONObject: RAISES NSInvalidArgumentException for an object it cannot serialise
+    // rather than returning nil, so the nil check below could never fire and the exception
+    // escaped instead — and nothing in Sources/ catches one, so a host-app handler returning
+    // -responseWithJSONObject: for a dictionary holding an NSDate, an NSURL or a NAN terminated
+    // the process. That factory is declared `nullable`, so a caller writing `resp ?: fallback`
+    // reasonably believes it has handled the failure. Ask first, exactly as -initWithText: does
+    // for a string it cannot encode.
+    if (![NSJSONSerialization isValidJSONObject:object]) {
+        WSK_LOG_ERROR(@"Failed encoding JSON response: not a valid JSON object");
+        return nil;
+    }
+
     NSData *const data = [NSJSONSerialization dataWithJSONObject:object options:0 error:NULL];
 
     if (data == nil) {
-        WSK_DNOT_REACHED();
+        WSK_LOG_ERROR(@"Failed encoding JSON response");
         return nil;
     }
 

--- a/Sources/WebServerKit/Responses/WSKFileResponse.m
+++ b/Sources/WebServerKit/Responses/WSKFileResponse.m
@@ -40,6 +40,10 @@
     NSUInteger _offset;
     NSUInteger _size;
     int _file;
+    // The representation this response promised, captured from the same fstat every header is
+    // derived from, so end-of-body can tell whether the bytes just sent were still that one.
+    off_t _expectedSize;
+    struct timespec _expectedModified;
 }
 
 @dynamic contentType, lastModifiedDate, eTag;
@@ -167,6 +171,9 @@ static NSString *_EscapeExtValue(NSString *string) {
         WSK_LOG_ERROR(@"Refusing to serve \"%@\": not a regular file", path);
         return nil;
     }
+
+    _expectedSize = info.st_size;
+    _expectedModified = info.st_mtimespec;
 
     // Past the type check nothing can block in open(2) anymore, so restore the blocking
     // read semantics the body reader was written against. Failure is not fatal: O_NONBLOCK
@@ -401,16 +408,60 @@ static NSString *_EscapeExtValue(NSString *string) {
     if (result > 0) {
         [data setLength:result];
         _size -= result;
+
+        // Holding one descriptor makes this response immune to the file being REPLACED — rename(2)
+        // gives the new content a new inode and this one keeps reading the old bytes. It does not
+        // make it immune to the file being REWRITTEN IN PLACE: cp(1) and `cat >` open the
+        // destination O_TRUNC and write through the same inode, so a descriptor opened before the
+        // rewrite reads the NEW build's bytes from that point on. A client parked mid-body then
+        // received the tail of one representation spliced onto the prefix of another under a
+        // single 200 OK, one strong ETag naming the old one, and a Content-Length that matched
+        // exactly — nothing in the response for a client to check.
+        //
+        // Checked on EVERY chunk, before that chunk is handed over, which is the whole point:
+        // verifying only at end-of-body detects the change after the spliced bytes are already on
+        // the wire under a Content-Length that has been satisfied, so the client sees a complete,
+        // well-formed, wrong response. Failing here instead means the bytes already sent are all
+        // from the representation that was promised and the transfer then dies visibly. One fstat
+        // per 32 KiB is nothing against the read it accompanies.
+        if (![self _representationStillMatches:error]) {
+            return nil;
+        }
     } else {
-        // result == 0 is a premature EOF (e.g. the file was truncated or replaced
-        // mid-download). Return empty data to end the response rather than a buffer
-        // of zeros with _size never decremented, which would stream 32 KB zero
-        // chunks forever and exceed the declared Content-Length.
-        [data setLength:0];
+        // result == 0 with bytes still owed is a premature EOF: the file was truncated under us.
+        // This used to return empty data and report success, ending the body short of the
+        // Content-Length already promised — a truncated response the client is told is complete.
         _size = 0;
+
+        if (error) {
+            *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:@"File \"%@\" was truncated while it was being served", _path]}];
+        }
+
+        return nil;
     }
 
     return data;
+}
+
+// Compares what the descriptor holds now against the representation whose size, ETag and
+// Last-Modified this response already sent. Size and mtime together are what cp(1) and `cat >`
+// both move; an equal-length rewrite that also restores the timestamp stays undetectable, exactly
+// as it does for the between-request validators, and nothing derived from stat(2) can close that.
+- (BOOL)_representationStillMatches:(NSError **)error {
+    struct stat info;
+
+    if ((fstat(_file, &info) == 0) && (info.st_size == _expectedSize) &&
+        (info.st_mtimespec.tv_sec == _expectedModified.tv_sec) && (info.st_mtimespec.tv_nsec == _expectedModified.tv_nsec)) {
+        return YES;
+    }
+
+    WSK_LOG_ERROR(@"File \"%@\" changed while it was being served", _path);
+
+    if (error) {
+        *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:@"File \"%@\" changed while it was being served", _path]}];
+    }
+
+    return NO;
 }
 
 - (void)close {

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -402,9 +402,44 @@ static NSString *_StagingPathForPath(NSString *path) {
 // that atomically, which -moveItemAtPath: cannot (it refuses an existing destination); it
 // will not replace a *non-empty directory*, so that one case still needs an explicit
 // removal first — safe here, because by then the replacement is already complete on disk.
-- (BOOL)_replaceItemAtPath:(NSString *)path withStagedItemAtPath:(NSString *)stagingPath error:(NSError **)error {
+// `expected` is the identity the caller vetted, or NULL when the caller established that nothing
+// was there. The fallback removal below is recursive and used to run against whatever occupied the
+// path at that instant rather than against the item any check had looked at — so a PUT that
+// -performPUT: had already cleared (405 if the destination is a collection) destroyed a collection
+// that arrived in the ~30 lines between, and answered 204 No Content. Comparing dev+ino makes the
+// removal refuse anything the caller did not authorise.
+- (BOOL)_replaceItemAtPath:(NSString *)path withStagedItemAtPath:(NSString *)stagingPath expecting:(nullable const struct stat *)expected error:(NSError **)error {
+    // With nothing vetted at the destination the swap must not replace anything: an item that
+    // appeared during the window belongs to whoever created it. RENAME_EXCL fails rather than
+    // clobbering, which is what lets the caller refuse and leave the newcomer alone.
+    if (expected == NULL) {
+        if (renamex_np([stagingPath fileSystemRepresentation], [path fileSystemRepresentation], RENAME_EXCL) == 0) {
+            return YES;
+        }
+
+        if (error) {
+            *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:nil];
+        }
+
+        return NO;
+    }
+
     if (rename([stagingPath fileSystemRepresentation], [path fileSystemRepresentation]) == 0) {
         return YES;
+    }
+
+    // rename(2) refuses here only when the destination is a non-empty directory, which means the
+    // path is no longer the item that was vetted — a plain file cannot become one in place. Verify
+    // before destroying anything.
+    struct stat current;
+
+    if ((lstat([path fileSystemRepresentation], &current) != 0) ||
+        (current.st_dev != expected->st_dev) || (current.st_ino != expected->st_ino)) {
+        if (error) {
+            *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ENOTEMPTY userInfo:@{NSLocalizedDescriptionKey: @"The destination changed while the replacement was being built"}];
+        }
+
+        return NO;
     }
 
     if (![[NSFileManager defaultManager] removeItemAtPath:path error:error]) {
@@ -589,11 +624,17 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     NSString *const writePath = stagingPath ? stagingPath : absolutePath;
     NSError *error = nil;
 
+    // The identity the 405 check above cleared, so the swap can refuse to destroy anything else.
+    // Without it a collection created in the window between that check and the swap was removed
+    // recursively by the fallback inside -_replaceItemAtPath:, and the client was told 204.
+    struct stat vetted;
+    BOOL const haveVetted = existing && (lstat([absolutePath fileSystemRepresentation], &vetted) == 0);
+
     if (![fileManager moveItemAtPath:request.temporaryPath toPath:writePath error:&error]) {
         return [WSKErrorResponse responseWithServerError:kWSKHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
     }
 
-    if (stagingPath && ![self _replaceItemAtPath:absolutePath withStagedItemAtPath:stagingPath error:&error]) {
+    if (stagingPath && ![self _replaceItemAtPath:absolutePath withStagedItemAtPath:stagingPath expecting:(haveVetted ? &vetted : NULL) error:&error]) {
         [fileManager removeItemAtPath:stagingPath error:NULL];
         return [WSKErrorResponse responseWithServerError:kWSKHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
     }
@@ -916,8 +957,25 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     // name rather than removing the destination first: copying a tree takes as long as the
     // tree is big, and a failure part way through the old destroy-then-create left the
     // client with neither the old item nor a whole new one.
-    NSString *const stagingPath = existing ? _StagingPathForPath(dstAbsolutePath) : nil;
-    NSString *const writePath = stagingPath ? stagingPath : dstAbsolutePath;
+    // Staged unconditionally, which the `existing ? ... : nil` form was not. When the destination
+    // looked absent, writePath WAS the destination — so the cleanup below, written for "a failed
+    // tree copy leaves a partial tree behind", recursively removed whatever occupied that name by
+    // the time the copy failed. Measured: a COPY racing a MKCOL destroyed 209 of 483 collections
+    // the other client had just created, answering 403 to one and 201 to the other, in the default
+    // configuration. The same line unlinked a pre-existing dangling symlink at the destination,
+    // which -fileExistsAtPath: reports as absent because it follows links.
+    //
+    // Staging always means writePath is never a path this request did not create, so the cleanup
+    // is safe by construction rather than by the caller remembering which branch it is in. The
+    // swap then decides whether replacing is allowed: `expecting` is NULL when nothing was vetted,
+    // which makes it exclusive, so an item that appeared in the window survives and the request
+    // refuses. Simply staging unconditionally WITHOUT that — the fix originally proposed — is
+    // worse than the defect: it moves the destruction into the swap's fallback and answers 201
+    // Created, measured at 83/144 against 25/95 unfixed.
+    struct stat vettedDst;
+    BOOL const haveVettedDst = existing && (lstat([dstAbsolutePath fileSystemRepresentation], &vettedDst) == 0);
+    NSString *const stagingPath = _StagingPathForPath(dstAbsolutePath);
+    NSString *const writePath = stagingPath;
 
     if (isMove) {
         if (![fileManager moveItemAtPath:srcAbsolutePath toPath:writePath error:&error]) {
@@ -930,7 +988,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
         }
     }
 
-    if (stagingPath && ![self _replaceItemAtPath:dstAbsolutePath withStagedItemAtPath:stagingPath error:&error]) {
+    if (![self _replaceItemAtPath:dstAbsolutePath withStagedItemAtPath:stagingPath expecting:(haveVettedDst ? &vettedDst : NULL) error:&error]) {
         // The swap is the only step that can fail with the replacement already built, so
         // unwind it: put a MOVE's source back rather than stranding it under the staging
         // name, and drop a COPY's staged duplicate. Either way the destination is intact.


### PR DESCRIPTION
The tenth pass exhausted the technique list, so the eleventh used four lenses this project had
never applied: **stateful model-based sequence testing**, **concurrent mutating operations**,
**metamorphic relations on the served bytes**, and **the host-app API surface**. Each found
something the request-at-a-time lenses could not — which is the argument for changing technique
rather than repeating a sweep.

Five findings fixed here. Each new test was run against the unfixed source first and confirmed to
fail on the intended assertion.

### A refused COPY destroyed what another client had just created

`performCOPY:isMove:` derived a staging path **only when the destination already existed**. When it
looked absent, `writePath` *was* the destination — so the cleanup written for "a failed tree copy
leaves a partial tree behind" recursively removed whatever occupied that name by the time the copy
failed.

```
COPY racing MKCOL, default config:
  TOTAL: 209/483 MKCOL-created collections vanished
  (MKCOL told 201 Created; COPY told 403 Forbidden)
```

No allow-list, no external actor, no host-app opt-in. It also defeated the tenth pass's overwrite
vetting, which is gated behind `if (existing)` and so never ran on this path. Pre-existing since
the fourth pass — measured identically on the parent commit.

**⚠️ The proposed fix was worse than the bug, and the suite stayed green through it.** "Stage
unconditionally and always swap" moves the destruction into `-_replaceItemAtPath:`'s `rename`
fallback, which is a recursive delete: **83/144 destroyed, answered `201 Created`**, against 25/95
unfixed. The one-line variant (remove only the staging path) closes the destruction but strands a
partial tree, trading a rare race for a routine residue class.

What ships does both: stage unconditionally **and** make the swap exclusive (`renamex_np` +
`RENAME_EXCL`) when nothing was vetted, so an item appearing in the window survives and the request
refuses. Fourth time a proposed fix has been the dangerous part here.

### The swap removed whatever was at the path, not what was vetted

`rename(2)` refuses only when the destination has become a directory, and the fallback then deleted
it recursively. `performPUT:` clears the destination (405 if it is a collection) and thirty lines
later destroyed a collection that arrived in between — answering **204 No Content**. The swap now
carries the `dev`+`ino` the caller vetted.

This falsifies a tenth-pass sentence: *"`performPUT` refuses an existing collection with 405."* True
at check time, false at swap time — the **seventh** time the record has claimed a property the code
held only partly.

### A build rewritten in place was spliced into one 200 OK

Holding one descriptor makes a response immune to *replacement* (`rename` gives a new inode). It
does **not** make it immune to a rewrite **in place** — `cp` and `cat >` open `O_TRUNC` and reuse
the inode. A client parked mid-body received **49,512,448 bytes from the replacement build**, under
one 200 OK, one ETag naming the old build, and a `Content-Length` that matched exactly.

Each chunk is now verified against the size and mtime the response promised, **before that chunk is
handed over**. Verifying only at end-of-body — as proposed — detects the change *after* the bytes
are on the wire under a satisfied `Content-Length`, so the client still gets a complete, well-formed,
wrong response. The regression test caught that by failing against the first attempt at the fix.

The design-priorities note claiming this was already handled is corrected in the same commit.
**Publish atomically anyway** — this refuses the transfer, it cannot make a torn read whole.

### `+responseWithJSONObject:` killed the process

Declared `nullable`, with a `data == nil` guard that was dead code: `dataWithJSONObject:` *raises*
rather than returning nil. A handler returning it for a dictionary holding an `NSDate`, `NSURL` or
`NAN` terminated the process, Debug and Release alike — and `resp ?: fallback` did not help, because
the raise happens first. It asks `+isValidJSONObject:` first now.

### Deliberately NOT fixed — needs a decision

`DELETE /latest` where `latest -> build-2026-07-30` answers **204**, removes the whole *target
directory*, and leaves the link behind dangling. `rm latest` does the opposite. MOVE matches.

I did not fix it because the obvious fix is dangerous three ways, all measured: it **relaxes the
extension allow-list** (403 → 204 for a link whose name is allow-listed but whose target's is not);
it **resolves twice**, re-opening the two-observations class the eighth pass closed and that
CLAUDE.md names as the form that will recur; and it is **incomplete**, since `MOVE /new.txt` with
`Destination: /latest` still replaces the build directory with a 3-byte file. The dangerous version
passes all 112 tests and the full trace corpus — a green suite is not evidence here. Source and
destination semantics need deciding together, and that is a judgement about what the library should
mean.

### Verified clean (worth not re-testing)

- "A refused operation changes nothing" held across **22,820 operations / 120 sequences**, firing
  only on the COPY case above. Checker proved sensitive by injection first.
- The three listings never disagreed across **431,151 requests**.
- **Torn writes do not happen**: 240 concurrent 128 KiB PUTs and 90 concurrent 4 MiB PUTs, zero
  mixed files.
- Atomic replacement under load is safe: 915 `rename(2)` replacements, 47.7 GB, zero splices — and
  the oracle is provably sensitive (1,584 splices the moment the writer switched to `O_TRUNC`).
- Range arithmetic exact across 1,008 spellings and ~5,000 partitions; 40 interrupted-and-resumed
  128 MiB transfers reassembled byte-perfectly.
- All 11 delegate methods on the main thread, no null-contract violations; 21 wrong-typed option
  values refused with named diagnostics; 21 lifecycle sequences with no hang or deadlock.

### Verification

**112 tests, 0 failures**, all eight trace suites, Release builds for all three platforms, exit 0.
