### PR TITLE
Stop six browser tabs deadlocking the uploader, and match the Host allow-list to its own documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,74 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Fourteenth audit pass: the browser was never in scope, and that is where the defects were
+
+Four oracles, weighted deliberately toward things outside this project's own reasoning: **static
+analysis**, **a second and third independent client**, **the uploader's page in a real browser**, and
+**a two-binary differential against upstream GCDWebServer**. Three of the four findings live in
+`index.js`, which thirteen passes had never touched.
+
+**Static analysis found nothing reproducible, and that is the most informative clean result yet.**
+Nine analyzer configurations across three engines, every plausible diagnostic then driven from the
+network before being believed. Zero survived. After thirteen passes of runtime instrumentation this
+says the defects that remain are not the kind a symbolic explorer finds — do not re-run it.
+
+**Six open browser tabs deadlocked the uploader UI completely.** A browser allows six HTTP/1.1
+connections per origin and an `EventSource` never completes, so six tabs consumed all six. Measured:
+tabs 1–5 answered in 2 ms, the sixth timed out, a seventh rendered nothing for 13.5 minutes. The
+server was idle throughout — curl through the same relay answered 200 with 122 free connection slots
+and 10 free SSE channels. **`kMaxSSEChannels` (16) sits above the bound that actually binds**: one
+browser deadlocks itself at 6 and can never reach 16. Default configuration, no hostility, and it is
+Shape B's entire deployment.
+
+**⚠️ The obvious fix is worse than the defect, and was measured rather than reasoned about.** Closing
+the stream on `visibilitychange` trades the deadlock for a live-update blackout: the server only
+reclaims a browser-closed channel when a heartbeat write fails 20–33 s later, so ordinary tab
+switching left zombies — 25 of 40 reconnects refused, and the tab actually being looked at stopped
+updating. It also does nothing for six *simultaneously visible* tabs. What shipped instead is **one
+stream per browser**: a single tab holds `/events` under a Web Lock and relays over a
+`BroadcastChannel`. The lock is released by the browser itself when the holding tab goes away, so
+there is no heartbeat, no timeout, and no way to leave the stream unheld or held twice; where either
+API is missing the old behaviour stands. Verified in Chromium: seven tabs all answering in 1–2 ms
+against tab 6 dead for 20 s before.
+
+**A deep link, or simply pressing Reload inside a subfolder, bounced to the root.** `_path` is only
+assigned when a listing *returns*, so between `_reload(hashPath)` and its response it still read
+`"/"` — and the SSE `onopen` re-sync firing in that window re-requested the root. 33 of 40 attempts.
+The re-sync now targets the path most recently *requested*.
+
+**Opening the rename box on a CR-bearing filename and pressing Enter renamed it, with nothing
+typed.** `<input>` in the Text state applies the "strip newlines" sanitization algorithm, so the box
+can never hold a CR — making `value != name` unconditionally true. This is the same shape as the
+fourth pass's `&` fix one layer further down: there the mangling was jeditable's and seeding cured
+it; here it is the browser's own and no seeding can. The comparison is now against what the box can
+actually hold.
+
+**The Host allow-list refused any Host whose port differed from the listening port** — contradicting
+`WSKOption_AllowedHostNames`' own documentation ("may include a port ...; **without one, any port
+matches**"), and refusing every deployment behind a port-translating hop. **This one is a judgement
+call and is easy to reverse:** the port comparison is gone, and an existing assertion in
+`testHostValidationRefusesRebindingButAllowsRealNames` was deliberately inverted. The reasoning is
+that `Host` is derived from the request URL, not from the page's origin, so a browser fetching this
+server can only ever state *this* server's port; a differing one comes from a forwarder, or from a
+non-browser client that could state any `Host` it liked and against which rebinding — which requires
+a browser — does not apply. The name carries the entire defence, and every rebinding assertion still
+passes unchanged. An entry that pins a port is still honoured verbatim.
+
+**Refuted, and worth recording as the method rather than the result.** A case-variant `PUT` on a
+case-insensitive volume looked like a real defect until the skeptic ran `rclone serve webdav` over
+the same directory and got byte-identical behaviour. Not a WebServerKit deviation — inherent to
+vending a case-insensitive namespace through a protocol whose clients assume otherwise.
+
+**Verified clean:** litmus `basic` 16/16, `http` 4/4, `locks` 3/3; 2.3 GB through a real
+`mount_webdav` client byte-perfect across 33,269 mixed operations; rclone `sync`/`check` agreeing in
+both directions; upstream GCDWebServer builds on a current toolchain and the behavioural differential
+found the hardening intended and documented.
+
+**The JS has no test harness**, so all three `index.js` fixes are verified by a Chromium probe run
+against the unfixed and fixed builds, not by the XCTest suite — which is blind to them and stayed at
+118/118 throughout, in both states.
+
 ### Thirteenth audit pass: an outside conformance suite, a real mounted client, and two regressions of my own
 
 Four more never-used techniques, and two of them were ones an earlier pass had written off as needing

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -4192,7 +4192,15 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     for (NSString* host in @[ @"evil.example", @"localhost.evil.com", @"attacker.localhost.evil.com" ]) {
         XCTAssertTrue([get(host) containsString:@"421"], @"host \"%@\" should have been refused", host);
     }
