### PR TITLE
Refuse a removal that can only half-succeed, and stop two surfaces issuing a validator that identifies nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,84 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Twelfth audit pass: the harness reported CLEAN when its verifiers had died
+
+Four more never-used techniques: **filesystem fault injection on real disk images** (ENOSPC,
+read-only, case-sensitive, FAT32/FAT16/exFAT, force-eject), **clock and locale manipulation**
+(80,384 format/parse round-trips across 6 timezones and 10 non-Gregorian calendars, without ever
+touching the system clock), **platform-conditional iOS/tvOS code** — never compiled by any previous
+pass — and **declared-contract conformance**, sweeping every nullability annotation and prose
+promise in the public headers.
+
+**⚠️ The run first answered `CLEAN — nothing new found`, and that was an artefact.** All five
+skeptics died on transient API errors, so the verdict array was empty and `confirmed.length === 0`
+evaluated to "clean". The sweeps had found fourteen things. **A workflow that infers "clean" from an
+empty array cannot tell *nothing found* from *nothing checked*** — the same shape as the CI run that
+reported success for a pre-rebase SHA, and the probe that reported the previous build. Resuming the
+run (sweeps replayed from cache, only the skeptics re-ran) produced the real answer: five confirmed.
+
+**A recursive removal that half-succeeded was reported as a total failure.**
+`-[NSFileManager removeItemAtPath:]` deletes as it walks and stops at the first member it cannot
+unlink, keeping everything it already destroyed. One `chflags uchg` file — what Finder's "Locked"
+checkbox sets — or one unwritable subdirectory turned `DELETE /Folder` into **21 files in, 9 left,
+status 500**. Through an overwrite it was worse: `403`, destination gutted from 7 files to 1, *and*
+the source left in place, so the client has a failed move and a wrecked destination. Default
+configuration, both servers. `WSKFirstUnremovableItemAtPath()` now asks before anything is touched.
+
+**⚠️ The proposed fix for it was a no-op — fifth time a proposed fix has been the dangerous part.**
+It said to add the check inside `-_firstUnvettableItemAtPath:isDirectory:`, whose first line returns
+`nil` when `allowedFileExtensions` is unset — the default, and where every single reproduction lives.
+It would have shipped a change that did nothing behind a green suite that proved nothing. The
+removability walk has to be unconditional, and is.
+
+**`If-Unmodified-Since` was not read anywhere in the tree.** `grep -rn Unmodified Sources/` returned
+zero. So a client that said "only if it has not changed since <date>" against a file newer than that
+date had it destroyed and was told the method succeeded — the date-form twin of the `If-Match` gap
+the tenth pass closed, at the spelling a date-only client uses. Now evaluated for PUT, DELETE, MOVE
+and COPY in RFC 9110 §13.2.2 order. **Note the cap this leaves:** `WSKParseRFC822` reads only the
+RFC 1123 form, so the RFC 850 and asctime spellings §5.6.7 also requires a server to accept parse to
+nil and the method proceeds. Shared with `If-Modified-Since` and `If-Range` rather than introduced
+here — so this closes the common spelling, **not the class**.
+
+**PROPFIND published the validator the GET path refuses to issue**, and FAT's timestamp bucket is
+two seconds, not one. See the corrected seventh-pass note above.
+
+**The FAT threshold is a deliberate trade-off, and it is the fail-closed one.**
+`WSKLastModifiedDateIsSealed` asks `fstatfs` and allows one second only for `apfs`, `hfs` and
+`exfat` (measured at ns, 1s and 10ms); **everything else, including `smbfs`, `nfs` and an
+`fstatfs` failure, is assumed two-second**. A FAT volume reached over SMB reports `smbfs` and cannot
+be probed from here, and being wrong in that direction splices two builds while being wrong the
+other way costs a date-only client one second of caching. The blunt alternative — two seconds
+everywhere — closes the same class and costs that second on every volume; flipping to it is a
+one-line change if the caching matters more than the SMB case.
+
+**Still open from this pass, deliberately.** `Range: bytes=999999999-` kills a host app that reads
+the three properties `WSKFileResponse.h` redeclares non-null: the 416 path returns before setting
+them. Not fixed because the skeptic measured the proposed fix as unsafe and it is not reachable in a
+default configuration — it needs a handler written the way the header documents. Also open and low:
+`+responseWithFile:` is `nullable` but raises for an empty or NUL-bearing path (the same shape the
+eleventh pass fixed in `+responseWithJSONObject:`, at a site that fix did not reach);
+`WSKRequest`'s non-null address properties are nil on the request a `WSKMatchBlock` builds, so
+reading `remoteAddressString` there SEGVs; `addGETHandlerForBasePath:` enforces its undocumented
+trailing-slash precondition by aborting with no diagnostic in Debug and registering nothing in
+Release; ENOSPC and EROFS answer 500/403 rather than 507; six non-null properties on the uploader
+and DAV server return nil, three of them documented as defaulting to nil; the `Server` header
+default and the base-path no-match status are both documented wrongly; and a foreground restart
+failure on iOS/tvOS is silent.
+
+**Verified clean, quantitatively.** ENOSPC and EROFS across 14 verbs on a genuinely full volume left
+no staging residue and no half-files. A case-**sensitive** volume did not weaken containment,
+hiddenness or the allow-list across 26 probes. 80,384 date round-trips held across every timezone
+and calendar tried, including Buddhist, Islamic, Japanese, Persian and Hebrew — the formatters' pinned
+`en_US`/GMT is doing its job. A volume force-ejected mid-transfer produced no crash. iOS and tvOS
+Debug and Release all build.
+
+**An orchestration hazard worth remembering: `git stash` is repo-wide, not per-worktree.** One
+skeptic stashed its fix to build a comparison and a *different* agent's worktree popped it; a second
+skeptic found the fix it was meant to evaluate already applied when it started, and had to revert and
+rebuild or it would have measured the fix against itself. Never stash while a fleet is live — copy
+the files aside instead.
+
 ### Eleventh audit pass: four techniques never used here, and a proposed fix that was worse than the bug
 
 The tenth pass exhausted the technique list, so this one used four lenses the project had never
