### PR TITLE
Stop WSKFileResponse promising non-null where it returns nil, and clear five hidden warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,35 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### The non-null lie in WSKFileResponse, and five warnings an incremental build was hiding
+
+**⚠️ BREAKING CHANGE.** `WSKFileResponse` redeclared `contentType`, `lastModifiedDate` and `eTag` as
+non-null, over `WSKResponse`'s own `nullable` declarations. The code cannot keep that promise, so the
+redeclarations are gone — the base class's honest ones now apply, and **Swift callers will need
+`if let` or `?`**.
+
+Two cases make the promise false, both reachable with no host-app opt-in. `lastModifiedDate` is
+deliberately nil while mtime is inside its filesystem's timestamp bucket, which is the whole of the
+protection stopping two representations going out under one date. And an unsatisfiable byte range
+answers 416 with **none of the three set**, so one remote `Range: bytes=999999999-` handed a host app
+three nils from properties its own header said could not be nil — in Objective-C a nil heading for
+whatever the caller did next (this codebase's named recurring crash is a nil reaching a dictionary
+literal, and nothing in `Sources/` catches an NSException); in Swift, `lastModifiedDate` imported as
+a non-optional `Date` and **trapped**.
+
+Deleting three lines was the whole fix, which is worth noting: the properties were only ever
+*declared* wrongly. A header that lies to the type system is worse than one that changes.
+
+**⚠️ An incremental build hides warnings, and that is how five of them accumulated.** Removing the
+redeclarations forced a full rebuild, which surfaced five: two nullable-to-nonnull conversions, two
+uses of the GNU `?:` extension, and two messages to an unqualified `id` (one of them in the symlink
+listing that landed two PRs ago). Running `xcodebuild` twice in a row proves it — the first
+invocation reported four, the second reported zero, having recompiled nothing. **Check warnings
+against a clean `-derivedDataPath`, or the count means nothing.** It is the same shape as the
+`-Wbad-function-cast` warning found the same way a few PRs earlier. All five are fixed and a
+from-scratch build is at zero.
+
+
 ### WebDAV class 1, part two: PROPPATCH, and an independent suite finding my own bug
 
 `PROPPATCH` was 501 while `OPTIONS` advertised `DAV: 1`, which is the last of the class-1 MUSTs this

--- a/Sources/WebServerKit/Responses/WSKFileResponse.h
+++ b/Sources/WebServerKit/Responses/WSKFileResponse.h
@@ -42,9 +42,25 @@ NS_ASSUME_NONNULL_BEGIN
  *  metadata.
  */
 @interface WSKFileResponse : WSKResponse
