### PR TITLE
Undo two regressions of my own, and stop a .DS_Store switching off the extension allow-list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,72 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Full confirmation re-run: every technique at once, and it caught what the individual passes could not
+
+Not a new technique — **all ten technique families re-run simultaneously against tip**, at the owner's
+request, as a sanity check. It was worth far more than expected, and the reason is worth keeping:
+every technique had last run against an OLDER commit, and five PRs had landed since. The individual
+passes each asked "is this correct?"; only running them together against the accumulated result asks
+**"do the repairs hold together?"** — and three times the answer was no.
+
+**Two of the findings were regressions from my own PR #48, and the full harness could not see
+either.** 118 tests, eight recorded trace suites and Release builds on three platforms passed on that
+PR and on every one since.
+
+**Every successful file response logged a false truncation, and gzip on a file response was entirely
+broken.** PR #48's per-chunk verification treated normal end-of-body as a premature EOF: once `_size`
+reaches 0 the read length is 0, so `read(2)` returns 0 for the ordinary reason. A **zero-length
+NSData is the end-of-stream sentinel** both consumers require — `-[WSKConnection
+writeBodyWithCompletionBlock:]` writes the terminal chunk on it and `-[WSKGZipEncoder readData:]`
+selects `Z_FINISH` on it — so returning nil aborted the chain. Measured: gzip broken at all 8 sizes
+from 0 B to 200 KB, chunked stream never terminated, and 8/8 successful responses logging an ERROR
+falsely claiming truncation — destroying the exact signal that change existed to create. Identity
+responses hid it completely, because `Content-Length` had already framed the body. One token:
+`} else {` → `} else if (_size > 0) {`.
+
+**On exFAT, WebDAV MOVE and COPY to any new name answered 403 — rename and duplicate simply did not
+work.** PR #48 swaps with `renamex_np(RENAME_EXCL)` when nothing was vetted, and macOS 15's FSKit
+exFAT returns `ENOTSUP` for it. APFS, FAT32 and HFS+ all implement it, which is exactly why every
+test passed: they run on APFS. Measured on a real exFAT image, 0/10 before and 10/10 after, with zero
+staging residue. The fallback reserves the name itself — `mkdir` for a staged directory,
+`open(O_CREAT|O_EXCL)` otherwise — which gets the same exclusivity, and **fires only on
+ENOTSUP/ENOSYS**: every other errno, `EEXIST` above all, must keep failing or the racing newcomer
+that branch exists to protect gets clobbered. **The proposed fix omitted reclaiming the reservation
+when the following `rename(2)` fails**, which would have left a zero-byte file or empty directory at
+a name the request then refuses — a brand-new residue class, and the seventh instance of a fix
+planting the next defect. What shipped unlinks or rmdirs it and preserves the original errno.
+
+**A dot-file one level down switched off the extension allow-list for the rest of that directory.**
+`-skipDescendants` is defined for the most recently returned SUBDIRECTORY; both subtree walks called
+it for every dot-name including regular FILES, which pops the enclosing level — so every entry after
+the first dot-name in that directory's readdir order was never vetted. A `.DS_Store` sits in every
+Finder-touched folder and sorts early, so this was the ordinary case: `DELETE /Vault` answered 204 and
+destroyed `sub/id_rsa` 60/60, as did the uploader's `/delete` and a MOVE/COPY overwrite, while the
+same file addressed directly is refused 403 by the same server in the same configuration. **The top
+level of the addressed collection is immune, which is why three existing tests looking straight at
+this all pass against the unfixed code** — their fixtures put the victim at the top. Any regression
+test for this class must put it one level down, and the new one does.
+
+This is the **fourth recurrence** of the class the eighth and tenth passes each declared closed, and
+it falsifies the design-priorities sentence "a recursive delete refuses when it would destroy a file
+a direct delete would have refused" for essentially every macOS folder. Pre-existing — established by
+building `e53c43d` and measuring, not by reading the diff. Only a dot-named DIRECTORY is skipped
+wholesale now; that judgement call is deliberate and still holds.
+
+**Still open from this run, deliberately.** The browser reload wedge — a listing arriving while the
+rename box is open leaves `_reloadingDisabled` above zero and the page stops tracking the share — is
+confirmed, but **the proposed fix re-introduces the identical permanent wedge with a negative
+counter**, so it needs a different approach. `WSKFileResponse.lastModifiedDate` being declared
+non-null while nil inside the timestamp bucket is real but its fix is a **source-breaking public API
+change**. Also low and open: an empty header name is accepted; MKCOL answers 500 after creating the
+collection in Debug builds; a header-time refusal can lose its error page body to a TCP reset (the
+status is never lost); `If-Match` on a resource that does not exist answers 404 rather than 412; and
+a MOVE whose swap fails can strand its staged item under an unreachable dot-name.
+
+**The lesson worth carrying: run everything together, periodically.** A per-pass green harness proved
+nothing about the accumulated tree, and the two regressions above sat on `main` through three
+subsequent PRs and their CI runs.
+
 ### Fourteenth audit pass: the browser was never in scope, and that is where the defects were
 
 Four oracles, weighted deliberately toward things outside this project's own reasoning: **static

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1968,6 +1968,88 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// -skipDescendants is defined for the most recently returned SUBDIRECTORY. Both subtree walks called
+// it for every dot-name including regular FILES, which popped the enclosing level instead — so every
+// entry after the first dot-name in that directory's readdir order was never vetted. A ".DS_Store"
+// sits in every Finder-touched folder, so this was the ordinary case: DELETE of a collection holding
+// "sub/{.DS_Store, id_rsa}" answered 204 and destroyed id_rsa, 60/60, while the same file addressed
+// directly is refused 403 by the same server in the same configuration.
+//
+// NOTE THE FIXTURE. The victim MUST be one level down. testDAVRecursiveDeleteRespectsExtensionAllowList,
+// testDAVOverwriteRespectsExtensionAllowList and testUploaderRecursiveDeleteRespectsExtensionAllowList
+// all put theirs at the top of the collection, which is immune — all three pass against the unfixed
+// code, which is exactly why this survived three passes that were looking straight at it.
+- (void)testAllowListVettingSurvivesADotFileInASubdirectory {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+
+    WSKWebDAVServer* dav = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    dav.allowedFileExtensions = @[ @"txt" ];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([dav startWithOptions:options error:NULL]);
+    WSKWebUploader* uploader = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    uploader.allowedFileExtensions = @[ @"txt" ];
+    XCTAssertTrue([uploader startWithOptions:options error:NULL]);
+
+    NSString* vault = [dir stringByAppendingPathComponent:@"Vault"];
+    NSString* sub = [vault stringByAppendingPathComponent:@"sub"];
+    NSString* victim = [sub stringByAppendingPathComponent:@"id_rsa"];
+    void (^rebuild)(void) = ^{
+        [fm removeItemAtPath:vault error:NULL];
+        XCTAssertTrue([fm createDirectoryAtPath:sub withIntermediateDirectories:YES attributes:nil error:NULL]);
+        XCTAssertTrue([@"ok" writeToFile:[vault stringByAppendingPathComponent:@"top.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        // The dot-file precedes the victim in readdir order, which is what suppressed it.
+        XCTAssertTrue([@"junk" writeToFile:[sub stringByAppendingPathComponent:@".DS_Store"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        XCTAssertTrue([@"KEYDATA" writeToFile:victim atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    };
+
+    // The control: addressed directly, this file is refused. The recursive forms must agree.
+    rebuild();
+    XCTAssertTrue([SendRawRequest(dav.port, @"DELETE /Vault/sub/id_rsa HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 403"], @"a direct delete of a disallowed file should be refused");
+
+    NSString* deleted = SendRawRequest(dav.port, @"DELETE /Vault HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 403"], @"DAV DELETE should refuse a collection holding a disallowed file one level down: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:victim], @"the recursive delete destroyed a file a direct delete refuses");
+
+    rebuild();
+    NSString* host = [NSString stringWithFormat:@"localhost:%lu", (unsigned long)uploader.port];
+    NSString* body = @"path=/Vault";
+    NSString* uploaderReply = SendRawRequest(uploader.port, [NSString stringWithFormat:@"POST /delete HTTP/1.1\r\nHost: %@\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: %lu\r\n\r\n%@", host, (unsigned long)body.length, body]);
+    XCTAssertTrue([uploaderReply containsString:@"403"], @"uploader /delete should refuse it too: %@", uploaderReply);
+    XCTAssertTrue([fm fileExistsAtPath:victim], @"the uploader's recursive delete destroyed it");
+
+    // The overwrite form: a collection destination whose name passes the allow-list.
+    rebuild();
+    XCTAssertTrue([fm moveItemAtPath:vault toPath:[dir stringByAppendingPathComponent:@"Backup.txt"] error:NULL]);
+    XCTAssertTrue([@"src" writeToFile:[dir stringByAppendingPathComponent:@"src.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    NSString* moved = SendRawRequest(dav.port, @"MOVE /src.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /Backup.txt\r\nOverwrite: T\r\n\r\n");
+    XCTAssertTrue([moved hasPrefix:@"HTTP/1.1 403"], @"an overwrite should refuse a destination holding a disallowed file one level down: %@", [moved substringToIndex:MIN((NSUInteger)40, moved.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:@"Backup.txt/sub/id_rsa"]], @"the overwrite destroyed it");
+
+    // What must keep working — the eighth pass's two judgement calls, which this must not undo.
+    // A folder whose only extra entry is filesystem noise stays deletable, at any depth...
+    NSString* ordinary = [dir stringByAppendingPathComponent:@"Ordinary"];
+    NSString* ordinarySub = [ordinary stringByAppendingPathComponent:@"sub"];
+    XCTAssertTrue([fm createDirectoryAtPath:ordinarySub withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"ok" writeToFile:[ordinarySub stringByAppendingPathComponent:@"note.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"junk" writeToFile:[ordinarySub stringByAppendingPathComponent:@".DS_Store"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    NSString* allowed = SendRawRequest(dav.port, @"DELETE /Ordinary HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertFalse([allowed hasPrefix:@"HTTP/1.1 403"], @"a nested .DS_Store must not make an ordinary folder undeletable: %@", [allowed substringToIndex:MIN((NSUInteger)40, allowed.length)]);
+    XCTAssertFalse([fm fileExistsAtPath:ordinary], @"the deletable folder was not removed");
+
+    // ...and a hidden DIRECTORY and everything under it is still skipped wholesale.
+    NSString* withHidden = [dir stringByAppendingPathComponent:@"WithHidden"];
+    XCTAssertTrue([fm createDirectoryAtPath:[withHidden stringByAppendingPathComponent:@".git"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"ok" writeToFile:[withHidden stringByAppendingPathComponent:@"note.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"KEY" writeToFile:[withHidden stringByAppendingPathComponent:@".git/id_rsa"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    NSString* hiddenOK = SendRawRequest(dav.port, @"DELETE /WithHidden HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertFalse([hiddenOK hasPrefix:@"HTTP/1.1 403"], @"a hidden directory's contents must still be skipped: %@", [hiddenOK substringToIndex:MIN((NSUInteger)40, hiddenOK.length)]);
+
+    [dav stop];
+    [uploader stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 // CFURLCopyPath() treats '#' as a fragment delimiter and returns only the prefix, and every verb was
 // then honoured against that prefix. '#' is a legal filename character and "MyApp#42.ipa" is an
 // ordinary CI build-number convention, so this needs no malice: three builds published that way

--- a/Sources/WebServerKit/Responses/WSKFileResponse.m
+++ b/Sources/WebServerKit/Responses/WSKFileResponse.m
@@ -431,10 +431,22 @@ static NSString *_EscapeExtValue(NSString *string) {
         if (![self _representationStillMatches:error]) {
             return nil;
         }
-    } else {
-        // result == 0 with bytes still owed is a premature EOF: the file was truncated under us.
+    } else if (_size > 0) {
+        // result == 0 with bytes STILL OWED is a premature EOF: the file was truncated under us.
         // This used to return empty data and report success, ending the body short of the
         // Content-Length already promised — a truncated response the client is told is complete.
+        //
+        // The `_size > 0` is load-bearing and its absence was a regression. Once the body is
+        // complete `_size` is 0, so `length` is 0 and read(2) returns 0 for the ordinary reason —
+        // there was nothing left to ask for. Treating that as truncation returned nil at the end of
+        // EVERY successful file response, which did two things: it logged an error falsely claiming
+        // the file had been truncated, destroying the very signal this check exists to provide; and
+        // because a ZERO-LENGTH NSData is the end-of-stream sentinel both consumers require —
+        // -[WSKConnection writeBodyWithCompletionBlock:] writes the terminal chunk on it, and
+        // -[WSKGZipEncoder readData:] selects Z_FINISH on it — nil aborted the chain instead. That
+        // left gzip on a file response producing an unterminated chunked stream and an undecodable
+        // gzip member at every size measured. Identity responses hid it, because Content-Length had
+        // already framed the body and the client had every byte before the sentinel mattered.
         _size = 0;
 
         if (error) {

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -259,7 +259,12 @@ static BOOL _EntityTagMatchesList(BOOL resourceExists, NSString *currentTag, NSS
         // RFC 850 and asctime spellings §5.6.7 also requires a server to accept parse to nil and
         // the method PROCEEDS. That is shared with If-Modified-Since and If-Range rather than
         // introduced here, so this closes the common spelling and not the whole class.
-        if (stated && (limit != nil) && ((time_t)floor(limit.timeIntervalSince1970) < info.st_mtimespec.tv_sec)) {
+        // Truncated to whole seconds through a named local rather than casting the call directly:
+        // -Weverything's -Wbad-function-cast flags a cast applied to a function result, and this
+        // project builds Debug with it.
+        double const limitSeconds = floor(limit.timeIntervalSince1970);
+
+        if (stated && (limit != nil) && ((time_t)limitSeconds < info.st_mtimespec.tv_sec)) {
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_PreconditionFailed message:@"\"If-Unmodified-Since\" precondition failed for \"%@\"", request.path];
         }
     } else if (_EntityTagMatchesList(stated, currentTag, ifNoneMatch, NO)) {
@@ -309,12 +314,24 @@ static BOOL _EntityTagMatchesList(BOOL resourceExists, NSString *currentTag, NSS
     NSDirectoryEnumerator<NSString *> *const enumerator = [[NSFileManager defaultManager] enumeratorAtPath:absolutePath];
 
     for (NSString *subpath in enumerator) {
+        NSString *const subpathType = [enumerator fileAttributes][NSFileType];
+
         if ([[subpath lastPathComponent] hasPrefix:@"."]) {
-            [enumerator skipDescendants];
+            // -skipDescendants is defined for the most recently returned SUBDIRECTORY. Calling it
+            // for a dot-named FILE popped the enclosing level instead, so every entry after the
+            // first dot-name in that directory's readdir order was never vetted — and a
+            // ".DS_Store" sits in every Finder-touched folder, sorting early. Measured: with an
+            // allow-list of "txt", DELETE of a collection holding "sub/{.DS_Store,id_rsa}"
+            // answered 204 and destroyed id_rsa, 60/60, while the same file addressed directly
+            // is refused 403. The top level of the addressed collection is immune, which is
+            // exactly why the existing tests could not see it. Only a dot-named DIRECTORY may be
+            // skipped wholesale — that part is deliberate and still holds.
+            if ([subpathType isEqualToString:NSFileTypeDirectory]) {
+                [enumerator skipDescendants];
+            }
+
             continue;
         }
-
-        NSString *const subpathType = [enumerator fileAttributes][NSFileType];
 
         if ([subpathType isEqualToString:NSFileTypeRegular] && ![self _checkFileExtension:subpath]) {
             return subpath;
@@ -442,8 +459,63 @@ static NSString *_StagingPathForPath(NSString *path) {
             return YES;
         }
 
+        int const exclusiveError = errno;
+
+        // Not every filesystem implements an exclusive rename. macOS 15's FSKit exFAT returns
+        // ENOTSUP, and with no fallback that made WebDAV MOVE and COPY to any NEW name answer 403
+        // on an exFAT-backed share — 10/10, files and collections alike, i.e. rename and duplicate
+        // simply did not work. APFS, FAT32 and HFS+ all implement it, which is why nothing caught
+        // it until the share was put on a USB stick.
+        //
+        // Reserve the name ourselves instead, which gets the same exclusivity from O_EXCL/mkdir:
+        // both fail with EEXIST if anything occupies the name, so an item that appeared in the
+        // window still survives and the request still refuses. ONLY on ENOTSUP/ENOSYS — every
+        // other errno, EEXIST above all, must keep failing, or the racing newcomer this branch
+        // exists to protect gets clobbered.
+        if ((exclusiveError == ENOTSUP) || (exclusiveError == ENOSYS)) {
+            struct stat stagedInfo;
+            BOOL const stagedIsDirectory = (lstat([stagingPath fileSystemRepresentation], &stagedInfo) == 0) &&
+                                           ((stagedInfo.st_mode & S_IFMT) == S_IFDIR);
+            BOOL reserved;
+
+            if (stagedIsDirectory) {
+                reserved = (mkdir([path fileSystemRepresentation], 0755) == 0);
+            } else {
+                int const descriptor = open([path fileSystemRepresentation], O_WRONLY | O_CREAT | O_EXCL, 0644);
+                reserved = (descriptor >= 0);
+
+                if (reserved) {
+                    close(descriptor);
+                }
+            }
+
+            if (reserved) {
+                if (rename([stagingPath fileSystemRepresentation], [path fileSystemRepresentation]) == 0) {
+                    return YES;
+                }
+
+                // Reclaim the reservation. Without this a failed rename leaves a zero-byte file or
+                // an empty directory at a name the request then refuses — a brand-new residue class
+                // on the failure path, which is exactly what this library says a transaction must
+                // never do. The original errno is what the client is told about.
+                int const renameError = errno;
+
+                if (stagedIsDirectory) {
+                    rmdir([path fileSystemRepresentation]);
+                } else {
+                    unlink([path fileSystemRepresentation]);
+                }
+
+                if (error) {
+                    *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:renameError userInfo:nil];
+                }
+
+                return NO;
+            }
+        }
+
         if (error) {
-            *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:nil];
+            *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:exclusiveError userInfo:nil];
         }
 
         return NO;

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -1551,12 +1551,22 @@ static NSString *_OriginAuthority(NSString *value) {
                 // pathExtension is in no allow-list), so vetting them would make ordinary
                 // directories permanently undeletable. Note this cannot use the shared rule,
                 // which reports NO for everything once hidden items are allowed.
+                NSString *const subpathType = [enumerator fileAttributes][NSFileType];
+
                 if ([[subpath lastPathComponent] hasPrefix:@"."]) {
-                    [enumerator skipDescendants];
+                    // -skipDescendants is defined for the most recently returned SUBDIRECTORY.
+                    // Calling it for a dot-named FILE popped the enclosing level instead, so every
+                    // entry after the first dot-name in that directory's readdir order was never
+                    // vetted at all — and a ".DS_Store" sits in every Finder-touched folder. The
+                    // top level of the addressed collection is immune, which is exactly why the
+                    // existing fixtures could not see it: they put the unvettable file there.
+                    // Only a dot-named DIRECTORY may be skipped wholesale.
+                    if ([subpathType isEqualToString:NSFileTypeDirectory]) {
+                        [enumerator skipDescendants];
+                    }
+
                     continue;
                 }
-
-                NSString *const subpathType = [enumerator fileAttributes][NSFileType];
 
                 // An extensionless file ("README", "LICENSE") is vetted like any other: a
                 // direct DELETE of it is already refused, so letting a recursive delete


### PR DESCRIPTION
Your sanity-check call was right, and my "limited value in retreading" framing was wrong.

Re-running **all ten technique families at once against tip** — rather than one technique per pass —
found three things the individual passes structurally could not. Each technique had last run against
an *older* commit, five PRs had landed since, and only running them together asks whether the
accumulated repairs hold together.

**Two of these are regressions from my own PR #48, and they sat on `main` through three subsequent
PRs.** 118 tests, eight recorded trace suites and Release builds on three platforms were green
through all of it.

### Every successful file response logged a false truncation — and gzip on file responses was broken

| | before | after |
|---|---|---|
| gzip round-trip (8 sizes, 0 B–200 KB) | **BROKEN, all 8** | OK, all 8 |
| chunked stream terminated | **never** | always |
| false "truncated" ERROR on success | **8 / 8** | 0 |

PR #48's per-chunk verification treated normal end-of-body as premature EOF: once `_size` is 0 the
read length is 0, so `read(2)` returns 0 for the ordinary reason. A **zero-length `NSData` is the
end-of-stream sentinel** both consumers require — the connection writes its terminal chunk on it and
`WSKGZipEncoder` selects `Z_FINISH` on it — so returning nil aborted the chain.

Identity responses hid it entirely: `Content-Length` had already framed the body, so the client had
every byte before the sentinel mattered. And the false ERROR destroyed the precise signal that change
existed to create — a log that can no longer distinguish real truncation from ordinary operation.

One token: `} else {` → `} else if (_size > 0) {`. The splice protection PR #48 was written for still
holds (`testFileResponseRefusesToSpliceAFileRewrittenInPlace` passes).

### On exFAT, WebDAV MOVE and COPY to any new name answered 403

```
exFAT, before: MOVE->new 0/10 201   COPY->new 0/10 201   MOVE collection->new 0/10 201
exFAT, after:  MOVE->new 10/10 201  COPY->new 10/10 201  MOVE collection->new 10/10 201   leftovers: 0
```

Rename and duplicate simply did not work on an exFAT-backed share. PR #48 swaps with
`renamex_np(RENAME_EXCL)`; macOS 15's FSKit exFAT returns `ENOTSUP`. APFS, FAT32 and HFS+ all
implement it — which is exactly why every test passed, since they run on APFS. Verified by me on a
real exFAT image in both directions, not just taken from the report.

The fallback reserves the name itself (`mkdir` for a staged directory, `open(O_CREAT|O_EXCL)`
otherwise), getting the same exclusivity from the filesystem. It fires **only on ENOTSUP/ENOSYS** —
every other errno, `EEXIST` above all, must keep failing or the racing newcomer that branch protects
gets clobbered.

**⚠️ The proposed fix omitted reclaiming the reservation when the following `rename(2)` fails**, which
would leave a zero-byte file or empty directory at a name the request then refuses — a new residue
class, and the seventh instance of a fix planting the next defect. This version unlinks/rmdirs it and
preserves the original errno.

### A `.DS_Store` one level down switched off the extension allow-list

`-skipDescendants` is defined for the most recently returned **subdirectory**. Both subtree walks
called it for every dot-name including regular **files**, which pops the enclosing level — so every
entry after the first dot-name in that directory's readdir order was never vetted.

```
DELETE /Vault  (Vault/sub/{.DS_Store, id_rsa})   -> 204, id_rsa destroyed   60/60
DELETE /Vault/sub/id_rsa  (same server, same config) -> 403
```

The uploader's `/delete` and a MOVE/COPY overwrite behave identically. `.DS_Store` is in every
Finder-touched folder and sorts early, so this is the ordinary case.

**The top level of the addressed collection is immune — which is why three existing tests aimed
straight at this pass against the unfixed code.** Their fixtures put the victim at the top. The new
test puts it one level down, which any regression test for this class has to do.

Fourth recurrence of the class the eighth and tenth passes each declared closed. Pre-existing, not a
regression — established by building `e53c43d` and measuring. Only a dot-named *directory* is skipped
wholesale now; that judgement call is deliberate and the test pins it, along with a folder whose only
extra entry is a nested `.DS_Store` staying deletable.

### Verification

**119 tests, 0 failures**, all eight trace suites, Release builds for all three platforms, exit 0.
Both PR #48 regressions are additionally verified by direct probes, because the suite is blind to
them: it has no gzip-on-file-response coverage and runs only on APFS. Also cleared a
`-Wbad-function-cast` warning a clean build surfaced.

### Left open, recorded in CLAUDE.md

The browser reload wedge is confirmed but **the proposed fix re-introduces the same permanent wedge
with a negative counter**, so it needs a different approach. `lastModifiedDate` non-null-but-nil is
real but its fix is a **source-breaking public API change**. Plus five lows.
