### PR TITLE
Make PROPFIND tell the truth about properties it cannot return, and accept the Depth spellings the RFC defines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,46 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### WebDAV class 1, part one: PROPFIND completeness and method semantics
+
+WebDAV was only partially promised in the original README, so this is **new capability rather than
+repair** — the gaps below are undocumented scope, not regressions. Split from `PROPPATCH`, which
+needs a dead-property storage design of its own, so each half stays reviewable.
+
+**A property that cannot be returned now gets its own propstat with 404.** The old model was a
+bitmask of the four live properties and an unrecognised name was logged and dropped, so a client
+asking for three properties and receiving one was told `HTTP/1.1 200 OK` over a `<prop>` that
+silently omitted the rest — unable to tell "this property does not exist here" from "it exists and is
+empty", which is the distinction the propstat structure exists to draw. Requested names are now
+remembered, with their namespace, so a client asking in its own namespace sees that name back rather
+than a `DAV:`-qualified guess.
+
+**`<propname/>` is supported** — it returns the names with empty values, and used to be refused with
+400, telling a client its perfectly legal request was malformed.
+
+**`Depth: infinity` on PROPFIND answers 403 with `<DAV:propfind-finite-depth/>`**, the
+machine-readable precondition RFC 4918 §9.1 defines for exactly this refusal, instead of a bare 400.
+
+**`Depth: 0` is accepted on COPY and DELETE.** For a resource with no internal members it cannot mean
+anything else, and refusing it meant a client that sets Depth uniformly could not delete or copy a
+single FILE at all. An unrecognised Depth is still refused.
+
+**`Allow` is sent on OPTIONS and on the 405**, the latter required by RFC 9110 §15.5.6.
+
+**⚠️ The trace corpus needed re-recording, exactly as predicted, and one recording was a lie worth
+keeping.** Four OPTIONS recordings gained the `Allow` header. The fifth is the interesting one:
+Finder asks for four quota properties, and the recorded response was `207` carrying
+`<D:propstat><D:prop></D:prop><D:status>HTTP/1.1 200 OK</D:status>` — "OK" over nothing. That is the
+dishonesty this change fixes, preserved in the corpus since 2014. Re-recorded by reconstructing the
+body and **validating the method against the OLD byte count first** (208 reconstructed = 208
+recorded) before trusting the new one (364 = 364 emitted).
+
+**A live Apple WebDAV client was driven against the change**, because CLAUDE.md records that the
+corpus proves recorded replay and "cannot prove live-client tolerance" — the class that broke Finder
+when the sixth pass first tightened `If-Range`. Mounted with `mount_webdav`, then list, read, write,
+read-back, mkdir, rename, delete and rmdir all succeeded, and it unmounted clean.
+
+
 ### Symlinks are aliases: decided semantics, not a defect fix
 
 Two owner decisions, implemented together because the eleventh pass's skeptic established that source

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1992,6 +1992,60 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// RFC 4918 class 1 completeness, minus PROPPATCH which needs storage of its own. Each of these was
+// a documented MUST that this server did not meet while OPTIONS advertised "DAV: 1".
+- (void)testDAVClassOnePropfindAndDepthSemantics {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    XCTAssertTrue([@"data" writeToFile:[dir stringByAppendingPathComponent:@"f.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([fm createDirectoryAtPath:[dir stringByAppendingPathComponent:@"coll"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* (^propfind)(NSString*, NSString*) = ^(NSString* depth, NSString* body) {
+        return SendRawRequest(server.port, [NSString stringWithFormat:@"PROPFIND /f.txt HTTP/1.1\r\nHost: localhost\r\nDepth: %@\r\nContent-Type: application/xml\r\nContent-Length: %lu\r\n\r\n%@", depth, (unsigned long)body.length, body]);
+    };
+
+    // A property that cannot be returned gets its own propstat with 404, rather than being dropped
+    // from a <prop> the response then declares "200 OK".
+    NSString* mixed = propfind(@"0", @"<?xml version=\"1.0\"?><D:propfind xmlns:D=\"DAV:\"><D:prop><D:getcontentlength/><D:getetag/><X:custom xmlns:X=\"urn:example\"/></D:prop></D:propfind>");
+    XCTAssertTrue([mixed hasPrefix:@"HTTP/1.1 207"], @"PROPFIND stopped working: %@", [mixed substringToIndex:MIN((NSUInteger)40, mixed.length)]);
+    XCTAssertTrue([mixed containsString:@"getcontentlength"], @"the supported property is missing");
+    XCTAssertTrue([mixed containsString:@"404 Not Found"], @"an unavailable property must be reported in a 404 propstat: %@", mixed);
+    XCTAssertTrue([mixed containsString:@"getetag"], @"the unavailable property must be named back");
+    XCTAssertTrue([mixed containsString:@"urn:example"], @"a foreign namespace must survive into the 404 propstat");
+
+    // <propname/> returns the names with empty values, and used to be refused with 400.
+    NSString* names = propfind(@"0", @"<?xml version=\"1.0\"?><D:propfind xmlns:D=\"DAV:\"><D:propname/></D:propfind>");
+    XCTAssertTrue([names hasPrefix:@"HTTP/1.1 207"], @"propname should be supported: %@", [names substringToIndex:MIN((NSUInteger)40, names.length)]);
+    XCTAssertTrue([names containsString:@"getcontentlength"], @"propname must list the property names");
+    XCTAssertFalse([names containsString:@"404"], @"propname reports names, not failures: %@", names);
+
+    // Depth: infinity is refused with the machine-readable precondition RFC 4918 §9.1 defines.
+    NSString* infinite = propfind(@"infinity", @"<?xml version=\"1.0\"?><D:propfind xmlns:D=\"DAV:\"><D:allprop/></D:propfind>");
+    XCTAssertTrue([infinite hasPrefix:@"HTTP/1.1 403"], @"an infinite-depth PROPFIND should be 403: %@", [infinite substringToIndex:MIN((NSUInteger)40, infinite.length)]);
+    XCTAssertTrue([infinite containsString:@"propfind-finite-depth"], @"the refusal must carry the precondition element: %@", infinite);
+
+    // Depth: 0 is meaningless for a plain file, so it must not make DELETE or COPY unusable.
+    XCTAssertTrue([SendRawRequest(server.port, @"COPY /f.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /copy.txt\r\nDepth: 0\r\n\r\n") hasPrefix:@"HTTP/1.1 201"], @"COPY of a file with Depth: 0 should be allowed");
+    XCTAssertTrue([SendRawRequest(server.port, @"DELETE /copy.txt HTTP/1.1\r\nHost: localhost\r\nDepth: 0\r\n\r\n") hasPrefix:@"HTTP/1.1 204"], @"DELETE with Depth: 0 should be allowed");
+    // ...and a nonsense Depth is still refused.
+    XCTAssertTrue([SendRawRequest(server.port, @"DELETE /f.txt HTTP/1.1\r\nHost: localhost\r\nDepth: 7\r\n\r\n") hasPrefix:@"HTTP/1.1 400"], @"an unrecognised Depth should still be refused");
+
+    // Allow, on OPTIONS and on the 405.
+    NSString* opts = SendRawRequest(server.port, @"OPTIONS / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([opts containsString:@"Allow:"], @"OPTIONS should advertise Allow: %@", opts);
+    XCTAssertTrue([opts containsString:@"PROPFIND"], @"Allow should name the DAV methods");
+    NSString* onCollection = SendRawRequest(server.port, @"PUT /coll HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\n\r\nx");
+    XCTAssertTrue([onCollection hasPrefix:@"HTTP/1.1 405"], @"PUT onto a collection should still be 405");
+    XCTAssertTrue([onCollection containsString:@"Allow:"], @"a 405 must carry Allow (RFC 9110 §15.5.6): %@", onCollection);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 // A symlink is an alias, so the verbs that REMOVE or RELOCATE one act on the entry the client named
 // rather than on what it points at — `rm latest` removes the link, `mv a latest` replaces it — while
 // reads still follow it. DELETE used to remove the multi-hundred-megabyte build directory and leave

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -52,6 +52,17 @@
 // of empty elements took the process from 5 MB to 561 MB and still answered 207.
 #define kDAVMaxRequestBodyLength (256 * 1024)
 
+// What a PROPFIND body asked for. The old model was a bitmask of the four live properties and an
+// unrecognised name was logged and dropped — which is why a requested-but-unavailable property got
+// no acknowledgement at all, and why <propname/> could not be answered. RFC 4918 §9.1 requires both:
+// a property that cannot be returned is reported in its own propstat with 404, and propname returns
+// the NAMES with empty values. Remembering the request is what makes either expressible.
+typedef NS_ENUM(NSInteger, DAVPropFindKind) {
+    kDAVPropFind_AllProp = 0,
+    kDAVPropFind_PropName,
+    kDAVPropFind_Named
+};
+
 typedef NS_ENUM(NSInteger, DAVProperties) {
     kDAVProperty_ResourceType = (1 << 0),
     kDAVProperty_CreationDate = (1 << 1),
@@ -639,8 +650,14 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     return ([userAgentHeader hasPrefix:@"WebDAVFS/"] || [userAgentHeader hasPrefix:@"WebDAVLib/"]);  // OS X WebDAV client
 }
 
+// Every method this server implements. RFC 9110 §15.5.6 requires an Allow header on a 405, and
+// §10.2.1 recommends one on OPTIONS; a client discovering capabilities from OPTIONS otherwise has
+// to guess. Kept beside performOPTIONS: so adding a verb without advertising it is visible here.
+static NSString *const kDAVAllowedMethods = @"OPTIONS, HEAD, GET, PUT, DELETE, MKCOL, PROPFIND, COPY, MOVE, LOCK, UNLOCK";
+
 - (WSKResponse *)performOPTIONS:(WSKRequest *)request {
     WSKResponse *response = [WSKResponse response];
+    [response setValue:kDAVAllowedMethods forAdditionalHeader:@"Allow"];
 
     if (_IsMacFinder(request)) {
         [response setValue:@"1, 2" forAdditionalHeader:@"DAV"];  // Classes 1 and 2
@@ -742,7 +759,9 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory];
 
     if (existing && isDirectory) {
-        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_MethodNotAllowed message:@"PUT not allowed on existing collection \"%@\"", relativePath];
+        WSKResponse *const notAllowed = [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_MethodNotAllowed message:@"PUT not allowed on existing collection \"%@\"", relativePath];
+        [notAllowed setValue:kDAVAllowedMethods forAdditionalHeader:@"Allow"];  // Required on a 405 by RFC 9110 §15.5.6.
+        return notAllowed;
     }
 
     NSString *const fileName = [absolutePath lastPathComponent];
@@ -797,7 +816,11 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
 - (WSKResponse *)performDELETE:(WSKRequest *)request {
     NSString *const depthHeader = request.headers[@"Depth"];
 
-    if (depthHeader && !_HeaderTokenIs(depthHeader, @"infinity")) {
+    // "Depth: 0" is accepted as well as "infinity". For a resource with no internal members it cannot
+    // mean anything else, and refusing it meant a client that sets Depth uniformly could not delete
+    // or copy a single FILE at all — 400 for an operation that is trivially satisfiable. RFC 4918
+    // §9.6.1 fixes DELETE's depth at infinity regardless, so accepting "0" costs nothing.
+    if (depthHeader && !_HeaderTokenIs(depthHeader, @"infinity") && !_HeaderTokenIs(depthHeader, @"0")) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
     }
 
@@ -956,7 +979,7 @@ static inline BOOL _IsMacFinder(WSKRequest *request) {
     if (!isMove) {
         NSString *const depthHeader = request.headers[@"Depth"];  // TODO: Support "Depth: 0"
 
-        if (depthHeader && !_HeaderTokenIs(depthHeader, @"infinity")) {
+        if (depthHeader && !_HeaderTokenIs(depthHeader, @"infinity") && !_HeaderTokenIs(depthHeader, @"0")) {
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
         }
     }
@@ -1205,7 +1228,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
     return NULL;
 }
 
-- (void)_addPropertyResponseForItem:(NSString *)itemPath resource:(NSString *)resourcePath properties:(DAVProperties)properties xmlString:(NSMutableString *)xmlString {
+- (void)_addPropertyResponseForItem:(NSString *)itemPath resource:(NSString *)resourcePath properties:(DAVProperties)properties kind:(DAVPropFindKind)kind unsupported:(NSArray<NSString *> *)unsupported xmlString:(NSMutableString *)xmlString {
     NSMutableCharacterSet *const allowed = [[NSCharacterSet URLPathAllowedCharacterSet] mutableCopy];
     [allowed removeCharactersInString:@"<&>?+"];
     NSString *const escapedPath = [resourcePath stringByAddingPercentEncodingWithAllowedCharacters:allowed];
@@ -1220,6 +1243,25 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
         if ((isFile && [self _checkFileExtension:itemPath]) || isDirectory) {
             [xmlString appendString:@"<D:response>"];
             [xmlString appendFormat:@"<D:href>%@</D:href>", escapedPath];
+
+            // <propname/> asks which properties EXIST, not what they hold, so the names go out as
+            // empty elements. RFC 4918 §9.1 makes it part of the method; it used to be refused with
+            // 400 by the body parser, which told a client the request was malformed.
+            if (kind == kDAVPropFind_PropName) {
+                [xmlString appendString:@"<D:propstat><D:prop>"];
+                [xmlString appendString:@"<D:resourcetype/>"];
+                [xmlString appendString:@"<D:creationdate/>"];
+
+                if (isFile) {
+                    [xmlString appendString:@"<D:getlastmodified/>"];
+                    [xmlString appendString:@"<D:getcontentlength/>"];
+                }
+
+                [xmlString appendString:@"</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat>"];
+                [xmlString appendString:@"</D:response>\n"];
+                return;
+            }
+
             [xmlString appendString:@"<D:propstat>"];
             [xmlString appendString:@"<D:prop>"];
 
@@ -1267,6 +1309,22 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
             [xmlString appendString:@"</D:prop>"];
             [xmlString appendString:@"<D:status>HTTP/1.1 200 OK</D:status>"];
             [xmlString appendString:@"</D:propstat>"];
+
+            // A property that was asked for and cannot be returned gets its OWN propstat with 404.
+            // Without it the response asserted "HTTP/1.1 200 OK" over a <prop> that silently
+            // omitted them, so a client asking for three properties and receiving one could not
+            // tell "this property does not exist here" from "it exists and is empty" — which is
+            // the distinction the propstat structure exists to draw.
+            if (unsupported.count > 0) {
+                [xmlString appendString:@"<D:propstat><D:prop>"];
+
+                for (NSString *element in unsupported) {
+                    [xmlString appendString:element];
+                }
+
+                [xmlString appendString:@"</D:prop><D:status>HTTP/1.1 404 Not Found</D:status></D:propstat>"];
+            }
+
             [xmlString appendString:@"</D:response>\n"];
         }
 
@@ -1283,11 +1341,20 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
         depth = 0;
     } else if ([depthHeader isEqualToString:@"1"]) {
         depth = 1;
+    } else if (_HeaderTokenIs(depthHeader, @"infinity")) {
+        // RFC 4918 §9.1: a server that refuses an infinite-depth PROPFIND SHOULD answer 403 with
+        // the DAV:propfind-finite-depth precondition, which is machine-readable and tells the
+        // client to retry with a bounded depth. A bare 400 says only "malformed", which this is not.
+        WSKDataResponse *const response = [WSKDataResponse responseWithData:[@"<?xml version=\"1.0\" encoding=\"utf-8\" ?><D:error xmlns:D=\"DAV:\"><D:propfind-finite-depth/></D:error>" dataUsingEncoding:NSUTF8StringEncoding] contentType:@"application/xml; charset=\"utf-8\""];
+        response.statusCode = kWSKHTTPStatusCode_Forbidden;
+        return response;
     } else {
-        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];  // TODO: Return 403 / propfind-finite-depth for "infinity" depth
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
     }
 
     DAVProperties properties = 0;
+    DAVPropFindKind kind = kDAVPropFind_AllProp;
+    NSMutableArray<NSString *> *const unsupported = [NSMutableArray array];
 
     if (request.data.length) {
         WSKErrorResponse *const tooLarge = _ResponseIfRequestBodyTooLarge(request);
@@ -1302,11 +1369,16 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
         if (document) {
             xmlNodePtr rootNode = _XMLChildWithName(document->children, (const xmlChar *)"propfind");
             xmlNodePtr allNode = rootNode ? _XMLChildWithName(rootNode->children, (const xmlChar *)"allprop") : NULL;
+            xmlNodePtr nameNode = rootNode ? _XMLChildWithName(rootNode->children, (const xmlChar *)"propname") : NULL;
             xmlNodePtr propNode = rootNode ? _XMLChildWithName(rootNode->children, (const xmlChar *)"prop") : NULL;
 
             if (allNode) {
                 properties = kDAVAllProperties;
+            } else if (nameNode) {
+                kind = kDAVPropFind_PropName;
+                properties = kDAVAllProperties;
             } else if (propNode) {
+                kind = kDAVPropFind_Named;
                 xmlNodePtr node = propNode->children;
 
                 while (node) {
@@ -1318,8 +1390,20 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
                         properties |= kDAVProperty_LastModified;
                     } else if (!xmlStrcmp(node->name, (const xmlChar *)"getcontentlength")) {
                         properties |= kDAVProperty_ContentLength;
-                    } else {
-                        [self logWarning:@"Unknown DAV property requested \"%s\"", node->name];
+                    } else if (node->type == XML_ELEMENT_NODE) {
+                        // Remembered rather than dropped, so it can be reported in a 404 propstat.
+                        // The namespace travels with it: a client asking for a property in its own
+                        // namespace must see that name back, not a DAV:-qualified guess at it.
+                        NSString *const localName = [NSString stringWithUTF8String:(const char *)node->name];
+                        const char *const href = (node->ns && node->ns->href) ? (const char *)node->ns->href : NULL;
+
+                        if (localName.length) {
+                            if (href && strcmp(href, "DAV:")) {
+                                [unsupported addObject:[NSString stringWithFormat:@"<W:%@ xmlns:W=\"%@\"/>", _XMLEscape(localName), _XMLEscape([NSString stringWithUTF8String:href])]];
+                            } else {
+                                [unsupported addObject:[NSString stringWithFormat:@"<D:%@/>", _XMLEscape(localName)]];
+                            }
+                        }
                     }
 
                     node = node->next;
@@ -1384,7 +1468,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
         relativePath = [@"/" stringByAppendingString:relativePath];
     }
 
-    [self _addPropertyResponseForItem:absolutePath resource:relativePath properties:properties xmlString:xmlString];
+    [self _addPropertyResponseForItem:absolutePath resource:relativePath properties:properties kind:kind unsupported:unsupported xmlString:xmlString];
 
     if (depth == 1) {
         if (![relativePath hasSuffix:@"/"]) {
@@ -1393,7 +1477,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
 
         for (NSString *item in items) {
             if (_allowHiddenItems || ![item hasPrefix:@"."]) {
-                [self _addPropertyResponseForItem:[absolutePath stringByAppendingPathComponent:item] resource:[relativePath stringByAppendingString:item] properties:properties xmlString:xmlString];
+                [self _addPropertyResponseForItem:[absolutePath stringByAppendingPathComponent:item] resource:[relativePath stringByAppendingString:item] properties:properties kind:kind unsupported:unsupported xmlString:xmlString];
             }
         }
     }

--- a/Tests/WebDAV-Finder/001-200.response
+++ b/Tests/WebDAV-Finder/001-200.response
@@ -1,4 +1,5 @@
 HTTP/1.1 200 OK
+Allow: OPTIONS, HEAD, GET, PUT, DELETE, MKCOL, PROPFIND, COPY, MOVE, LOCK, UNLOCK
 Cache-Control: no-cache
 DAV: 1, 2
 Connection: Close

--- a/Tests/WebDAV-Finder/002-200.response
+++ b/Tests/WebDAV-Finder/002-200.response
@@ -1,4 +1,5 @@
 HTTP/1.1 200 OK
+Allow: OPTIONS, HEAD, GET, PUT, DELETE, MKCOL, PROPFIND, COPY, MOVE, LOCK, UNLOCK
 Cache-Control: no-cache
 DAV: 1, 2
 Connection: Close

--- a/Tests/WebDAV-Finder/003-200.response
+++ b/Tests/WebDAV-Finder/003-200.response
@@ -1,4 +1,5 @@
 HTTP/1.1 200 OK
+Allow: OPTIONS, HEAD, GET, PUT, DELETE, MKCOL, PROPFIND, COPY, MOVE, LOCK, UNLOCK
 Cache-Control: no-cache
 DAV: 1, 2
 Connection: Close

--- a/Tests/WebDAV-Finder/005-207.response
+++ b/Tests/WebDAV-Finder/005-207.response
@@ -1,11 +1,11 @@
 HTTP/1.1 207 Multi-Status
 Cache-Control: no-cache
-Content-Length: 208
+Content-Length: 364
 Content-Type: application/xml; charset="utf-8"
 Connection: Close
 Server: WebServerKit
 Date: Sat, 12 Apr 2014 05:10:55 GMT
 
 <?xml version="1.0" encoding="utf-8" ?><D:multistatus xmlns:D="DAV:">
-<D:response><D:href>/</D:href><D:propstat><D:prop></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+<D:response><D:href>/</D:href><D:propstat><D:prop></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat><D:propstat><D:prop><D:quota-available-bytes/><D:quota-used-bytes/><D:quota/><D:quotaused/></D:prop><D:status>HTTP/1.1 404 Not Found</D:status></D:propstat></D:response>
 </D:multistatus>

--- a/Tests/WebDAV-Transmit/001-200.response
+++ b/Tests/WebDAV-Transmit/001-200.response
@@ -1,4 +1,5 @@
 HTTP/1.1 200 OK
+Allow: OPTIONS, HEAD, GET, PUT, DELETE, MKCOL, PROPFIND, COPY, MOVE, LOCK, UNLOCK
 Cache-Control: no-cache
 DAV: 1
 Connection: Close


### PR DESCRIPTION
Decision **3**, part one. WebDAV was only partially promised in the README, so this is **new
capability rather than repair** — these are undocumented scope, not regressions.

Split from `PROPPATCH`, which needs a dead-property storage design of its own, so each half stays
reviewable.

### PROPFIND now tells the truth about properties it cannot return

The old model was a bitmask of four live properties; an unrecognised name was logged and **dropped**.
So a client asking for three properties and receiving one was told:

```xml
<D:propstat><D:prop><D:getcontentlength>5</D:getcontentlength></D:prop>
<D:status>HTTP/1.1 200 OK</D:status></D:propstat>
```

— unable to tell *"this property does not exist here"* from *"it exists and is empty"*, which is the
distinction the propstat structure exists to draw. Requested names are now remembered **with their
namespace**, so a client asking in its own namespace sees that name back rather than a
`DAV:`-qualified guess.

- **`<propname/>` supported** — names with empty values. It used to be refused with **400**, telling a
  client its legal request was malformed.
- **`Depth: infinity` → 403 with `<DAV:propfind-finite-depth/>`**, the machine-readable precondition
  RFC 4918 §9.1 defines, instead of a bare 400. The source already carried a TODO naming this.
- **`Depth: 0` accepted on COPY and DELETE.** For a resource with no internal members it can't mean
  anything else, and refusing it meant a client setting Depth uniformly couldn't delete or copy a
  single *file*. An unrecognised Depth is still refused.
- **`Allow` on OPTIONS and on the 405**, the latter required by RFC 9110 §15.5.6.

### ⚠️ The corpus needed re-recording — and one recording had preserved a lie since 2014

Four OPTIONS recordings simply gained `Allow`. The fifth is the interesting one. Finder asks for four
quota properties, and the recorded response was:

```xml
<D:propstat><D:prop></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat>
```

**"OK" over nothing** — exactly the dishonesty this change fixes, frozen into the corpus.

Re-recorded by reconstructing the body and **validating the method against the OLD byte count
first**: my reconstruction of the old body came to 208 against the recorded 208, so the new one at
364 against the emitted 364 could be trusted. Guessing at the bytes and hoping the runner agreed
would have proved nothing.

### A live Apple client was driven against it

CLAUDE.md records that the corpus proves *recorded replay* and "cannot prove live-client tolerance" —
the class that broke Finder when the sixth pass first tightened `If-Range`. So rather than leave that
gap open again:

```
mount_webdav -S http://127.0.0.1:<port>/  ->  mounted
ls / cat / write / read-back / mkdir / mv / rm / rmdir  ->  all OK
umount  ->  clean
```

### Verification

**121 tests, 0 failures**, all eight trace suites, Release builds for all three platforms, exit 0.

### Next

**Part two** — `PROPPATCH` with dead-property storage (xattr-backed, degrading to a per-property 403
on filesystems that can't store them, which now demonstrably includes exFAT). That completes class 1.
