### PR TITLE
Refuse a fragment in the request target, and undo two over-refusals the twelfth pass introduced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,94 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Thirteenth audit pass: an outside conformance suite, a real mounted client, and two regressions of my own
+
+Four more never-used techniques, and two of them were ones an earlier pass had written off as needing
+hardware: **litmus 0.13**, the standard WebDAV conformance suite, built from source (its 2005-era
+autoconf needs `CFLAGS=-Wno-implicit-function-declaration` on a modern clang, or it dies claiming it
+cannot find `socket`); **a real `mount_webdav` mount** driven by macOS's own kernel WebDAV client,
+which needs no privileges when an ordinary user owns the mount point; **mutational fuzzing seeded
+from the eight recorded real-client sessions** rather than from synthetic requests; and **the
+long-lived resources** — the SSE channel state machine, Bonjour, the heartbeat reaper — under churn.
+
+**A raw `#` in the request-target was discarded and every verb honoured against the prefix.**
+`CFURLCopyPath()` treats it as a fragment delimiter. `#` is a legal filename character and
+`MyApp#42.ipa` is an ordinary CI convention, so this needs no malice:
+
+    PUT /ci/MyApp#41.ipa -> 201     PUT /ci/MyApp#42.ipa -> 204    PUT /ci/MyApp#43.ipa -> 204
+    files on disk in /ci: ['MyApp'] = BUILD-43-BYTES
+    GET /ci/MyApp#42.ipa -> 200 OK    body = BUILD-43-BYTES
+    DELETE /D1/#nope     -> 204       /D1 destroyed
+
+Three builds collapse into one, two are destroyed, every answer says success, and a GET naming build
+42 hands over build 43. Same class as the NUL truncation the eighth pass refused rather than
+honoured, at a delimiter that fix never covered. litmus finds it independently (`delete_fragment`).
+Not an allow-list bypass — the allow-list judges the truncated path and still refuses.
+
+**⚠️ Guarding the request-target alone leaves the whole defect reachable.** HTTP stacks sanitize a
+URL they put in the request line but never a header value, so curl strips `#` from the target and
+passes it through in `Destination` untouched — measured with the target-only guard in place, `COPY`
+with `Destination: http://h/Builds#x` still answered 204 and still replaced a three-build collection
+with a 4-byte file. Both sites are guarded. The request-line check is on the raw wire bytes in
+`_ValidateRequestLine`, ahead of any CF parsing, so a `-rewriteRequestURL:` subclass cannot route
+around it. What it costs, measured: `GET /q.txt?a=1#b=2` and a bare trailing `#` become 400, and a
+`Destination` of `/Builds#nope.txt` no longer creates a file with that literal name. `%23` still
+addresses a `#`-bearing file correctly, and the test asserts that, because it is what a naive fix
+breaks.
+
+**⚠️ Two of this pass's findings were regressions from the TWELFTH pass — mine.** Both in the
+default configuration:
+
+- The removability walk required `W_OK` on every directory in the subtree, but `unlink(2)` and
+  `rmdir(2)` need write permission on the **parent**, not on the item — so an **empty** directory is
+  removable whatever its own mode says. `chmod 555` on one made its whole ancestry permanently
+  undeletable, and both `unzip` and `ditto -x -k` preserve 0555, so it arrives through ordinary
+  archive extraction. A directory is now only required to be writable if it actually has entries; one
+  that cannot be listed at all is still refused, and a read-only NON-empty directory is still refused,
+  which the test pins in both directions.
+- `If-Match: *` was keyed on the entity tag, which is only minted for a regular file, so it always
+  failed for a collection: a conditional `DELETE`, `MOVE` or `COPY` of a folder could never succeed.
+  `*` asks whether a representation exists at all (RFC 9110 §13.1.1), and now does.
+
+That is the fifth and sixth time a fix in this project planted the next defect, and the first time the
+fix was written here rather than proposed by an agent. The lesson generalises: **a guard justified by
+one failure mode has to be checked against the operations it now refuses**, not only against the one
+it was written to catch.
+
+**Still open from this pass, and worth deciding on.** Directory enumeration omits every symlink the
+same server serves with 200, so through a real mount `mv` returns 0, copies only what was listed, and
+then deletes the source — silent loss via the OS's own client. `MOVE`/`COPY` of a *collection*
+relocates and duplicates members the allow-list refuses individually, which is the class the eighth
+and twelfth passes closed for `DELETE` and the overwrite, at the two verbs they did not reach.
+PROPFIND publishes no `getetag` at all, so since the twelfth pass a just-written file has *zero*
+validators for a PROPFIND-driven client where it previously had one (an unsealed, useless one) — the
+skeptic measured the obvious fix as failing CI. MKCOL on an existing URL answers 500 rather than the
+RFC-required 405, breaking the universal "MKCOL each ancestor, treat 405 as already-exists" idiom;
+its fix is safe, but the "nearly free" second half — adding `Allow` to OPTIONS — **breaks the trace
+runner**, which fails on any header present in the response but absent from the recording. Also:
+`PROPPATCH` is 501 while `OPTIONS` advertises `DAV: 1` and the header promises class 1 compliance;
+`propname` is refused with 400; unavailable properties get no 404 propstat; `Depth: 0` is refused on
+COPY/DELETE of a plain file and MOVE has no Depth check at all; an SSE client that stops reading but
+holds its socket open is never reaped; SSE event paths collapse to `/` when the share is reached
+through a symlinked ancestor; and `-bonjourName` reports the configured name rather than the
+auto-renamed one.
+
+**A record correction that no server-side fix closes.** macOS's WebDAV client fetches a large file as
+~99 independent 1 MiB `Range` requests on separate connections. A build republished mid-download
+therefore produced a local file that was 20 MiB of build A and 80 MiB of build B — with the server
+answering every request truthfully and handing out two distinct ETags. Shape A's in-flight
+consistency guarantee holds *within* a response and cannot hold *across* independent requests. The
+client, not the server, is the only place that could bind them.
+
+**Verified clean, quantitatively.** litmus `basic` 16/16, `http` 4/4, `locks` 3/3, and 409/204
+overwrite semantics exactly right. Through a real mount: 2.3 GB of large writes and 33,269 mixed
+operations with zero wrong bytes and 3,290 mount-vs-disk listing comparisons agreeing; 34 hostile
+filenames including the NFC/NFD pair round-tripping both ways; **the twelfth pass's dateless-PROPFIND
+window is well tolerated by the OS client**, which falls back to `creationdate` — the specific
+question that pass could not answer. 316,047 trace-seeded mutated requests produced no crash and zero
+"refused but changed" across 176,661 snapshot comparisons. 1,268,184 SSE connection attempts with all
+16 slots reclaimed within two ticks, no retain cycle, and Bonjour deregistering 9 Add / 9 Rmv 1:1.
+
 ### Twelfth audit pass: the harness reported CLEAN when its verifiers had died
 
 Four more never-used techniques: **filesystem fault injection on real disk images** (ENOSPC,

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1968,6 +1968,116 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// CFURLCopyPath() treats '#' as a fragment delimiter and returns only the prefix, and every verb was
+// then honoured against that prefix. '#' is a legal filename character and "MyApp#42.ipa" is an
+// ordinary CI build-number convention, so this needs no malice: three builds published that way
+// collapsed into ONE file under 201/204/204, and a GET naming build 42 answered 200 with build 43's
+// bytes. Same class as the NUL truncation the eighth pass refused rather than honoured.
+//
+// Guarded in two places, because HTTP stacks sanitize a request line but never a header value —
+// curl strips '#' from the target and passes it through in Destination untouched. With only the
+// request-target guard, a COPY still destroyed a collection through Destination.
+- (void)testFragmentInRequestTargetIsRefusedRatherThanTruncated {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* collection = [dir stringByAppendingPathComponent:@"Builds"];
+    void (^rebuild)(void) = ^{
+        [fm removeItemAtPath:collection error:NULL];
+        XCTAssertTrue([fm createDirectoryAtPath:collection withIntermediateDirectories:YES attributes:nil error:NULL]);
+        XCTAssertTrue([@"BUILD" writeToFile:[collection stringByAppendingPathComponent:@"a.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        XCTAssertTrue([@"SRC" writeToFile:[dir stringByAppendingPathComponent:@"src.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    };
+
+    // A fragment in the request-target must be refused, not silently dropped.
+    rebuild();
+    NSString* deleted = SendRawRequest(server.port, @"DELETE /Builds/#nonexistent HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 400"], @"a '#' in the request-target should be refused: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:collection], @"the request destroyed a collection the client never named");
+
+    rebuild();
+    NSString* put = SendRawRequest(server.port, @"PUT /src.txt#new.ipa HTTP/1.1\r\nHost: localhost\r\nContent-Length: 9\r\n\r\nCLOBBERED");
+    XCTAssertTrue([put hasPrefix:@"HTTP/1.1 400"], @"a '#' in a PUT target should be refused: %@", [put substringToIndex:MIN((NSUInteger)40, put.length)]);
+    XCTAssertEqualObjects([NSString stringWithContentsOfFile:[dir stringByAppendingPathComponent:@"src.txt"] encoding:NSUTF8StringEncoding error:NULL], @"SRC", @"the PUT overwrote a different file than the one named");
+
+    // The same defect through the Destination header, which no HTTP stack sanitizes.
+    rebuild();
+    NSString* copied = SendRawRequest(server.port, @"COPY /src.txt HTTP/1.1\r\nHost: localhost\r\nDestination: http://localhost/Builds#nonexistent.txt\r\nOverwrite: T\r\n\r\n");
+    XCTAssertTrue([copied hasPrefix:@"HTTP/1.1 400"], @"a '#' in Destination should be refused: %@", [copied substringToIndex:MIN((NSUInteger)40, copied.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:[collection stringByAppendingPathComponent:@"a.txt"]], @"the COPY replaced a collection named only by a discarded fragment");
+
+    // What must keep working: %23 is how a '#'-bearing filename is legitimately addressed, and a
+    // naive fix breaks exactly this.
+    rebuild();
+    NSString* encoded = SendRawRequest(server.port, @"PUT /MyApp%2342.ipa HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nBUILD");
+    XCTAssertTrue([encoded hasPrefix:@"HTTP/1.1 201"], @"%%23 must still address a '#'-bearing name: %@", [encoded substringToIndex:MIN((NSUInteger)40, encoded.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:@"MyApp#42.ipa"]], @"the percent-encoded name did not land on disk");
+    XCTAssertTrue([SendRawRequest(server.port, @"GET /MyApp%2342.ipa HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"BUILD"], @"a '#'-bearing file could not be read back");
+    XCTAssertTrue([SendRawRequest(server.port, @"GET /src.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 200"], @"an ordinary GET stopped working");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// Two regressions from the twelfth pass's own fixes, both in the default configuration.
+//
+// The removability walk required W_OK on every directory in the subtree, but unlink(2) and rmdir(2)
+// need write permission on the PARENT, not on the item — so an EMPTY directory is removable whatever
+// its own mode says. `chmod 555` on one therefore made its whole ancestry permanently undeletable,
+// and both unzip and `ditto -x -k` preserve 0555, so it arrives through ordinary archive extraction.
+//
+// And `If-Match: *` was keyed on the entity tag, which is only minted for a regular file, so it
+// always failed for a collection: a conditional DELETE/MOVE/COPY of a folder could never succeed.
+- (void)testTwelfthPassFixesDoNotOverRefuse {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // An extracted archive leaving a read-only EMPTY directory behind.
+    NSString* build = [dir stringByAppendingPathComponent:@"Build"];
+    NSString* empty = [build stringByAppendingPathComponent:@"Empty"];
+    XCTAssertTrue([fm createDirectoryAtPath:empty withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"data" writeToFile:[build stringByAppendingPathComponent:@"f.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertEqual(chmod(empty.fileSystemRepresentation, 0555), 0, @"could not make the directory read-only");
+
+    NSString* deleted = SendRawRequest(server.port, @"DELETE /Build HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 204"], @"a read-only EMPTY directory must not make its parent undeletable: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+    XCTAssertFalse([fm fileExistsAtPath:build], @"the tree was not removed");
+
+    // A read-only NON-empty directory genuinely cannot be emptied, so it must still be refused.
+    NSString* guarded = [dir stringByAppendingPathComponent:@"Guarded"];
+    NSString* inner = [guarded stringByAppendingPathComponent:@"Inner"];
+    XCTAssertTrue([fm createDirectoryAtPath:inner withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"data" writeToFile:[inner stringByAppendingPathComponent:@"stuck.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertEqual(chmod(inner.fileSystemRepresentation, 0555), 0);
+
+    NSString* refused = SendRawRequest(server.port, @"DELETE /Guarded HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([refused hasPrefix:@"HTTP/1.1 403"], @"a genuinely unremovable tree must still be refused: %@", [refused substringToIndex:MIN((NSUInteger)40, refused.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:[inner stringByAppendingPathComponent:@"stuck.txt"]], @"the refused delete still destroyed part of the tree");
+    chmod(inner.fileSystemRepresentation, 0755);
+
+    // If-Match: * must succeed against a collection, which has no entity tag.
+    NSString* coll = [dir stringByAppendingPathComponent:@"Coll"];
+    XCTAssertTrue([fm createDirectoryAtPath:coll withIntermediateDirectories:YES attributes:nil error:NULL]);
+    NSString* conditional = SendRawRequest(server.port, @"DELETE /Coll HTTP/1.1\r\nHost: localhost\r\nIf-Match: *\r\n\r\n");
+    XCTAssertTrue([conditional hasPrefix:@"HTTP/1.1 204"], @"If-Match: * should succeed against an existing collection: %@", [conditional substringToIndex:MIN((NSUInteger)40, conditional.length)]);
+    XCTAssertFalse([fm fileExistsAtPath:coll], @"the conditional delete did not happen");
+
+    // And must still fail against something that does not exist.
+    NSString* absent = SendRawRequest(server.port, @"DELETE /Nope HTTP/1.1\r\nHost: localhost\r\nIf-Match: *\r\n\r\n");
+    XCTAssertFalse([absent hasPrefix:@"HTTP/1.1 2"], @"If-Match: * should not succeed against an absent resource: %@", [absent substringToIndex:MIN((NSUInteger)40, absent.length)]);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 // The date form of the lost-update guarantee. If-Match was fixed in the tenth pass;
 // If-Unmodified-Since was not parsed ANYWHERE in the tree, so a client that explicitly said
 // "only if it has not changed since <date the file is newer than>" had its resource destroyed and

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -946,6 +946,24 @@ static BOOL _ValidateRequestLine(const unsigned char *line, NSUInteger length) {
         }
     }
 
+    // A '#' in the request-target is not a fragment to be discarded, it is a malformed target: RFC
+    // 9110 §7.1 says the fragment is not part of the request target at all. CFURLCopyPath() honours
+    // it as a delimiter and hands back only the prefix, and every verb was then executed against
+    // that prefix — so `PUT /ci/MyApp#42.ipa` wrote to `/ci/MyApp`, three builds published that way
+    // collapsed into one file under 201/204/204, and `DELETE /D1/#nope` answered 204 having
+    // destroyed `/D1`. Same shape as the NUL truncation the eighth pass refused rather than
+    // honoured, at a delimiter that fix never covered, and refused here for the same reason:
+    // truncating does not make the request mean what the client wrote.
+    //
+    // Checked on the raw wire bytes, ahead of any CF parsing, so a -rewriteRequestURL: subclass
+    // cannot route around it. "%23" still addresses a '#'-bearing filename correctly and must keep
+    // working — that is the case a naive fix breaks.
+    for (NSUInteger i = firstSpace + 1; i < lastSpace; i++) {
+        if (line[i] == '#') {
+            return NO;
+        }
+    }
+
     NSUInteger const versionLength = length - lastSpace - 1;
     const unsigned char *const version = line + lastSpace + 1;
 

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -680,7 +680,27 @@ static BOOL _ItemIsRemovable(NSString *path) {
     }
 
     if ((info.st_mode & S_IFMT) == S_IFDIR) {
-        return access([path fileSystemRepresentation], R_OK | W_OK | X_OK) == 0;
+        // A directory's own write permission is only needed to unlink its CHILDREN. Removing the
+        // directory itself is rmdir(2), which needs write permission on its PARENT — so an EMPTY
+        // directory is removable whatever its own mode says. Requiring W_OK unconditionally made
+        // `chmod 555` on an empty directory render its whole ancestry permanently undeletable, and
+        // both unzip and `ditto -x -k` preserve mode 0555, so that arrives through ordinary archive
+        // extraction with no attacker and in the default configuration.
+        //
+        // A directory that cannot be listed at all is refused: its children cannot be unlinked, and
+        // whether it has any cannot be established. That is the rare case (mode 0300); the common
+        // one is 0555, which is readable, so emptiness can be checked directly.
+        if (access([path fileSystemRepresentation], R_OK | X_OK) != 0) {
+            return NO;
+        }
+
+        NSArray<NSString *> *const contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:NULL];
+
+        if (contents.count == 0) {
+            return YES;
+        }
+
+        return access([path fileSystemRepresentation], W_OK) == 0;
     }
 
     return YES;

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -180,11 +180,15 @@ static inline BOOL _HeaderTokenIs(NSString *value, NSString *token) {
 // If-Match requires the STRONG comparison (RFC 9110 §13.1.1), where a "W/" tag can never match;
 // If-None-Match uses the weak one, where the prefix is stripped from both sides. Tags this
 // server issues are always strong, so only the client's side can carry the prefix.
-static BOOL _EntityTagMatchesList(NSString *currentTag, NSString *list, BOOL strong) {
+static BOOL _EntityTagMatchesList(BOOL resourceExists, NSString *currentTag, NSString *list, BOOL strong) {
     NSString *const trimmed = [list stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 
+    // "*" asks whether the origin has a current representation AT ALL (RFC 9110 §13.1.1), which is
+    // not the same question as "does it have an entity tag". Keying it on the tag made `If-Match: *`
+    // always FAIL for a collection, since no tag is minted for a directory — so a conditional
+    // DELETE, MOVE or COPY of a folder could never succeed.
     if ([trimmed isEqualToString:@"*"]) {
-        return (currentTag != nil);
+        return resourceExists;
     }
 
     if (currentTag == nil) {
@@ -244,7 +248,7 @@ static BOOL _EntityTagMatchesList(NSString *currentTag, NSString *list, BOOL str
     // Evaluation order is RFC 9110 §13.2.2: If-Match, then If-Unmodified-Since only in its
     // absence, then If-None-Match. If-Modified-Since plays no part in a state-changing method.
     if (ifMatch != nil) {
-        if (!_EntityTagMatchesList(currentTag, ifMatch, YES)) {
+        if (!_EntityTagMatchesList(stated, currentTag, ifMatch, YES)) {
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"\"If-Match\" precondition failed for \"%@\"", request.path];
         }
     } else if (ifUnmodifiedSince != nil) {
@@ -258,7 +262,7 @@ static BOOL _EntityTagMatchesList(NSString *currentTag, NSString *list, BOOL str
         if (stated && (limit != nil) && ((time_t)floor(limit.timeIntervalSince1970) < info.st_mtimespec.tv_sec)) {
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"\"If-Unmodified-Since\" precondition failed for \"%@\"", request.path];
         }
-    } else if (_EntityTagMatchesList(currentTag, ifNoneMatch, NO)) {
+    } else if (_EntityTagMatchesList(stated, currentTag, ifNoneMatch, NO)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"\"If-None-Match\" precondition failed for \"%@\"", request.path];
     }
 
@@ -849,6 +853,17 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     // file — any short, common, or ".local" host that happened to appear in a name did it.
     if ((destinationHeader.length == 0) || (hostHeader.length == 0)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Malformed 'Destination' header: %@", destinationHeader];
+    }
+
+    // The same fragment truncation the request-line validator refuses, at the one place it can
+    // still arrive: HTTP stacks sanitize a URL they put in the request line but never a header
+    // value, so curl strips '#' from the target and passes it through here untouched. Measured with
+    // the request-target guard alone in place: `COPY /tiny.txt` with `Destination: http://h/Builds#x`
+    // still answered 204 and still replaced a three-build collection with a 4-byte file. Guarding
+    // only the target and calling the class closed would be exactly the "fixed at one of the sites
+    // it occurs at" pattern this file keeps recording.
+    if ([destinationHeader rangeOfString:@"#"].location != NSNotFound) {
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Malformed 'Destination' header: a fragment is not part of a request target: %@", destinationHeader];
     }
 
     // RFC 4918 lets Destination be an absolute URI or an absolute path. Take the path


### PR DESCRIPTION
Four fixes from the thirteenth pass. **Two are regressions the twelfth pass introduced** — mine, not
an agent's proposal — and both are reachable in the default configuration.

### The two regressions, first

**A read-only but EMPTY directory made its whole ancestry permanently undeletable.** The removability
walk required `W_OK` on every directory in the subtree. But `unlink(2)`/`rmdir(2)` need write
permission on the **parent**, not on the item, so an empty directory is removable whatever its own
mode says. `unzip` and `ditto -x -k` both preserve mode 0555, so this arrives through ordinary archive
extraction into a served folder.

A directory is now only required to be writable when it actually **has entries**. Still refused, and
pinned by the test in both directions: a read-only NON-empty directory, and one that cannot be listed
at all.

**`If-Match: *` always failed against a collection.** It was keyed on the entity tag, which is only
minted for a regular file — so a conditional `DELETE`/`MOVE`/`COPY` of a folder could never succeed.
RFC 9110 §13.1.1 defines `*` as asking whether the origin has a current representation at all, which
a directory does.

Fifth and sixth time a fix here has planted the next defect. The general form, worth stating: *a
guard justified by one failure mode has to be checked against the operations it now refuses, not only
against the one it was written to catch.*

### A raw `#` in the request-target was discarded and the verb honoured against the prefix

```
PUT /ci/MyApp#41.ipa -> 201    PUT /ci/MyApp#42.ipa -> 204    PUT /ci/MyApp#43.ipa -> 204
files on disk in /ci: ['MyApp']  = BUILD-43-BYTES
GET /ci/MyApp#42.ipa -> 200 OK   body = BUILD-43-BYTES
DELETE /Builds/#nonexistent -> 204   /Builds destroyed
```

`CFURLCopyPath()` treats `#` as a fragment delimiter. `#` is a legal filename character and
`MyApp#42.ipa` is an ordinary CI convention, so this needs no malice — three builds collapse into
one, two are destroyed, every answer says success, and a GET naming build 42 hands over build 43.

Same class as the NUL truncation the eighth pass refused rather than honoured, at a delimiter that fix
never covered. litmus finds it independently (`delete_fragment`). **Not** an allow-list bypass — the
allow-list judges the truncated path and still refuses.

**⚠️ Guarding only the request-target would have left it fully reachable.** HTTP stacks sanitize a URL
they put in the request line but never a header value: curl strips `#` from the target and passes it
through in `Destination` untouched. Measured with the target-only guard in place, `COPY` with
`Destination: http://host/Builds#x` still answered **204** and still replaced a three-build collection
with a 4-byte file. Both sites are guarded, and the request-line check runs on the raw wire bytes in
`_ValidateRequestLine` — ahead of any CF parsing, so a `-rewriteRequestURL:` subclass cannot route
around it.

**What it costs**, measured: `GET /q.txt?a=1#b=2` and a bare trailing `#` become 400, and a
`Destination` of `/Builds#nope.txt` no longer creates a file with that literal name. Anything relying
on those was relying on silent truncation. `%23` still addresses a `#`-bearing file on GET, PUT and as
a Destination — asserted in the test, because that is what a naive fix breaks.

### Verification

Both new tests were run against the unfixed source first and failed on **ten** intended assertions,
including the collection destroyed through `Destination` and the read-only empty directory making its
parent undeletable.

**117 tests, 0 failures**, all eight trace suites, Release builds for all three platforms, exit 0.

### Not included, recorded in CLAUDE.md for a decision

Directory enumeration omits symlinks the server serves with 200, so `mv` through a real mount returns
0, copies only what was listed, then deletes the source. `MOVE`/`COPY` of a *collection* relocates
members the allow-list refuses individually. PROPFIND publishes no `getetag`, so since the twelfth
pass a just-written file has zero validators for a PROPFIND client (the skeptic measured the obvious
fix as failing CI). MKCOL on an existing URL answers 500 not 405 — its fix is safe, but adding `Allow`
to OPTIONS **breaks the trace runner**, which fails on any header present in the response and absent
from the recording. Plus the DAV class-1 conformance gaps (`PROPPATCH` 501, `propname` 400, no 404
propstat, Depth handling) and two SSE issues.
