### PR TITLE
Treat symlinks as the aliases they are, and put them in the listings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,46 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Symlinks are aliases: decided semantics, not a defect fix
+
+Two owner decisions, implemented together because the eleventh pass's skeptic established that source
+and destination semantics have to be decided as one or the next pass finds the half that was missed.
+
+**A destructive verb now acts on the entry the client NAMED, not on what it points at.** `DELETE
+/latest` where `latest -> build/` used to remove the multi-hundred-megabyte build directory and leave
+the dangling link behind, answering 204; no shell tool behaves that way, and the residue was then
+invisible to every listing and removable by nothing. `rm` removes the alias, `mv a latest` replaces
+it, and reads still FOLLOW it — `GET /latest/app.ipa` is unchanged. Applied to DELETE, and to
+MOVE/COPY on **both** source and destination, in both servers.
+
+**The three dangers the skeptic measured are each addressed rather than accepted.** It resolves
+ONCE — `WSKResolveNamedEntryWithinDirectory()` resolves the PARENT and appends the raw leaf, deriving
+containment and hiddenness from that single observation, so the two-observations shape the eighth
+pass closed is not reopened. The destination side is covered, which the proposed fix left untouched.
+And the "it relaxes the extension allow-list" objection dissolves under these semantics rather than
+being overridden: removing an alias named `x.txt` that points at `id_rsa` does not touch `id_rsa`, so
+refusing it was the wrong answer.
+
+**Containment is exactly as strong**, and that is what the new test asserts hardest: the parent is
+still resolved, so `PUT /escape/x` through a link out of the share is still 403 with nothing landing
+outside, and reads and deletes through it are still refused.
+
+**⚠️ `testSymlinkResolvingToTheShareRootCannotDestroyIt` was deliberately re-pointed.** It asserted
+that `DELETE /self` (where `self -> .`) is REFUSED, because when the resolver substituted the
+resolved path the only safe answer was refusal. Acting on the named entry means the share root is
+never the thing operated on, so the catastrophe it guards — the ninth pass's five-entry share emptied
+to zero by one request — is now impossible **by construction**. The test now asserts that the
+contents survive rather than that the request was refused, which is the property that actually
+matters.
+
+**Symlinks now appear in listings**, classified by what they point at. They were served but omitted
+from all three enumerations, which through a real mounted client is data loss rather than cosmetics:
+`mv` returns 0 having copied only what the listing reported, then deletes the source. A link is only
+advertised when its target resolves INSIDE the share and is a regular file or directory — otherwise
+it would be advertised and then refused on access, which is the same disagreement with the sign
+flipped. Shared through `WSKServableFileTypeAtPath()` so the three enumerators cannot drift.
+
+
 ### Full confirmation re-run: every technique at once, and it caught what the individual passes could not
 
 Not a new technique — **all ten technique families re-run simultaneously against tip**, at the owner's

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1655,17 +1655,37 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     NSString* davRoot = fixture(@"dav");
     WSKWebDAVServer* dav = [[WSKWebDAVServer alloc] initWithUploadDirectory:davRoot];
     XCTAssertTrue([dav startWithOptions:options error:NULL]);
+    // The catastrophe this test exists for is the share being EMPTIED — the ninth pass measured one
+    // unauthenticated request taking a five-entry share to zero. That is now impossible by
+    // construction rather than by a special-case refusal: a destructive verb resolves the PARENT and
+    // acts on the entry the client named, so the share root is never the thing operated on. Removing
+    // the alias itself is the correct answer to "DELETE /self" and is what `rm self` does; the
+    // assertions below therefore check that the CONTENTS survive, not that the request was refused.
     NSString* deleted = SendRawRequest(dav.port, @"DELETE /self HTTP/1.1\r\nHost: localhost\r\n\r\n");
-    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 403"], @"DELETE through a self-referential link: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
-    XCTAssertEqual(count(davRoot), (NSUInteger)5, @"the share was emptied by a DELETE through a link resolving to its root");
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 204"], @"DELETE of a self-referential link should remove the link: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
 