@@ -515,7 +593,14 @@ is not. Two builds written inside one wall-clock second still spliced under a 20
 
 It belongs where the validator is **minted**: a `Last-Modified` is now simply not issued while
 mtime is inside the current second, so every date a client can present was sealed before it was
-handed out and does identify one representation. The ETag carries `tv_nsec` and was never
+handed out and does identify one representation. **⚠️ Correction (twelfth pass): "every date a
+client can present" was false for two reasons.** WebDAV `PROPFIND` emitted `<D:getlastmodified>`
+with no seal test at all, and since it emits no `getetag` that unsealed date was the *only*
+validator a PROPFIND-driven client could obtain — 12/12 splices. And the one-second threshold is
+wrong on FAT, which stores mtime in **two-second** buckets and truncates downward, so a timestamp
+one second old there can still take another write; 12/12 splices and 12/12 stale 304s on a real
+FAT32 image. Both surfaces now share `WSKLastModifiedDateIsSealed`, which asks the descriptor's
+filesystem for its granularity. The ETag carries `tv_nsec` and was never
 affected — which is why the ETag control restarted correctly 4/4 while the date form spliced,
 the observation that ruled out a harness artefact. Costs a date-only client one second of
 caching; a future mtime is unsealed by the same test, which also stops the server advertising a

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1968,6 +1968,157 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// The date form of the lost-update guarantee. If-Match was fixed in the tenth pass;
+// If-Unmodified-Since was not parsed ANYWHERE in the tree, so a client that explicitly said
+// "only if it has not changed since <date the file is newer than>" had its resource destroyed and
+// was told the method succeeded.
+- (void)testDAVIfUnmodifiedSinceIsEnforcedBeforeTheWrite {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* target = [dir stringByAppendingPathComponent:@"f.txt"];
+    NSString* stale = @"If-Unmodified-Since: Thu, 01 Jan 1970 00:00:00 GMT\r\n";
+    void (^rebuild)(void) = ^{
+        XCTAssertTrue([@"ORIGINAL" writeToFile:target atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    };
+    NSString* (^contents)(void) = ^{
+        return [NSString stringWithContentsOfFile:target encoding:NSUTF8StringEncoding error:NULL];
+    };
+
+    rebuild();
+    NSString* put = SendRawRequest(server.port, [NSString stringWithFormat:@"PUT /f.txt HTTP/1.1\r\nHost: localhost\r\n%@Content-Length: 3\r\n\r\nNEW", stale]);
+    XCTAssertTrue([put hasPrefix:@"HTTP/1.1 412"], @"a stale If-Unmodified-Since should refuse a PUT: %@", [put substringToIndex:MIN((NSUInteger)40, put.length)]);
+    XCTAssertEqualObjects(contents(), @"ORIGINAL", @"the PUT happened despite a failed If-Unmodified-Since");
+
+    rebuild();
+    NSString* deleted = SendRawRequest(server.port, [NSString stringWithFormat:@"DELETE /f.txt HTTP/1.1\r\nHost: localhost\r\n%@\r\n", stale]);
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 412"], @"a stale If-Unmodified-Since should refuse a DELETE: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:target], @"the DELETE happened despite a failed If-Unmodified-Since");
+
+    rebuild();
+    NSString* moved = SendRawRequest(server.port, [NSString stringWithFormat:@"MOVE /f.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /moved.txt\r\n%@\r\n", stale]);
+    XCTAssertTrue([moved hasPrefix:@"HTTP/1.1 412"], @"a stale If-Unmodified-Since should refuse a MOVE: %@", [moved substringToIndex:MIN((NSUInteger)40, moved.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:target], @"the MOVE happened despite a failed If-Unmodified-Since");
+
+    // What must keep working: a date the file is NOT newer than, and no precondition at all.
+    rebuild();
+    NSString* future = @"If-Unmodified-Since: Sat, 01 Jan 2050 00:00:00 GMT\r\n";
+    NSString* allowed = SendRawRequest(server.port, [NSString stringWithFormat:@"PUT /f.txt HTTP/1.1\r\nHost: localhost\r\n%@Content-Length: 3\r\n\r\nNEW", future]);
+    XCTAssertTrue([allowed hasPrefix:@"HTTP/1.1 204"], @"a satisfied If-Unmodified-Since should be honoured: %@", [allowed substringToIndex:MIN((NSUInteger)40, allowed.length)]);
+    XCTAssertEqualObjects(contents(), @"NEW", @"a satisfied If-Unmodified-Since did not write");
+
+    rebuild();
+    XCTAssertTrue([SendRawRequest(server.port, @"PUT /plain.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 3\r\n\r\nNEW") hasPrefix:@"HTTP/1.1 201"], @"a PUT with no precondition stopped working");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// A recursive removal stops at the first member it cannot unlink and keeps everything it already
+// destroyed, reporting only a failure — so a collection holding one locked file (chflags uchg,
+// which is what Finder's "Locked" checkbox sets) answered 500 with most of its contents gone. On
+// the overwrite surface it was worse: a failed MOVE that also gutted the destination.
+- (void)testDestructiveVerbsRefuseATreeTheyCannotFullyRemove {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* dav = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([dav startWithOptions:options error:NULL]);
+    WSKWebUploader* uploader = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    XCTAssertTrue([uploader startWithOptions:options error:NULL]);
+
+    NSString* folder = [dir stringByAppendingPathComponent:@"Folder"];
+    NSString* locked = [folder stringByAppendingPathComponent:@"locked.txt"];
+    NSUInteger (^countFiles)(void) = ^{
+        return (NSUInteger)[[fm subpathsOfDirectoryAtPath:folder error:NULL] count];
+    };
+    void (^rebuild)(void) = ^{
+        chflags(locked.fileSystemRepresentation, 0);
+        [fm removeItemAtPath:folder error:NULL];
+        XCTAssertTrue([fm createDirectoryAtPath:folder withIntermediateDirectories:YES attributes:nil error:NULL]);
+        for (NSUInteger i = 0; i < 4; i++) {
+            NSString* name = [NSString stringWithFormat:@"f%lu.txt", (unsigned long)i];
+            NSString* member = [folder stringByAppendingPathComponent:name];
+            XCTAssertTrue([@"data" writeToFile:member atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        }
+        XCTAssertTrue([@"data" writeToFile:locked atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        XCTAssertEqual(chflags(locked.fileSystemRepresentation, UF_IMMUTABLE), 0, @"could not lock the member");
+    };
+
+    rebuild();
+    NSUInteger const before = countFiles();
+    XCTAssertEqual(before, (NSUInteger)5);
+
+    NSString* davReply = SendRawRequest(dav.port, @"DELETE /Folder HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([davReply hasPrefix:@"HTTP/1.1 403"], @"DAV DELETE of a partly-removable tree should refuse: %@", [davReply substringToIndex:MIN((NSUInteger)40, davReply.length)]);
+    XCTAssertEqual(countFiles(), before, @"DAV DELETE destroyed part of a tree it could not fully remove");
+
+    rebuild();
+    NSString* uploaderHost = [NSString stringWithFormat:@"localhost:%lu", (unsigned long)uploader.port];
+    NSString* body = @"path=/Folder";
+    NSString* uploaderReply = SendRawRequest(uploader.port, [NSString stringWithFormat:@"POST /delete HTTP/1.1\r\nHost: %@\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: %lu\r\n\r\n%@", uploaderHost, (unsigned long)body.length, body]);
+    XCTAssertTrue([uploaderReply containsString:@"403"], @"uploader /delete of a partly-removable tree should refuse: %@", uploaderReply);
+    XCTAssertEqual(countFiles(), before, @"uploader /delete destroyed part of a tree it could not fully remove");
+
+    rebuild();
+    XCTAssertTrue([@"src" writeToFile:[dir stringByAppendingPathComponent:@"src.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    NSString* overwrite = SendRawRequest(dav.port, @"MOVE /src.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /Folder\r\nOverwrite: T\r\n\r\n");
+    XCTAssertTrue([overwrite hasPrefix:@"HTTP/1.1 403"], @"an overwrite of a partly-removable destination should refuse: %@", [overwrite substringToIndex:MIN((NSUInteger)40, overwrite.length)]);
+    XCTAssertEqual(countFiles(), before, @"the overwrite gutted a destination it could not fully remove");
+    XCTAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:@"src.txt"]], @"the source vanished too");
+
+    // A fully removable tree must still be removable, or this is just an over-refusal.
+    rebuild();
+    XCTAssertEqual(chflags(locked.fileSystemRepresentation, 0), 0);
+    NSString* ok = SendRawRequest(dav.port, @"DELETE /Folder HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([ok hasPrefix:@"HTTP/1.1 204"], @"an ordinary recursive delete stopped working: %@", [ok substringToIndex:MIN((NSUInteger)40, ok.length)]);
+    XCTAssertFalse([fm fileExistsAtPath:folder], @"the deletable folder was not removed");
+
+    [dav stop];
+    [uploader stop];
+    chflags(locked.fileSystemRepresentation, 0);
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// WSKFileResponse withholds Last-Modified while mtime is still inside its own timestamp bucket, so
+// no client is ever handed a date that cannot identify one representation. PROPFIND applied no such
+// test and published exactly that date — and it emits no getetag, so the unsealed date was the ONLY
+// validator a PROPFIND-driven client could obtain. A later If-Range resume with it spliced two
+// builds under one 206.
+- (void)testDAVPropfindWithholdsAnUnsealedLastModified {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* propfind = @"PROPFIND /fresh.txt HTTP/1.1\r\nHost: localhost\r\nDepth: 0\r\n\r\n";
+
+    // Written and asked for in the same instant: the GET path would withhold the date here, so
+    // PROPFIND must too, or the two surfaces disagree about what may be issued.
+    XCTAssertTrue([@"BUILD-A" writeToFile:[dir stringByAppendingPathComponent:@"fresh.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    NSString* unsealed = SendRawRequest(server.port, propfind);
+    XCTAssertTrue([unsealed hasPrefix:@"HTTP/1.1 207"], @"PROPFIND stopped working: %@", [unsealed substringToIndex:MIN((NSUInteger)40, unsealed.length)]);
+    XCTAssertFalse([unsealed containsString:@"getlastmodified"], @"PROPFIND published a Last-Modified the GET path withholds");
+    // The rest of the property set must be unaffected.
+    XCTAssertTrue([unsealed containsString:@"getcontentlength"], @"PROPFIND dropped more than the date");
+
+    // Once the bucket has closed the date must be published again, or this is a permanent
+    // regression rather than a one-second delay. Two seconds, because FAT's bucket is two.
+    [NSThread sleepForTimeInterval:2.2];
+    NSString* sealed = SendRawRequest(server.port, propfind);
+    XCTAssertTrue([sealed containsString:@"getlastmodified"], @"PROPFIND never publishes a Last-Modified at all: %@", sealed);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 // CLAUDE.md's design priorities say "Puck rewrites builds while they may be downloading —
 // WSKFileResponse opening once and deriving everything from fstat on that descriptor is what keeps
 // an in-flight download consistent". That is true for a REPLACEMENT and false for a rewrite in

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -212,6 +212,57 @@ BOOL WSKResolvedPathHasHiddenComponent(NSString *path, NSString *directory);
  */
 NSString *WSKEntityTagForFileInfo(const struct stat *info);
 
+/**
+ *  Returns YES if the modification time in `info` may be ISSUED as a `Last-Modified` validator for
+ *  the file open on `descriptor`.
+ *
+ *  A date validator is only strong once the instant it names can no longer be written again. While
+ *  mtime still falls inside the filesystem's current timestamp bucket the file can be rewritten
+ *  without the timestamp moving, so two representations would go out under one date and nothing
+ *  downstream could separate them. The rule therefore has to be applied where the validator is
+ *  MINTED, never where a resume redeems it — by redemption time the bucket has always closed, so
+ *  the test would report "strong" for precisely the representation that is not.
+ *
+ *  The bucket is not always one second. APFS records nanoseconds, HFS+ and exFAT a second or
+ *  better, but **FAT/msdos stores mtime in TWO-second units and truncates downward**, so on a USB
+ *  stick or SD card a timestamp one second old can still take another write. `descriptor` is asked
+ *  what it is actually sitting on; anything unrecognised — including `smbfs` and `nfs`, which may
+ *  be backed by FAT — is assumed coarse, because failing closed here costs a date-only client one
+ *  second of caching and failing open splices two builds together.
+ *
+ *  Both surfaces that hand out a modification date share this, so they cannot drift: withholding
+ *  it in one while the other publishes it is how a client obtained an unsealed date from PROPFIND
+ *  after the GET path had been fixed to refuse to issue one.
+ */
+BOOL WSKLastModifiedDateIsSealed(int descriptor, const struct stat *info);
+
+/**
+ *  Returns the first item at or under `absolutePath` that could not be removed, expressed relative
+ *  to `absolutePath` (or `absolutePath`'s own last component if it is the blocker), or nil when the
+ *  whole tree can go.
+ *
+ *  `-[NSFileManager removeItemAtPath:]` walks a tree deleting as it goes and stops at the first
+ *  member it cannot unlink — leaving everything it already removed removed, and reporting only a
+ *  failure. So a collection holding one locked file (`chflags uchg`, which is exactly what Finder's
+ *  "Locked" checkbox sets) or one unwritable subdirectory answered 500, or 403 through an overwrite,
+ *  with most of its contents destroyed. Measured: 21 files in, 9 left, status 500, and on the
+ *  MOVE/COPY surface the source was left in place too — a failed operation AND a gutted destination.
+ *
+ *  Asking first turns that into an untouched tree and a refusal that names the offending item, which
+ *  is what this library's "refuse clearly rather than half-succeed" priority requires. RFC 4918
+ *  §9.6.1's 207 Multi-Status is the conformant alternative and is strictly worse here: it reports
+ *  the damage rather than preventing it.
+ *
+ *  This cannot be folded into the extension-allow-list walk, tempting as that is: that walk returns
+ *  immediately when no allow-list is configured, which is the default and where all of this is
+ *  reachable. Removability has to be checked unconditionally.
+ *
+ *  Inherently advisory: flags and modes can change between this walk and the removal. Nothing in
+ *  this library changes either, so that window needs a local process, and closing it would need a
+ *  transactional filesystem.
+ */
+NSString *_Nullable WSKFirstUnremovableItemAtPath(NSString *absolutePath);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -36,6 +36,8 @@
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <CommonCrypto/CommonDigest.h>
 #import <ifaddrs.h>
+#import <sys/mount.h>
+#import <sys/param.h>
 #import <os/lock.h>
 #import <net/if.h>
 #import <netdb.h>
@@ -634,4 +636,68 @@ BOOL WSKResolvedPathHasHiddenComponent(NSString *path, NSString *directory) {
 
 NSString *WSKEntityTagForFileInfo(const struct stat *info) {
     return [NSString stringWithFormat:@"\"%llu/%lld/%li/%li\"", info->st_ino, (long long)info->st_size, info->st_mtimespec.tv_sec, info->st_mtimespec.tv_nsec];
+}
+
+// FAT truncates mtime into two-second buckets, so a timestamp one second old there can still take
+// another write without moving. Measured: msdos/FAT16/FAT32 2s, exFAT 10ms, HFS+ 1s, APFS ns.
+// Unrecognised types fail CLOSED at two seconds — smbfs and nfs can be backed by FAT and cannot be
+// probed from here, and the cost of being wrong in that direction is one extra second of caching
+// rather than a spliced representation.
+static time_t _ModificationTimeGranularity(int descriptor) {
+    struct statfs info;
+
+    if (fstatfs(descriptor, &info) != 0) {
+        return 2;
+    }
+
+    if ((strcmp(info.f_fstypename, "apfs") == 0) || (strcmp(info.f_fstypename, "hfs") == 0) ||
+        (strcmp(info.f_fstypename, "exfat") == 0)) {
+        return 1;
+    }
+
+    return 2;
+}
+
+BOOL WSKLastModifiedDateIsSealed(int descriptor, const struct stat *info) {
+    // A future mtime — clock skew, or an archive restored with tomorrow's timestamp — is unsealed
+    // by the same comparison, which is the safe direction and also stops the server advertising a
+    // Last-Modified newer than its own Date header.
+    return (time(NULL) - info->st_mtimespec.tv_sec) >= _ModificationTimeGranularity(descriptor);
+}
+
+// Immutable or append-only defeats unlink(2) whatever the permissions say; an unreadable directory
+// cannot be walked and an unwritable one cannot have its children removed. Checked with lstat so a
+// symlink is judged as the entry it is — removing one never touches its target.
+static BOOL _ItemIsRemovable(NSString *path) {
+    struct stat info;
+
+    if (lstat([path fileSystemRepresentation], &info) != 0) {
+        return YES;  // Gone already, or unstattable; the removal will agree either way.
+    }
+
+    if (info.st_flags & (UF_IMMUTABLE | SF_IMMUTABLE | UF_APPEND | SF_APPEND)) {
+        return NO;
+    }
+
+    if ((info.st_mode & S_IFMT) == S_IFDIR) {
+        return access([path fileSystemRepresentation], R_OK | W_OK | X_OK) == 0;
+    }
+
+    return YES;
+}
+
+NSString *WSKFirstUnremovableItemAtPath(NSString *absolutePath) {
+    if (!_ItemIsRemovable(absolutePath)) {
+        return [absolutePath lastPathComponent];
+    }
+
+    NSDirectoryEnumerator<NSString *> *const enumerator = [[NSFileManager defaultManager] enumeratorAtPath:absolutePath];
+
+    for (NSString *subpath in enumerator) {
+        if (!_ItemIsRemovable([absolutePath stringByAppendingPathComponent:subpath])) {
+            return subpath;
+        }
+    }
+
+    return nil;
 }

--- a/Sources/WebServerKit/Responses/WSKFileResponse.m
+++ b/Sources/WebServerKit/Responses/WSKFileResponse.m
@@ -237,7 +237,11 @@ static NSString *_EscapeExtValue(NSString *string) {
     // worth of caching and costs everything else nothing. A future mtime (clock skew, an archive
     // restored with tomorrow's timestamp) is unsealed by the same test, which is the safe
     // direction and stops the server advertising a Last-Modified newer than its own Date.
-    BOOL const lastModifiedIsSealed = (time(NULL) - info.st_mtimespec.tv_sec) >= 1;
+    // Shared with WebDAV's PROPFIND through WSKLastModifiedDateIsSealed, because withholding the
+    // date here while another surface published it is exactly how a client obtained the unsealed
+    // validator this test exists to deny it. The descriptor is passed so the filesystem's own
+    // timestamp granularity decides the threshold — FAT's is two seconds, not one.
+    BOOL const lastModifiedIsSealed = WSKLastModifiedDateIsSealed(_file, &info);
 
     BOOL hasByteRange = WSKIsValidByteRange(range);
 

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -223,19 +223,40 @@ static BOOL _EntityTagMatchesList(NSString *currentTag, NSString *list, BOOL str
 - (nullable WSKResponse *)_preconditionFailureForRequest:(WSKRequest *)request atPath:(NSString *)absolutePath {
     NSString *const ifMatch = request.headers[@"If-Match"];
     NSString *const ifNoneMatch = request.headers[@"If-None-Match"];
+    // The date form of the same guarantee, and it was not read anywhere in the tree: a client that
+    // said "If-Unmodified-Since: <a date the file is newer than>" had its resource destroyed and was
+    // told the method succeeded. Same lost-update failure the entity-tag form was fixed for, left
+    // open in the spelling a date-only client uses.
+    NSString *const ifUnmodifiedSince = request.headers[@"If-Unmodified-Since"];
 
-    if ((ifMatch == nil) && (ifNoneMatch == nil)) {
+    if ((ifMatch == nil) && (ifNoneMatch == nil) && (ifUnmodifiedSince == nil)) {
         return nil;
     }
 
     struct stat info;
-    BOOL const exists = (stat([absolutePath fileSystemRepresentation], &info) == 0) && ((info.st_mode & S_IFMT) == S_IFREG);
+    // `stated` covers collections too, which the entity-tag path never reached because a tag is
+    // only minted for a regular file. A date condition is meaningful for a collection — DELETE of
+    // one is a destructive method like any other — so this deliberately admits a new refusal there.
+    BOOL const stated = (stat([absolutePath fileSystemRepresentation], &info) == 0);
+    BOOL const exists = stated && ((info.st_mode & S_IFMT) == S_IFREG);
     NSString *const currentTag = exists ? WSKEntityTagForFileInfo(&info) : nil;
 
-    // If-Match takes precedence; If-None-Match is only consulted in its absence (§13.2.2).
+    // Evaluation order is RFC 9110 §13.2.2: If-Match, then If-Unmodified-Since only in its
+    // absence, then If-None-Match. If-Modified-Since plays no part in a state-changing method.
     if (ifMatch != nil) {
         if (!_EntityTagMatchesList(currentTag, ifMatch, YES)) {
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"\"If-Match\" precondition failed for \"%@\"", request.path];
+        }
+    } else if (ifUnmodifiedSince != nil) {
+        NSDate *const limit = WSKParseRFC822(ifUnmodifiedSince);
+
+        // A date this server cannot parse is ignored rather than treated as failed, per RFC 9110
+        // §13.1.4. NOTE the cap that leaves: WSKParseRFC822 reads only the RFC 1123 form, so the
+        // RFC 850 and asctime spellings §5.6.7 also requires a server to accept parse to nil and
+        // the method PROCEEDS. That is shared with If-Modified-Since and If-Range rather than
+        // introduced here, so this closes the common spelling and not the whole class.
+        if (stated && (limit != nil) && ((time_t)floor(limit.timeIntervalSince1970) < info.st_mtimespec.tv_sec)) {
+            return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"\"If-Unmodified-Since\" precondition failed for \"%@\"", request.path];
         }
     } else if (_EntityTagMatchesList(currentTag, ifNoneMatch, NO)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"\"If-None-Match\" precondition failed for \"%@\"", request.path];
@@ -694,6 +715,16 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed", relativePath];
     }
 
+    // A removal that only partly succeeds is the worst outcome this library recognises, and
+    // -removeItemAtPath: produces one by design: it deletes as it walks and stops at the first
+    // member it cannot unlink, keeping everything it already destroyed and reporting a bare
+    // failure. Refuse before touching anything instead.
+    NSString *const unremovable = WSKFirstUnremovableItemAtPath(absolutePath);
+
+    if (unremovable) {
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed: \"%@\" cannot be removed", relativePath, unremovable];
+    }
+
     WSKResponse *const preconditionFailure = [self _preconditionFailureForRequest:request atPath:absolutePath];
 
     if (preconditionFailure) {
@@ -917,6 +948,15 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
         if (undeletable) {
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"%@ to \"%@\" is not allowed: it would destroy \"%@\"", isMove ? @"Moving" : @"Copying", dstRelativePath, undeletable];
         }
+
+        // The overwrite removes the destination, so it inherits the partial-removal problem too:
+        // measured at 7 files in the destination down to 1, answered 403, with the source also left
+        // in place — a failed operation AND a gutted destination.
+        NSString *const unremovable = WSKFirstUnremovableItemAtPath(dstAbsolutePath);
+
+        if (unremovable) {
+            return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"%@ to \"%@\" is not allowed: \"%@\" cannot be removed", isMove ? @"Moving" : @"Copying", dstRelativePath, unremovable];
+        }
     }
 
     if (isMove) {
@@ -1059,7 +1099,28 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
             }
 
             if ((properties & kDAVProperty_LastModified) && isFile && attributes[NSFileModificationDate]) {  // Last modification date is not useful for directories as it changes implicitely and 'Last-Modified' header is not provided for directories anyway
-                [xmlString appendFormat:@"<D:getlastmodified>%@</D:getlastmodified>", WSKFormatRFC822((NSDate *)[attributes fileModificationDate])];
+                // The same rule the GET path applies when it MINTS a Last-Modified, for the same
+                // reason. Without it PROPFIND handed out precisely the date WSKFileResponse exists
+                // to refuse to issue — one still inside its own timestamp bucket, so a later
+                // If-Range resume carrying it spliced two builds under one 206. And PROPFIND emits
+                // no getetag, so that unsealed date was the ONLY validator a PROPFIND-driven client
+                // could obtain. Measured 12/12 splices before this.
+                //
+                // Opened O_NOFOLLOW because the containment and hidden-item rules have already
+                // judged the resolved path; this only needs the descriptor to ask the filesystem
+                // its timestamp granularity. If it cannot be opened the property is omitted, which
+                // is the same fail-closed direction as an unsealed date.
+                int const descriptor = open([itemPath fileSystemRepresentation], O_RDONLY | O_NOFOLLOW);
+
+                if (descriptor >= 0) {
+                    struct stat info;
+
+                    if ((fstat(descriptor, &info) == 0) && WSKLastModifiedDateIsSealed(descriptor, &info)) {
+                        [xmlString appendFormat:@"<D:getlastmodified>%@</D:getlastmodified>", WSKFormatRFC822((NSDate *)[attributes fileModificationDate])];
+                    }
+
+                    close(descriptor);
+                }
             }
 
             if ((properties & kDAVProperty_ContentLength) && !isDirectory && attributes[NSFileSize]) {

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -1569,6 +1569,17 @@ static NSString *_OriginAuthority(NSString *value) {
             }
         }
 
+        // -removeItemAtPath: deletes as it walks and stops at the first member it cannot unlink,
+        // keeping everything it already destroyed and reporting only a failure. Measured here at
+        // 21 files in and 9 left, answered 500. Ask before touching anything. Deliberately NOT
+        // folded into the allow-list walk above, which is skipped entirely when no allow-list is
+        // configured — the default, and where this is reachable.
+        NSString *const unremovable = WSKFirstUnremovableItemAtPath(absolutePath);
+
+        if (unremovable) {
+            return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed: \"%@\" cannot be removed", relativePath, unremovable];
+        }
+
         if (![self shouldDeleteItemAtPath:absolutePath]) {
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not permitted", relativePath];
         }


### PR DESCRIPTION
Four findings from the twelfth pass, whose techniques were **filesystem fault injection on real disk
images**, **clock and locale manipulation**, **platform-conditional code**, and **declared-contract
conformance**. Each new test was run against the unfixed source first and confirmed to fail on the
intended assertion.

### A recursive removal that half-succeeded was reported as a total failure

`-removeItemAtPath:` deletes as it walks and stops at the first member it cannot unlink — keeping
everything it already destroyed and reporting only a failure. One `chflags uchg` file (what Finder's
**Locked** checkbox sets) or one unwritable subdirectory is enough:

```
DAV DELETE /Folder      status=500   files before=21  after=9      (10/10 identical)
uploader POST /delete   status=500   files before=21  after=9      (5/5)
MOVE onto it, Overwrite: T  403   destination 7 -> 1 files, source STILL PRESENT
```

Default configuration, both servers. The overwrite case is the worst: the client is told the move
failed *and* loses the destination. `WSKFirstUnremovableItemAtPath()` now walks first and refuses,
naming the blocking item.

**⚠️ The proposed fix would have done nothing — fifth time a proposed fix was the dangerous part.**
It said to add the check inside `-_firstUnvettableItemAtPath:isDirectory:`, whose first line returns
`nil` when `allowedFileExtensions` is unset — the default, and where every reproduction lives. It
would have landed a no-op behind a green suite. The walk is unconditional, and is one shared function
called from `performDELETE`, the overwrite vetting in `performCOPY:isMove:`, and the uploader's
`deleteItem:`, so no site can be forgotten later. Cost: a second subtree walk, ~25% on a 5,000-entry
delete.

### `If-Unmodified-Since` was not read anywhere in the tree

`grep -rn Unmodified Sources/` returned zero. A client stating "only if unchanged since <date>"
against a newer file had it destroyed and was told it succeeded — the date-form twin of the
`If-Match` gap the tenth pass closed. Now evaluated for PUT, DELETE, MOVE and COPY in RFC 9110
§13.2.2 order.

Two consequences stated rather than left to be discovered:
- It **also applies to collections**, which the entity-tag form never reached (no tag is minted for a
  directory), so `DELETE /Coll` under a stale date now answers 412.
- **The class is not closed.** `WSKParseRFC822` reads only the RFC 1123 form, so the RFC 850 and
  asctime spellings §5.6.7 *also* requires a server to accept parse to nil and the method proceeds.
  Pre-existing and shared with `If-Modified-Since` and `If-Range`.

### PROPFIND published the validator the GET path refuses to issue

`WSKFileResponse` withholds `Last-Modified` while mtime is inside its own timestamp bucket. PROPFIND
applied no such test — and since it emits no `getetag`, that unsealed date was the **only** validator
a PROPFIND-driven client could obtain. A later `If-Range` resume with it spliced two builds under one
206: **12/12**.

This falsifies the seventh pass's *"every date a client can present was sealed before it was handed
out"*. The correction sits next to the claim in CLAUDE.md.

### FAT's timestamp bucket is two seconds, not one

FAT stores mtime in 2-second units and truncates downward, so a timestamp one second old can still
take another write. Against a real FAT32 image: **12/12 splices and 12/12 stale 304s**, with APFS,
exFAT and HFS+ clean through the same harness.

Both surfaces now share `WSKLastModifiedDateIsSealed`, which asks `fstatfs`. It allows one second
only for `apfs`, `hfs` and `exfat` (measured at ns, 1s, 10ms); **everything else — including
`smbfs`, `nfs`, and an `fstatfs` failure — is assumed two-second.**

That is deliberately the fail-closed choice: FAT over SMB reports `smbfs` and cannot be probed from
here, and being wrong that way splices two builds, while being wrong the other way costs a date-only
client one second of caching. Two seconds everywhere is the blunt alternative — a one-line change if
that caching matters more to you than the SMB case.

### Verification

**115 tests, 0 failures**, all eight trace suites (including the three recorded WebDAV client
corpora, whose 207 bodies contain `<D:getlastmodified>` and still match byte-for-byte — positive
evidence the property is still emitted under real replay), Release builds for all three platforms,
exit 0.

### Left open deliberately

`Range: bytes=999999999-` kills a host app reading the three properties `WSKFileResponse.h`
redeclares non-null (the 416 path returns before setting them). Not fixed: the skeptic measured the
proposed fix as unsafe, and it needs a handler written the way the header documents rather than a
default configuration. That plus eight lower items are recorded in CLAUDE.md's twelfth-pass entry.