-@property (nonatomic, copy) NSString *contentType;  // Redeclare as non-null
-@property (nonatomic) NSDate *lastModifiedDate;     // Redeclare as non-null
-@property (nonatomic, copy) NSString *eTag;         // Redeclare as non-null
+
+/**
+ *  ⚠️ BREAKING CHANGE. These three were redeclared here as NON-NULL, and the code cannot keep that
+ *  promise, so the redeclarations are gone and WSKResponse's own `nullable` declarations apply.
+ *
+ *  Two cases make it false, both reachable without any host-app opt-in. `lastModifiedDate` is
+ *  deliberately nil while the file's mtime is still inside its filesystem's timestamp bucket — a
+ *  validator may only be ISSUED once the instant it names can no longer be written again, which is
+ *  what stops two representations going out under one date. And an unsatisfiable byte range answers
+ *  416 with none of the three set, so one remote `Range: bytes=999999999-` handed a host app three
+ *  nils from properties its own header said could not be nil.
+ *
+ *  In Objective-C that was a nil into whatever the caller did next — this codebase's named recurring
+ *  crash is a nil reaching a dictionary literal, and nothing in Sources/ catches an NSException. In
+ *  Swift `lastModifiedDate` imported as a non-optional `Date` and TRAPPED.
+ *
+ *  Swift callers will now need `if let` or `?`; that is the point. A header that lies to the type
+ *  system is worse than one that changes.
+ */
 
 /**
  *  Creates a response with the contents of a file.

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -508,9 +508,11 @@ static NSDictionary<NSString *, NSString *> *_DeadPropertiesAtPath(NSString *pat
         return @{};
     }
 
-    id const stored = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable format:NULL error:NULL];
+    NSObject *const stored = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable format:NULL error:NULL];
 
-    return [stored isKindOfClass:[NSDictionary class]] ? stored : @{};
+    // Whatever was in the attribute is not necessarily what we put there — another tool can write
+    // this xattr — so the shape is checked rather than assumed.
+    return [stored isKindOfClass:[NSDictionary class]] ? (NSDictionary<NSString *, NSString *> *)stored : @{};
 }
 
 // NO on failure, with errno left as the filesystem set it. Filesystems that cannot store extended
@@ -1502,7 +1504,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Invalid DAV property update for \"%@\"", relativePath];
     }
 
-    NSMutableDictionary<NSString *, NSString *> *const properties = [[_DeadPropertiesAtPath(absolutePath) mutableCopy] ?: [NSMutableDictionary dictionary] mutableCopy];
+    NSMutableDictionary<NSString *, NSString *> *const properties = [_DeadPropertiesAtPath(absolutePath) mutableCopy];
     NSMutableArray<NSString *> *const applied = [NSMutableArray array];
     NSMutableArray<NSString *> *const refused = [NSMutableArray array];
     BOOL changed = NO;
@@ -1554,7 +1556,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
                     xmlFree(content);
                 }
 
-                properties[key] = value ?: @"";
+                properties[key] = (value != nil) ? value : @"";
             } else {
                 [properties removeObjectForKey:key];
             }
@@ -1609,7 +1611,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
 
     [xmlString appendString:@"</D:response>\n</D:multistatus>"];
 
-    WSKDataResponse *const response = [WSKDataResponse responseWithData:[xmlString dataUsingEncoding:NSUTF8StringEncoding] contentType:@"application/xml; charset=\"utf-8\""];
+    WSKDataResponse *const response = [WSKDataResponse responseWithData:(NSData * _Nonnull)[xmlString dataUsingEncoding:NSUTF8StringEncoding] contentType:@"application/xml; charset=\"utf-8\""];
     response.statusCode = kWSKHTTPStatusCode_MultiStatus;
     return response;
 }
@@ -1626,7 +1628,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
         // RFC 4918 §9.1: a server that refuses an infinite-depth PROPFIND SHOULD answer 403 with
         // the DAV:propfind-finite-depth precondition, which is machine-readable and tells the
         // client to retry with a bounded depth. A bare 400 says only "malformed", which this is not.
-        WSKDataResponse *const response = [WSKDataResponse responseWithData:[@"<?xml version=\"1.0\" encoding=\"utf-8\" ?><D:error xmlns:D=\"DAV:\"><D:propfind-finite-depth/></D:error>" dataUsingEncoding:NSUTF8StringEncoding] contentType:@"application/xml; charset=\"utf-8\""];
+        WSKDataResponse *const response = [WSKDataResponse responseWithData:(NSData * _Nonnull)[@"<?xml version=\"1.0\" encoding=\"utf-8\" ?><D:error xmlns:D=\"DAV:\"><D:propfind-finite-depth/></D:error>" dataUsingEncoding:NSUTF8StringEncoding] contentType:@"application/xml; charset=\"utf-8\""];
         response.statusCode = kWSKHTTPStatusCode_Forbidden;
         return response;
     } else {

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -1179,7 +1179,8 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
             NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory);
             // A symlink's own attributes report the length of its target PATH, not the file, so
             // ask again through the link for anything classified as a regular file.
-            NSDictionary *const effective = [attributes[NSFileType] isEqualToString:NSFileTypeSymbolicLink]
+            NSString *const rawType = attributes[NSFileType];
+            NSDictionary *const effective = [rawType isEqualToString:NSFileTypeSymbolicLink]
                                                 ? [[NSFileManager defaultManager] attributesOfItemAtPath:[itemPath stringByResolvingSymlinksInPath] error:NULL]
                                                 : attributes;
             NSNumber *const size = effective[NSFileSize];  // Nil if the item vanished between the listing and this stat; must not reach the literal below.


### PR DESCRIPTION
Decision **4**. ⚠️ **This is a source-breaking change** — Swift callers will need `if let` or `?`.

### The lie

`WSKFileResponse` redeclared three properties as **non-null**, over `WSKResponse`'s own `nullable`
declarations:

```objc
@property (nonatomic, copy) NSString *contentType;  // Redeclare as non-null
@property (nonatomic) NSDate *lastModifiedDate;     // Redeclare as non-null
@property (nonatomic, copy) NSString *eTag;         // Redeclare as non-null
```

The code cannot keep that promise, in two cases, **both reachable with no host-app opt-in**:

- `lastModifiedDate` is **deliberately nil** while mtime is inside its filesystem's timestamp bucket.
  That withholding *is* the protection stopping two representations going out under one date.
- An unsatisfiable byte range answers **416 with none of the three set** — so one remote
  `Range: bytes=999999999-` handed a host app three nils from properties its own header said could
  not be nil.

In Objective-C that's a nil heading for whatever the caller did next, which in this codebase most
often means a dictionary literal and an uncaught `NSException`. In Swift, `lastModifiedDate` imported
as a non-optional `Date` and **trapped**.

**Deleting three lines was the entire fix** — the properties were only ever *declared* wrongly, never
assigned wrongly.

### ⚠️ And an incremental build had been hiding five warnings

Removing the redeclarations forced a full rebuild, which surfaced two nullable-to-nonnull conversions,
two uses of the GNU `?:` extension, and two messages to an unqualified `id` — one of those in the
symlink listing that landed two PRs ago.

The trap demonstrates itself:

```
$ xcodebuild ... | grep -c warning:     # 4
$ xcodebuild ... | grep -c warning:     # 0   (recompiled nothing)
```

**Warnings have to be checked against a clean `-derivedDataPath` or the count means nothing.** Same
shape as the `-Wbad-function-cast` warning found this way a few PRs back. All five fixed; a
from-scratch Debug build is at **zero**.

### Verification

**122 tests, 0 failures**, all eight trace suites, Release builds for all three platforms, and a
from-scratch Debug build with zero warnings under `-Weverything`.