+    for (NSUInteger i = 0; i < 4; i++) {
+        NSString* build = [davRoot stringByAppendingPathComponent:[NSString stringWithFormat:@"build%lu.txt", (unsigned long)i]];
+        XCTAssertTrue([fm fileExistsAtPath:build], @"the share was emptied by a DELETE through a link resolving to its root");
+    }
+
+    XCTAssertEqual(count(davRoot), (NSUInteger)4, @"exactly the alias should have gone");
+
+    // Moving onto the alias replaces the alias. The share's other contents must be untouched.
+    symlink(".", [[davRoot stringByAppendingPathComponent:@"self"] fileSystemRepresentation]);
     NSString* moved = SendRawRequest(dav.port, [NSString stringWithFormat:@"MOVE /build0.txt HTTP/1.1\r\nHost: localhost:%lu\r\nDestination: http://localhost:%lu/self\r\nOverwrite: T\r\n\r\n", (unsigned long)dav.port, (unsigned long)dav.port]);
-    XCTAssertTrue([moved hasPrefix:@"HTTP/1.1 403"], @"MOVE onto a self-referential link: %@", [moved substringToIndex:MIN((NSUInteger)40, moved.length)]);
-    XCTAssertEqual(count(davRoot), (NSUInteger)5, @"the share was replaced by a MOVE onto a link resolving to its root");
+    XCTAssertTrue([moved hasPrefix:@"HTTP/1.1 204"], @"MOVE onto a self-referential link should replace the link: %@", [moved substringToIndex:MIN((NSUInteger)40, moved.length)]);
+
+    for (NSUInteger i = 1; i < 4; i++) {
+        NSString* build = [davRoot stringByAppendingPathComponent:[NSString stringWithFormat:@"build%lu.txt", (unsigned long)i]];
+        XCTAssertTrue([fm fileExistsAtPath:build], @"the share was replaced by a MOVE onto a link resolving to its root");
+    }
+
+    XCTAssertEqualObjects([NSString stringWithContentsOfFile:[davRoot stringByAppendingPathComponent:@"self"] encoding:NSUTF8StringEncoding error:NULL], @"build 0", @"the alias was not replaced by the moved file");
 
     // The ordinary destructive operation must still work, or this has just disabled the feature.
     XCTAssertTrue([SendRawRequest(dav.port, @"DELETE /build1.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 204"], @"an ordinary DELETE stopped working");
-    XCTAssertEqual(count(davRoot), (NSUInteger)4);
+    XCTAssertFalse([fm fileExistsAtPath:[davRoot stringByAppendingPathComponent:@"build1.txt"]], @"an ordinary DELETE did not remove the file");
     [dav stop];
 
     NSString* upRoot = fixture(@"up");
@@ -1673,8 +1693,12 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     XCTAssertTrue([uploader startWithOptions:options error:NULL]);
     NSString* body = @"path=%2Fself";
     NSString* reply = SendRawRequest(uploader.port, [NSString stringWithFormat:@"POST /delete HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: %lu\r\n\r\n%@", (unsigned long)body.length, body]);
-    XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 403"], @"the uploader deleted through a self-referential link: %@", [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
-    XCTAssertEqual(count(upRoot), (NSUInteger)5, @"the share was emptied by /delete through a link resolving to its root");
+    XCTAssertTrue([reply containsString:@"200"], @"the uploader should remove the alias: %@", [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+
+    for (NSUInteger i = 0; i < 4; i++) {
+        NSString* build = [upRoot stringByAppendingPathComponent:[NSString stringWithFormat:@"build%lu.txt", (unsigned long)i]];
+        XCTAssertTrue([fm fileExistsAtPath:build], @"the share was emptied by /delete through a link resolving to its root");
+    }
 
     // Listing the root by name is still an ordinary operation and must not be caught by this.
     XCTAssertTrue([SendRawRequest(uploader.port, @"GET /list?path=/ HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 200"], @"listing the share root stopped working");
@@ -1966,6 +1990,79 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 
     [server stop];
     [fm removeItemAtPath:dir error:NULL];
+}
+
+// A symlink is an alias, so the verbs that REMOVE or RELOCATE one act on the entry the client named
+// rather than on what it points at — `rm latest` removes the link, `mv a latest` replaces it — while
+// reads still follow it. DELETE used to remove the multi-hundred-megabyte build directory and leave
+// the dangling link behind, answering 204; no shell tool behaves that way, and the residue was then
+// invisible to every listing and removable by nothing.
+//
+// And a symlink is now LISTED, classified by what it points at. It was served but omitted from all
+// three enumerations, which through a real mounted client is data loss rather than cosmetics: `mv`
+// returns 0 having copied only what the listing reported, then deletes the source.
+//
+// The dangerous part of this change is that it must not weaken containment, so that is asserted
+// hardest: the parent is still resolved, so an escape through an intermediate link is still refused.
+- (void)testSymlinksAreAliasesToDestructiveVerbsAndAppearInListings {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* parent = MakeTempDirectory();
+    NSString* dir = [parent stringByAppendingPathComponent:@"share"];
+    NSString* outside = [parent stringByAppendingPathComponent:@"outside"];
+    XCTAssertTrue([fm createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([fm createDirectoryAtPath:outside withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"SECRET" writeToFile:[outside stringByAppendingPathComponent:@"o.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    NSString* build = [dir stringByAppendingPathComponent:@"build"];
+    XCTAssertTrue([fm createDirectoryAtPath:build withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"BUILD" writeToFile:[build stringByAppendingPathComponent:@"app.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([fm createSymbolicLinkAtPath:[dir stringByAppendingPathComponent:@"latest"] withDestinationPath:@"build" error:NULL]);
+    XCTAssertTrue([fm createSymbolicLinkAtPath:[dir stringByAppendingPathComponent:@"escape"] withDestinationPath:outside error:NULL]);
+
+    WSKWebDAVServer* dav = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([dav startWithOptions:options error:NULL]);
+
+    // Reading still FOLLOWS the link — that is what a link is for.
+    XCTAssertTrue([SendRawRequest(dav.port, @"GET /latest/app.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"BUILD"], @"reading through a symlink stopped working");
+
+    // The listing now advertises it, classified as the directory it points at.
+    NSString* listing = SendRawRequest(dav.port, @"PROPFIND / HTTP/1.1\r\nHost: localhost\r\nDepth: 1\r\n\r\n");
+    XCTAssertTrue([listing containsString:@"latest"], @"a served symlink must appear in the listing: %@", [listing substringToIndex:MIN((NSUInteger)200, listing.length)]);
+    // ...but one pointing OUT of the share is not servable, so it is not advertised either.
+    XCTAssertFalse([listing containsString:@"escape"], @"a symlink out of the share must not be advertised");
+
+    // DELETE removes the ALIAS and preserves the target.
+    NSString* deleted = SendRawRequest(dav.port, @"DELETE /latest HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 204"], @"deleting a symlink should succeed: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+    struct stat info;
+    XCTAssertNotEqual(lstat([[dir stringByAppendingPathComponent:@"latest"] fileSystemRepresentation], &info), 0, @"the link itself was not removed");
+    XCTAssertTrue([fm fileExistsAtPath:[build stringByAppendingPathComponent:@"app.txt"]], @"deleting the alias destroyed the target it pointed at");
+
+    // MOVE renames the alias rather than the target.
+    XCTAssertTrue([fm createSymbolicLinkAtPath:[dir stringByAppendingPathComponent:@"current"] withDestinationPath:@"build" error:NULL]);
+    NSString* moved = SendRawRequest(dav.port, @"MOVE /current HTTP/1.1\r\nHost: localhost\r\nDestination: /renamed\r\n\r\n");
+    XCTAssertTrue([moved hasPrefix:@"HTTP/1.1 201"], @"moving a symlink should succeed: %@", [moved substringToIndex:MIN((NSUInteger)40, moved.length)]);
+    XCTAssertEqual(lstat([[dir stringByAppendingPathComponent:@"renamed"] fileSystemRepresentation], &info), 0, @"the renamed alias is missing");
+    XCTAssertTrue([fm fileExistsAtPath:build], @"the move relocated the target instead of the alias");
+
+    // Moving ONTO an alias replaces the alias, not what it points at — the destination side.
+    XCTAssertTrue([@"NEW" writeToFile:[dir stringByAppendingPathComponent:@"new.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    NSString* onto = SendRawRequest(dav.port, @"MOVE /new.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /renamed\r\nOverwrite: T\r\n\r\n");
+    XCTAssertTrue([onto hasPrefix:@"HTTP/1.1 204"], @"moving onto a symlink should replace it: %@", [onto substringToIndex:MIN((NSUInteger)40, onto.length)]);
+    XCTAssertTrue([fm fileExistsAtPath:[build stringByAppendingPathComponent:@"app.txt"]], @"moving onto an alias destroyed the directory it pointed at");
+    XCTAssertEqualObjects([NSString stringWithContentsOfFile:[dir stringByAppendingPathComponent:@"renamed"] encoding:NSUTF8StringEncoding error:NULL], @"NEW", @"the alias was not replaced by the moved file");
+
+    // CONTAINMENT MUST BE EXACTLY AS STRONG. The parent is still resolved, so a write or a read
+    // through a link that leaves the share is still refused, and the outside file is untouched.
+    XCTAssertTrue([SendRawRequest(dav.port, @"PUT /escape/planted.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 3\r\n\r\nBAD") hasPrefix:@"HTTP/1.1 403"], @"a write through an escaping symlink must still be refused");
+    XCTAssertFalse([fm fileExistsAtPath:[outside stringByAppendingPathComponent:@"planted.txt"]], @"a write landed outside the share");
+    XCTAssertFalse([SendRawRequest(dav.port, @"GET /escape/o.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"SECRET"], @"a read through an escaping symlink must still be refused");
+    XCTAssertTrue([SendRawRequest(dav.port, @"DELETE /escape/o.txt HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 403"], @"a delete through an escaping symlink must still be refused");
+    XCTAssertTrue([fm fileExistsAtPath:[outside stringByAppendingPathComponent:@"o.txt"]], @"a delete reached outside the share");
+
+    [dav stop];
+    [fm removeItemAtPath:parent error:NULL];
 }
 
 // -skipDescendants is defined for the most recently returned SUBDIRECTORY. Both subtree walks called

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -182,6 +182,47 @@ BOOL WSKResolvedPathIsWithinDirectory(NSString *path, NSString *directory);
  */
 NSString *_Nullable WSKResolveWithinDirectory(NSString *path, NSString *directory, NSString *_Nullable __autoreleasing *_Nullable outRelativePath);
 
+/**
+ *  Like WSKResolveWithinDirectory(), but returns the entry the client NAMED rather than what that
+ *  entry points at: the parent is resolved, and the final component is appended raw.
+ *
+ *  Read paths want the target — `GET /latest/app.ipa` should follow the link, and does. Verbs that
+ *  REMOVE or RELOCATE an entry want the entry, because that is what `rm`, `mv` and `cp -P` do and
+ *  what a user means: `DELETE /latest` used to remove the multi-hundred-megabyte build directory
+ *  the link pointed at and leave the dangling link behind, answering 204. No shell tool behaves
+ *  that way, and the residue was then invisible to every listing and removable by nothing.
+ *
+ *  The PARENT is resolved, and the containment and hidden-item verdicts are both derived from that
+ *  one observation, exactly as WSKResolveWithinDirectory() does for the full path. That matters:
+ *  resolving once for the verdict and again for the path to act on is the two-observations shape
+ *  the eighth pass closed and this file names as the form that will recur. It also keeps the
+ *  eighth pass's protection intact — `PUT /link/x` where `link` retargets outside is still refused,
+ *  because the escape is in the parent and the parent is still resolved.
+ *
+ *  Unlinking or renaming a symlink never touches its target, so a link pointing outside the share
+ *  is safe to remove: the entry itself lives inside. Returns nil when the parent does not resolve
+ *  inside `directory`, or when `path` names the directory itself (which has no final component to
+ *  keep, and which every destructive verb must refuse anyway).
+ */
+NSString *_Nullable WSKResolveNamedEntryWithinDirectory(NSString *path, NSString *directory, NSString *_Nullable __autoreleasing *_Nullable outRelativePath);
+
+/**
+ *  The NSFileType an enumeration should CLASSIFY `path` as, which for a symlink is the type of what
+ *  it points at — or nil when nothing servable is there.
+ *
+ *  `-attributesOfItemAtPath:` does not follow links, so a symlink is neither NSFileTypeRegular nor
+ *  NSFileTypeDirectory and fell out of all three listings while the same servers happily served
+ *  through it. That disagreement is the one this project has now fixed twice in the opposite
+ *  direction, and through a real mounted client it is data loss rather than cosmetics: `mv` returns
+ *  0 having copied only what the listing reported, then deletes the source, so the entries it never
+ *  saw are gone.
+ *
+ *  A link is only classified when its target resolves INSIDE `directory` — otherwise it would be
+ *  advertised and then refused on access, which is the same disagreement with the sign flipped. A
+ *  dangling link resolves to nothing and is likewise not classified.
+ */
+NSString *_Nullable WSKServableFileTypeAtPath(NSString *path, NSString *directory);
+
 NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory);
 
 /**

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -582,6 +582,74 @@ NSString *WSKResolveWithinDirectory(NSString *path, NSString *directory, NSStrin
     return resolvedPath;
 }
 
+NSString *WSKServableFileTypeAtPath(NSString *path, NSString *directory) {
+    NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:NULL];
+    NSString *const type = attributes[NSFileType];
+
+    if (![type isEqualToString:NSFileTypeSymbolicLink]) {
+        return type;
+    }
+
+    // Judge the link by what it points at, and only when that is something this server would
+    // actually serve: inside the directory, and a regular file or a directory itself.
+    if (!WSKResolvedPathIsWithinDirectory(path, directory)) {
+        return nil;
+    }
+
+    struct stat info;
+
+    if (stat([path fileSystemRepresentation], &info) != 0) {
+        return nil;  // Dangling, or a loop: there is nothing to advertise.
+    }
+
+    if ((info.st_mode & S_IFMT) == S_IFDIR) {
+        return NSFileTypeDirectory;
+    }
+
+    if ((info.st_mode & S_IFMT) == S_IFREG) {
+        return NSFileTypeRegular;
+    }
+
+    return nil;
+}
+
+NSString *WSKResolveNamedEntryWithinDirectory(NSString *path, NSString *directory, NSString *__autoreleasing *outRelativePath) {
+    if (outRelativePath) {
+        *outRelativePath = nil;
+    }
+
+    NSString *const leaf = [path lastPathComponent];
+    NSString *const parent = [path stringByDeletingLastPathComponent];
+
+    // No final component to preserve — "/" and the directory itself. Every destructive verb
+    // refuses the root separately, so returning nil here is the same answer by a shorter route.
+    if ((leaf.length == 0) || [leaf isEqualToString:@"/"] || (parent.length == 0)) {
+        return nil;
+    }
+
+    NSString *const resolvedParent = _RealPath(parent);
+    NSString *const resolvedDirectory = _RealPath(directory);
+
+    if ((resolvedParent == nil) || (resolvedDirectory == nil)) {
+        return nil;  // Fail closed rather than acting on a path we could not verify.
+    }
+
+    if (![resolvedParent isEqualToString:resolvedDirectory] && !WSKPathIsInsideDirectory(resolvedParent, resolvedDirectory)) {
+        return nil;
+    }
+
+    NSString *const namedPath = [resolvedParent stringByAppendingPathComponent:leaf];
+
+    if (outRelativePath) {
+        NSString *const parentRelative = [resolvedParent isEqualToString:resolvedDirectory]
+                                             ? @""
+                                             : [resolvedParent substringFromIndex:(resolvedDirectory.length + ([resolvedDirectory hasSuffix:@"/"] ? 0 : 1))];
+        *outRelativePath = (parentRelative.length == 0) ? leaf : [parentRelative stringByAppendingPathComponent:leaf];
+    }
+
+    return namedPath;
+}
+
 NSString *WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory) {
     NSString *const resolvedPath = _RealPath(path);
     // Resolve the directory too: /var is itself a symlink to /private/var on Apple

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1530,7 +1530,12 @@ static NSString *_EscapeHTMLString(NSString *string) {
         // disagreement, in the opposite direction, that the sixth pass fixed by refusing to
         // serve what this listing hid.
         if (includeHiddenItems || ![entry hasPrefix:@"."]) {
-            NSString *const type = [[NSFileManager defaultManager] attributesOfItemAtPath:[path stringByAppendingPathComponent:entry] error:NULL][NSFileType];
+            // Classified by what a symlink points at, so the index describes what is actually
+            // served — the same "the listing must agree with the handler" rule the sixth and
+            // eighth passes each fixed in the other direction. A link out of the served root, or
+            // a dangling one, classifies as nothing and stays unlisted, because that is what the
+            // handler would refuse.
+            NSString *const type = WSKServableFileTypeAtPath([path stringByAppendingPathComponent:entry], path);
 
             // Any process can delete the entry between the directory read above and this
             // stat, so a missing type is an ordinary race, not a logic error to assert on.

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -348,6 +348,55 @@ static BOOL _EntityTagMatchesList(BOOL resourceExists, NSString *currentTag, NSS
 // observation, and act on the returned path rather than the one the client sent. A symlink
 // retargeted between two independent resolutions served content from outside the share and
 // landed a PUT outside it.
+// The same resolution, but yielding the entry the client NAMED rather than what it points at —
+// see WSKResolveNamedEntryWithinDirectory(). Used by the verbs that REMOVE or RELOCATE an entry
+// (DELETE, and MOVE/COPY on both their source and their destination), because `rm latest` removes
+// the alias and `mv a latest` replaces it; only reads follow a link. The NUL guard, the
+// containment check, the hidden-item rule and the refusal to act on the root all still apply, and
+// all still come from a single resolution.
+- (nullable NSString *)_namedEntryPathForRelativePath:(NSString *)relativePath hidden:(BOOL *)outHidden {
+    if (WSKPathContainsNULByte(relativePath)) {
+        return nil;
+    }
+
+    NSString *const normalizedPath = WSKNormalizePath(relativePath);
+
+    if (outHidden) {
+        *outHidden = NO;
+    }
+
+    // Naming the root itself is not something a destructive verb may act on, and there is no
+    // final component to preserve either.
+    if ((normalizedPath.length == 0) || [normalizedPath isEqualToString:@"/"]) {
+        return nil;
+    }
+
+    NSString *namedRelativePath = nil;
+    NSString *const namedPath = WSKResolveNamedEntryWithinDirectory([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory, &namedRelativePath);
+
+    if (namedPath == nil) {
+        return nil;
+    }
+
+    if (outHidden && !_allowHiddenItems) {
+        for (NSString *component in [normalizedPath pathComponents]) {
+            if ([component hasPrefix:@"."]) {
+                *outHidden = YES;
+                return namedPath;
+            }
+        }
+
+        for (NSString *component in [namedRelativePath pathComponents]) {
+            if ([component hasPrefix:@"."]) {
+                *outHidden = YES;
+                return namedPath;
+            }
+        }
+    }
+
+    return namedPath;
+}
+
 - (nullable NSString *)_resolvedPathForRelativePath:(NSString *)relativePath hidden:(BOOL *)outHidden {
     // WSKNormalizePath truncates at an embedded NUL — deliberately, because the filesystem's
     // C-string APIs do and the mismatch is otherwise exploitable. But truncating does not make
@@ -765,7 +814,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     // Deleting is destructive, so also confirm the resolved target is inside the share
     // rather than whatever a symlink points to outside it.
     BOOL isHidden = NO;
-    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+    NSString *const resolvedPath = [self _namedEntryPathForRelativePath:relativePath hidden:&isHidden];
 
     if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed", relativePath];
@@ -987,8 +1036,8 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     // falls back to its parent.
     BOOL srcIsHidden = NO;
     BOOL dstIsHidden = NO;
-    NSString *const resolvedSrcPath = [self _resolvedPathForRelativePath:srcRelativePath hidden:&srcIsHidden];
-    NSString *const resolvedDstPath = [self _resolvedPathForRelativePath:dstRelativePath hidden:&dstIsHidden];
+    NSString *const resolvedSrcPath = [self _namedEntryPathForRelativePath:srcRelativePath hidden:&srcIsHidden];
+    NSString *const resolvedDstPath = [self _namedEntryPathForRelativePath:dstRelativePath hidden:&dstIsHidden];
 
     if ((resolvedSrcPath == nil) || (resolvedDstPath == nil)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"%@ \"%@\" to \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", srcRelativePath, dstRelativePath];
@@ -1163,7 +1212,8 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
 
     if (escapedPath) {
         NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:itemPath error:NULL];
-        NSString *const type = attributes[NSFileType];
+        // Classified by what a symlink points at, so the listing describes what is actually served.
+        NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory);
         BOOL isFile = [type isEqualToString:NSFileTypeRegular];
         BOOL isDirectory = [type isEqualToString:NSFileTypeDirectory];
 

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -965,6 +965,55 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 //
 // Returns nil when the path does not resolve inside the share. Sets *outHidden when the
 // resolved location — or the path the client typed — lies inside a hidden item.
+// The same resolution, but yielding the entry the client NAMED rather than what it points at —
+// see WSKResolveNamedEntryWithinDirectory(). Used by the verbs that REMOVE or RELOCATE an entry
+// (DELETE, and MOVE/COPY on both their source and their destination), because `rm latest` removes
+// the alias and `mv a latest` replaces it; only reads follow a link. The NUL guard, the
+// containment check, the hidden-item rule and the refusal to act on the root all still apply, and
+// all still come from a single resolution.
+- (nullable NSString *)_namedEntryPathForRelativePath:(NSString *)relativePath hidden:(BOOL *)outHidden {
+    if (WSKPathContainsNULByte(relativePath)) {
+        return nil;
+    }
+
+    NSString *const normalizedPath = WSKNormalizePath(relativePath);
+
+    if (outHidden) {
+        *outHidden = NO;
+    }
+
+    // Naming the root itself is not something a destructive verb may act on, and there is no
+    // final component to preserve either.
+    if ((normalizedPath.length == 0) || [normalizedPath isEqualToString:@"/"]) {
+        return nil;
+    }
+
+    NSString *namedRelativePath = nil;
+    NSString *const namedPath = WSKResolveNamedEntryWithinDirectory([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory, &namedRelativePath);
+
+    if (namedPath == nil) {
+        return nil;
+    }
+
+    if (outHidden && !_allowHiddenItems) {
+        for (NSString *component in [normalizedPath pathComponents]) {
+            if ([component hasPrefix:@"."]) {
+                *outHidden = YES;
+                return namedPath;
+            }
+        }
+
+        for (NSString *component in [namedRelativePath pathComponents]) {
+            if ([component hasPrefix:@"."]) {
+                *outHidden = YES;
+                return namedPath;
+            }
+        }
+    }
+
+    return namedPath;
+}
+
 - (nullable NSString *)_resolvedPathForRelativePath:(NSString *)relativePath hidden:(BOOL *)outHidden {
     NSString *const normalizedPath = WSKNormalizePath(relativePath);
     NSString *resolvedRelativePath = nil;
@@ -1124,9 +1173,16 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 
     for (NSString *item in [contents sortedArrayUsingSelector:@selector(localizedStandardCompare:)]) {
         if (_allowHiddenItems || ![item hasPrefix:@"."]) {
-            NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[absolutePath stringByAppendingPathComponent:item] error:NULL];
-            NSString *const type = attributes[NSFileType];
-            NSNumber *const size = attributes[NSFileSize];  // Nil if the item vanished between the listing and this stat; must not reach the literal below.
+            NSString *const itemPath = [absolutePath stringByAppendingPathComponent:item];
+            NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:itemPath error:NULL];
+            // Classified by what a symlink points at, so the listing describes what is served.
+            NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory);
+            // A symlink's own attributes report the length of its target PATH, not the file, so
+            // ask again through the link for anything classified as a regular file.
+            NSDictionary *const effective = [attributes[NSFileType] isEqualToString:NSFileTypeSymbolicLink]
+                                                ? [[NSFileManager defaultManager] attributesOfItemAtPath:[itemPath stringByResolvingSymlinksInPath] error:NULL]
+                                                : attributes;
+            NSNumber *const size = effective[NSFileSize];  // Nil if the item vanished between the listing and this stat; must not reach the literal below.
 
             if ([type isEqualToString:NSFileTypeRegular] && size && [self _checkFileExtension:item]) {
                 [array addObject:@{
@@ -1405,8 +1461,8 @@ static NSString *_OriginAuthority(NSString *value) {
     // into plain view, and a move into one would smuggle files past the same guard.
     BOOL oldIsHidden = NO;
     BOOL newIsHidden = NO;
-    NSString *const resolvedOldPath = [self _resolvedPathForRelativePath:oldRelativePath hidden:&oldIsHidden];
-    NSString *const resolvedNewPath = [self _resolvedPathForRelativePath:newRelativePath hidden:&newIsHidden];
+    NSString *const resolvedOldPath = [self _namedEntryPathForRelativePath:oldRelativePath hidden:&oldIsHidden];
+    NSString *const resolvedNewPath = [self _namedEntryPathForRelativePath:newRelativePath hidden:&newIsHidden];
 
     if ((resolvedOldPath == nil) || (resolvedNewPath == nil)) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Moving \"%@\" to \"%@\" is not allowed", oldRelativePath, newRelativePath];
@@ -1508,7 +1564,7 @@ static NSString *_OriginAuthority(NSString *value) {
     // Deleting is destructive, so resolve once and destroy exactly what was vetted: a symlink
     // retargeted between the check and the unlink would otherwise decide what gets removed.
     BOOL isHidden = NO;
-    NSString *const resolvedPath = [self _resolvedPathForRelativePath:relativePath hidden:&isHidden];
+    NSString *const resolvedPath = [self _namedEntryPathForRelativePath:relativePath hidden:&isHidden];
 
     if (resolvedPath == nil) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed", relativePath];


### PR DESCRIPTION
Decisions **1** and **2** from your list, implemented together — the eleventh pass established that
symlink source and destination semantics have to be decided as one, or the next pass finds the half
that was missed.

### A destructive verb acts on the entry you named, not what it points at

`DELETE /latest` where `latest -> build/` used to remove the **build directory** and leave the
dangling link, answering 204. `rm` removes the alias. Now so does this — and `mv a latest` replaces
the alias rather than writing through it. **Reads still follow the link**: `GET /latest/app.ipa` is
unchanged. Applied to DELETE, and MOVE/COPY on **both source and destination**, in both servers.

The three dangers a skeptic measured against the originally proposed version are each addressed
rather than accepted:

- **Resolves once.** `WSKResolveNamedEntryWithinDirectory()` resolves the *parent* and appends the raw
  leaf, deriving containment and hiddenness from that single observation — so the two-observations
  shape the eighth pass closed is not reopened.
- **Destination side covered.** The proposal left it untouched, where `MOVE /new.txt` with
  `Destination: /latest` still replaced a whole build directory with a 3-byte file.
- **The "it relaxes the allow-list" objection dissolves** under these semantics rather than being
  overridden: removing an alias named `x.txt` that points at `id_rsa` doesn't touch `id_rsa`, so
  refusing it was the wrong answer.

**Containment is exactly as strong**, and the test asserts that hardest because it's what this change
could plausibly break — the parent is still resolved, so `PUT /escape/x` through a link out of the
share is still 403 with nothing landing outside, and reads and deletes through it are still refused.

### ⚠️ One existing test was deliberately re-pointed

`testSymlinkResolvingToTheShareRootCannotDestroyIt` asserted that `DELETE /self` (where `self -> .`)
is **refused** — correct when the resolver substituted the resolved path, because refusal was the only
safe answer available.

Acting on the named entry means the share root is never the thing operated on, so the catastrophe that
test exists for — the ninth pass measured one unauthenticated request emptying a five-entry share to
**zero** — is now impossible *by construction* rather than by a special-case guard. It now asserts
that **the contents survive**, which is the property that actually matters, and still pins that an
ordinary delete works and listing the root is unaffected.

### Symlinks appear in listings

They were **served but omitted** from all three enumerations. Through a real mounted client that's data
loss, not cosmetics: `mv` returns 0 having copied only what the listing reported, then deletes the
source.

A link is advertised only when its target resolves **inside** the share and is a regular file or
directory — otherwise it'd be advertised then refused on access, the same disagreement with the sign
flipped. Shared through `WSKServableFileTypeAtPath()` so the three enumerators can't drift, which is
how this disagreement arose twice before.

### Verification

RED first: 8 failing assertions before the change (listing omission, DELETE hitting the target, MOVE
relocating the target, MOVE-onto destroying the pointed-at directory) — while the containment
assertions passed *both* before and after.

**120 tests, 0 failures**, all eight trace suites, Release builds for all three platforms.

Still to come from your list: **3** (WebDAV class 1, its own PR with the trace corpus re-recorded) and
**4** (the `lastModifiedDate` nullability break).