-    XCTAssertTrue([get([NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port + 1]) containsString:@"421"], @"a mismatched port should be refused");
+    // A mismatched port is deliberately NOT refused any more, and this assertion was inverted on
+    // purpose — see testHostValidationMatchesAnyPortUnlessAnEntryPinsOne. It used to be refused,
+    // which contradicted WSKOption_AllowedHostNames' own documentation and broke every deployment
+    // behind a port-translating hop. It protected nothing: Host is derived from the request URL,
+    // not from the page's origin, so a browser fetching this server can only ever state THIS
+    // server's port — a differing one comes from a forwarder, or from a non-browser client that
+    // could state any Host it liked and for which rebinding (which needs a browser) does not apply.
+    // The name is what carries the defence, and the assertions above still prove it does.
+    XCTAssertFalse([get([NSString stringWithFormat:@"localhost:%lu", (unsigned long)server.port + 1]) containsString:@"421"], @"a differing port on an accepted name should no longer be refused");
 
     // No Host at all is allowed: HTTP/1.0 and native clients omit it, and rebinding needs a
     // browser, which never does.
@@ -4225,6 +4233,54 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 
 // The escape hatch for anyone reached under another name — a reverse proxy, a custom DNS
 // entry. Entries may pin their own port.
+// WSKOption_AllowedHostNames documents that an entry "may include a port ... without one, any port
+// matches". The code did the opposite: a Host stating ANY port was refused unless that port equalled
+// the one the connection arrived on, checked before the name was even consulted. Every deployment
+// behind a port-translating hop was therefore 421 for every request — which is the priority
+// deployment, since Tailscale Serve terminates TLS on 443 and forwards to a local port.
+//
+// Dropping the comparison costs no security: the DNS-rebinding defence turns entirely on the NAME,
+// and an attacker controls the port he targets either way. An entry that DOES pin a port is still
+// honoured verbatim, which this pins in both directions.
+- (void)testHostValidationMatchesAnyPortUnlessAnEntryPinsOne {
+    NSString* dir = MakeTempDirectory();
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:NO];
+    NSDictionary* options = @{
+        WSKOption_Port : @0,
+        WSKOption_BindToLocalhost : @YES,
+        WSKOption_AllowedHostNames : @[ @"files.example", @"pinned.example:9999" ]
+    };
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* (^get)(NSString*) = ^(NSString* host) {
+        return SendRawRequest(server.port, [NSString stringWithFormat:@"GET / HTTP/1.1\r\nHost: %@\r\n\r\n", host]);
+    };
+
+    // An entry with no port matches whatever port the client states, including none.
+    for (NSString* host in @[ @"files.example", @"files.example:80", @"files.example:443", @"files.example:8080" ]) {
+        XCTAssertFalse([get(host) hasPrefix:@"HTTP/1.1 421"], @"an unpinned entry should match any port, but \"%@\" was refused", host);
+    }
+
+    // The same for the names accepted without configuration — a forwarded localhost or IP literal
+    // arrives carrying the port the client dialled, not the one being listened on.
+    for (NSString* host in @[ @"localhost", @"localhost:8080", @"127.0.0.1:8080", @"[::1]:8080" ]) {
+        XCTAssertFalse([get(host) hasPrefix:@"HTTP/1.1 421"], @"\"%@\" should be accepted whatever port it states", host);
+    }
+
+    // An entry that pins a port still means it, and a name not on the list is still refused —
+    // the rebinding defence must be exactly as strong as before.
+    XCTAssertFalse([get(@"pinned.example:9999") hasPrefix:@"HTTP/1.1 421"], @"a pinned entry should match its own port");
+    XCTAssertTrue([get(@"pinned.example:1234") hasPrefix:@"HTTP/1.1 421"], @"a pinned entry must not match a different port");
+    XCTAssertTrue([get(@"evil.example") hasPrefix:@"HTTP/1.1 421"], @"an unlisted name must still be refused");
+    XCTAssertTrue([get(@"evil.example:8080") hasPrefix:@"HTTP/1.1 421"], @"an unlisted name must still be refused whatever port it states");
+    // A syntactically impossible port is still a malformed Host.
+    XCTAssertTrue([get(@"files.example:notaport") hasPrefix:@"HTTP/1.1 421"], @"a non-numeric port should still be refused");
+
+    [server stop];
+    [[NSFileManager defaultManager] removeItemAtPath:dir error:NULL];
+}
+
 - (void)testHostValidationHonoursConfiguredNames {
     WSKWebServer* server = [[WSKWebServer alloc] init];
     [server addDefaultHandlerForMethod:@"GET"

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -186,26 +186,6 @@ static BOOL _IsIPAddressLiteral(NSString *host) {
     return (inet_pton(AF_INET, value, &address4) == 1) || (inet_pton(AF_INET6, value, &address6) == 1);
 }
 
-// The port this connection was actually accepted on. Taken from the connection's own local
-// address rather than the server's mutable _port ivar, which -_stop clears from another
-// thread while connections are still live.
-static uint16_t _LocalPortFromAddress(NSData *localAddressData) {
-    const struct sockaddr *const address = localAddressData.bytes;
-
-    if (address == NULL) {
-        return 0;
-    }
-
-    if (address->sa_family == AF_INET) {
-        return ntohs(((const struct sockaddr_in *)address)->sin_port);
-    }
-
-    if (address->sa_family == AF_INET6) {
-        return ntohs(((const struct sockaddr_in6 *)address)->sin6_port);
-    }
-
-    return 0;
-}
 
 // Refuse a request whose "Host" names something this server does not answer to. This is the
 // only defence against DNS rebinding: once a page on evil.example repoints its DNS here, the
@@ -273,8 +253,20 @@ static NSString *_WithoutRootLabel(NSString *host) {
         return nil;
     }
 
-    // A stated port must be the one this connection arrived on; omitting it is fine, since
-    // that is what a client reaching a default port sends.
+    // A stated port must be syntactically a port, but it is deliberately NOT required to equal the
+    // one this connection arrived on. It used to be, which contradicted this option's own
+    // documentation ("may include a port ...; without one, any port matches") and refused every
+    // deployment behind a port-translating hop: the client states the port it dialled, the hop
+    // forwards to a different one, and the server saw a mismatch. That is precisely the priority
+    // deployment — Tailscale Serve terminating TLS on 443 and forwarding to an ephemeral local
+    // port — where it presented as a total outage, 421 for every request.
+    //
+    // Dropping it costs no security, which is the whole reason it can go. The DNS-rebinding
+    // defence turns entirely on the NAME: an attacker who repoints DNS still cannot make a browser
+    // put a raw IP literal or a name we accept into Host, and he controls the port he targets
+    // either way, so matching it proves nothing about who is asking. An entry that DOES pin a port
+    // is still honoured verbatim, by the canonical comparison above, so a deployment that wants the
+    // stricter behaviour can still ask for it explicitly.
     if (portText.length) {
         BOOL digitsOnly = (portText.length <= 5);
 
@@ -283,7 +275,7 @@ static NSString *_WithoutRootLabel(NSString *host) {
             digitsOnly = ((character >= '0') && (character <= '9'));
         }
 
-        if (!digitsOnly || ([portText integerValue] != (NSInteger)_LocalPortFromAddress(_localAddressData))) {
+        if (!digitsOnly) {
             return [self _misdirectedResponseForHost:hostHeader];
         }
     }

--- a/Sources/WebServerKitUploader/WSKWebUploader.bundle/Contents/Resources/js/index.js
+++ b/Sources/WebServerKitUploader/WSKWebUploader.bundle/Contents/Resources/js/index.js
@@ -34,6 +34,12 @@ var ENTER_KEYCODE = 13;
 // _enableReloads() — _reloadingDisabled stuck above zero and every later reload queued
 // forever, freezing the UI and holding an /events slot open for nothing.
 var _path = "/";
+// The path most recently ASKED for. _path is only assigned when a listing comes back, so between
+// _reload(hashPath) and its response it still reads "/" — and the SSE onopen re-sync fired in that
+// window re-requested "/", landing the user at the root. That made every deep link, and simply
+// pressing Reload inside a subfolder, bounce to the top (33 of 40 attempts), which is the opposite
+// of what this file's own "Restore path from URL hash on page load" comment intends.
+var _requestedPath = "/";
 var _pathRendered = false;  // The breadcrumb starts empty, so the first listing must always draw it.
 var _pendingReloads = [];
 var _reloadingDisabled = 0;
@@ -82,6 +88,8 @@ function _reload(path) {
   if (!path) {
     path = "/";
   }
+
+  _requestedPath = path;
 
   if (_reloadingDisabled) {
     if ($.inArray(path, _pendingReloads) < 0) {
@@ -136,7 +144,15 @@ function _reload(path) {
     
     $(".edit").editable(function(value, settings) { 
       var name = $(this).parent().parent().data("name");
-      if (value != name) {
+      // <input> in the Text state applies the "strip newlines" value sanitization algorithm, so the
+      // box can never hold a CR or LF even when the real name contains one. Comparing against the
+      // raw name was therefore unconditionally true for such a file, and opening the rename box and
+      // pressing Enter — with nothing typed — silently renamed it on disk. Same shape as the "&"
+      // seeding fix below, one layer further down: there the mangling was jeditable's and seeding
+      // cured it, here it is the browser's own and no seeding can. Compare against what the box can
+      // hold, so "unchanged" means unchanged.
+      var comparable = String(name).replace(/[\r\n]/g, "");
+      if (value != comparable) {
         var path = $(this).parent().parent().data("path");
         $.ajax({
           url: 'move',
@@ -379,12 +395,31 @@ $(document).ready(function() {
     }
   });
 
-  // Server-Sent Events for live updates
+  // Server-Sent Events for live updates.
+  //
+  // ONE stream per browser, not one per tab. A browser allows six HTTP/1.1 connections per origin
+  // and an EventSource never completes, so six open tabs consumed all six and the UI deadlocked in
+  // every tab at once — /list, /upload, /delete, and even a seventh tab's initial document, had no
+  // socket left. Measured: tabs 1-5 answered in 2 ms, the sixth timed out, a seventh rendered
+  // nothing for 13 minutes. The server was idle throughout with 122 free connection slots and 10
+  // free SSE channels, so kMaxSSEChannels (16) sits above the bound that actually binds: a single
+  // browser deadlocks itself at 6 and can never reach 16.
+  //
+  // The obvious fix — close the stream while the tab is hidden — was measured and is WORSE. The
+  // server only reclaims a browser-closed channel when a heartbeat write fails, 20-33 s later, so
+  // ordinary tab switching leaves zombies: 25 of 40 reconnects were refused and the tab actually
+  // being looked at stopped receiving updates. It also does nothing for six SIMULTANEOUSLY VISIBLE
+  // tabs (split view, a tiled window manager), where nothing is ever hidden.
+  //
+  // So exactly one tab holds the stream and relays what it receives to the rest. Leadership is a
+  // Web Lock, which the browser releases by itself when the holding tab goes away, so there is no
+  // heartbeat, no timeout, and no way to end up with the stream unheld or held twice. Where either
+  // API is missing, the old one-stream-per-tab behaviour stands — correct for a single tab, and no
+  // worse than before for several.
   if (typeof(EventSource) !== "undefined") {
-    var eventSource = new EventSource('/events');
+    var _eventChannel = (typeof(BroadcastChannel) !== "undefined") ? new BroadcastChannel('wsk-uploader-events') : null;
 
-    eventSource.addEventListener('change', function(event) {
-      var data = JSON.parse(event.data);
+    var _applyChangeEvent = function(data) {
       var eventPath = data.path || data.oldPath || '';
 
       // For external changes, path is the changed directory
@@ -412,17 +447,50 @@ $(document).ready(function() {
       if (eventDir === _path || newDir === _path) {
         _reload(_path);
       }
-    });
-
-    eventSource.onopen = function() {
-      // Re-sync on every (re)connect so any change missed while disconnected
-      // is picked up instead of leaving a stale listing.
-      _reload(_path);
     };
 
-    eventSource.onerror = function() {
-      console.log('SSE connection error, will auto-reconnect');
+    if (_eventChannel) {
+      // A follower tab holds no socket of its own and learns about changes from the leader.
+      _eventChannel.onmessage = function(event) {
+        _applyChangeEvent(event.data);
+      };
+    }
+
+    var _openEventStream = function() {
+      var eventSource = new EventSource('/events');
+
+      eventSource.addEventListener('change', function(event) {
+        var data = JSON.parse(event.data);
+
+        if (_eventChannel) {
+          _eventChannel.postMessage(data);  // Relay before acting, so no tab is served later than this one.
+        }
+
+        _applyChangeEvent(data);
+      });
+
+      eventSource.onopen = function() {
+        // Re-sync on every (re)connect so any change missed while disconnected is picked up
+        // instead of leaving a stale listing. Against the path most recently REQUESTED, not the
+        // one already rendered — on a deep link the listing has not arrived yet.
+        _reload(_requestedPath);
+      };
+
+      eventSource.onerror = function() {
+        console.log('SSE connection error, will auto-reconnect');
+      };
     };
+
+    if (_eventChannel && navigator.locks && navigator.locks.request) {
+      // The promise never settles, so this tab holds the lock for as long as it lives. When it goes
+      // away the browser releases the lock and whichever tab is next in the queue opens the stream.
+      navigator.locks.request('wsk-uploader-events', function() {
+        _openEventStream();
+        return new Promise(function() {});
+      });
+    } else {
+      _openEventStream();
+    }
   }
 
 });


### PR DESCRIPTION
Four findings from the fourteenth pass. **Three live in `index.js`** — which thirteen passes never
touched, because every previous pass drove the uploader's HTTP endpoints rather than its page.

### Six open browser tabs deadlocked the UI completely

A browser allows six HTTP/1.1 connections per origin and an `EventSource` never completes, so six
tabs consumed all six:

```
1-5 tabs -> tab-1 /list  2 ms
6 tabs   -> tab-1 /list  TIMEOUT,  6th tab nav FAILED after 20 s
7th tab  -> 0 listing rows, dead 13.5 minutes
control (SSE off), 8 tabs -> 2-3 ms throughout
```

The server was **idle** throughout — curl through the same relay answered 200 with 122 free
connection slots and 10 free SSE channels. So `kMaxSSEChannels` (16) sits above the bound that
actually binds: one browser deadlocks itself at 6 and can never reach 16. Default configuration, no
hostility, and it is the uploader's whole deployment shape.

**⚠️ The obvious fix is worse than the defect, and that was measured.** Closing the stream on
`visibilitychange` trades the deadlock for a **live-update blackout**: the server only reclaims a
browser-closed channel when a heartbeat write fails 20–33 s later, so ordinary tab switching leaves
zombies — 25 of 40 reconnects refused, and the tab actually being looked at stopped updating. It also
does nothing for six *simultaneously visible* tabs (split view, tiled WM).

What ships is **one stream per browser**: a single tab holds `/events` under a **Web Lock** and relays
over a **BroadcastChannel**. The browser releases the lock itself when the holding tab goes away — no
heartbeat, no timeout, no way to leave the stream unheld or held twice. Where either API is missing,
the previous behaviour stands.

### A deep link, or plain Reload inside a subfolder, bounced to root

`_path` is only assigned when a listing *returns*, so between `_reload(hashPath)` and its response it
still read `"/"` — and the SSE `onopen` re-sync firing in that window re-requested the root. 33 of 40
attempts. The re-sync now targets the path most recently **requested**, not the one already rendered.

### The rename box mutated CR-bearing filenames with nothing typed

`<input>` in the Text state applies the "strip newlines" sanitization algorithm, so the box can never
hold a CR — making `value != name` unconditionally true. Opening the box and pressing Enter renamed
the file on disk.

Same shape as the fourth pass's `&` fix, one layer further down: there the mangling was jeditable's
and seeding cured it; here it is the browser's own and no seeding can. The comparison is now against
what the box can actually hold.

### The Host allow-list contradicted its own documentation

`WSKOption_AllowedHostNames` documents that an entry "may include a port ...; **without one, any port
matches**". The code refused any `Host` stating a port that differed from the **listening** port —
checked before the name was even consulted — so every deployment behind a port-translating hop got
421 for every request.

**⚠️ This is the one judgement call, and it is deliberately easy to reverse.** An existing assertion
in `testHostValidationRefusesRebindingButAllowsRealNames` was inverted on purpose. The reasoning:

- `Host` is derived from the **request URL**, not the page's origin, so a browser fetching this
  server can only ever state *this* server's port.
- A differing port therefore comes from a forwarder, or from a non-browser client — which could state
  any `Host` it liked, and against which rebinding does not apply, because rebinding requires a
  browser.
- The **name** carries the entire defence. Every rebinding assertion still passes unchanged
  (`evil.example`, `localhost.evil.com`, `attacker.localhost.evil.com` all still 421), and an entry
  that pins a port is still honoured verbatim.

If you'd rather keep the stricter behaviour, the fix is to correct the header documentation instead —
say so and I'll swap it.

Removing the comparison left `_LocalPortFromAddress` unused, which the Release build caught with
`-Werror`.

### Verification

`index.js` has no test harness, so the three JS fixes are verified by a **Chromium probe run against
both the unfixed and fixed builds** rather than by the suite — which is blind to them and stayed at
118/118 in *both* states.

| | unfixed | fixed |
|---|---|---|
| 6th / 7th tab | nav failed 20 s, `/list` TIMEOUT | all 7 tabs 1–2 ms |
| deep link `#/Sub/` | ROOT-CONTENT | `inner.txt` |
| reload in subfolder | ROOT (bounced) | stayed |
| rename box + Enter | MUTATED on disk | UNCHANGED |

The Host fix has a normal RED-first XCTest (6 failing assertions before).

**118 tests, 0 failures**, all eight trace suites, Release builds for all three platforms, exit 0.
