### PR TITLE
Replace the shared reload counter, which has now wedged the page twice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,39 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### The reload guard was a counter two parties shared, and it has now wedged twice
+
+A listing arriving while the rename box is open froze the page permanently: it stopped tracking the
+share, and no later change — SSE, Refresh, navigation — ever moved it again.
+
+`_reloadingDisabled` was a COUNTER that two independent parties incremented and decremented:
+`_reload()` around its own request, and the rename box between `onedit` and `onsubmit`/`onreset`. A
+counter like that is only ever as correct as its least reliable decrement, and this one has now
+failed twice for two unrelated reasons. The first, already recorded in this file, was a throw
+skipping the release. The second: with a reload IN FLIGHT the box is opened (count 2), the listing
+lands and `$("#listing").empty()` destroys the box, so jeditable's `onsubmit` and `onreset` never
+fire and that increment is never matched — the request's own release takes it to 1, where it stays
+forever.
+
+**⚠️ The obvious repair makes it worse, which is why this was left for a designed fix.** Decrementing
+by the number of destroyed editors trips over jeditable's default `onblur: 'cancel'`, which fires
+`onreset` as well — so the same teardown can decrement twice and the counter goes NEGATIVE, which is
+just as truthy in `if (_reloadingDisabled)` and wedges identically.
+
+**So the counter is gone.** Re-entrancy is now a boolean owned solely by `_reload()` and cleared in
+its `.always()`, which jQuery always runs; and whether an editor is open is **derived from the DOM**
+rather than remembered, so there is no pairing to get wrong and nothing to leak. If a box is
+destroyed, the next question simply answers "no".
+
+That is the property that matters, and it is what the old design could not have: **self-healing**. A
+missed flush now leaves a stale listing until the next reload rather than a permanently frozen page.
+
+Verified in Chromium with the reload deliberately held in flight (a delayed route) so the box can be
+opened underneath it — the ordering the wedge actually needs, which an earlier attempt at the probe
+got wrong and so measured correct queueing instead of the bug. Unfixed: WEDGED. Fixed: healthy. The
+three UI fixes from the previous browser pass were re-checked in the same run and all still hold.
+
+
 ### The non-null lie in WSKFileResponse, and five warnings an incremental build was hiding
 
 **⚠️ BREAKING CHANGE.** `WSKFileResponse` redeclared `contentType`, `lastModifiedDate` and `eTag` as

--- a/Sources/WebServerKitUploader/WSKWebUploader.bundle/Contents/Resources/js/index.js
+++ b/Sources/WebServerKitUploader/WSKWebUploader.bundle/Contents/Resources/js/index.js
@@ -30,9 +30,9 @@ var ENTER_KEYCODE = 13;
 // The root, not null: _reload() is called with _path from handlers that can fire before
 // the first listing comes back (the Refresh button, the EventSource "open" callback), and
 // a null there used to reach path.split("/") and throw. jQuery's Callbacks.fire has no
-// try/catch and .always() sits on the same list, so the throw also skipped
-// _enableReloads() — _reloadingDisabled stuck above zero and every later reload queued
-// forever, freezing the UI and holding an /events slot open for nothing.
+// try/catch and .always() sits on the same list, so the throw also skipped the reload guard's
+// release — it stuck "busy" and every later reload queued forever, freezing the UI and holding an
+// /events slot open for nothing. That guard is no longer a counter; see _reloadInFlight below.
 var _path = "/";
 // The path most recently ASKED for. _path is only assigned when a listing comes back, so between
 // _reload(hashPath) and its response it still reads "/" — and the SSE onopen re-sync fired in that
@@ -42,7 +42,20 @@ var _path = "/";
 var _requestedPath = "/";
 var _pathRendered = false;  // The breadcrumb starts empty, so the first listing must always draw it.
 var _pendingReloads = [];
-var _reloadingDisabled = 0;
+// Owned SOLELY by _reload(), and cleared in its .always(), which jQuery always runs. It used to be a
+// counter that two independent parties incremented and decremented — _reload() around its own
+// request, and the rename box between onedit and onsubmit/onreset — and a counter like that is only
+// ever as correct as its least reliable decrement. It has now wedged twice for two different
+// reasons: once when a throw skipped _enableReloads() (see the note on _path above), and once when a
+// listing arrived while the rename box was open, because $("#listing").empty() destroys the box so
+// jeditable's onsubmit and onreset never fire and the onedit increment is never matched. Both left
+// it stuck above zero with every later reload queued forever, and the page silently stopped tracking
+// the share.
+//
+// Decrementing by the number of destroyed editors — the obvious repair — makes it worse: jeditable's
+// default onblur is 'cancel', which fires onreset too, so the same teardown can decrement twice and
+// the counter goes NEGATIVE, which is just as truthy and wedges identically.
+var _reloadInFlight = false;
 
 // Escape server-provided strings (file/folder names, device name) before they are
 // concatenated into HTML, to prevent stored XSS via crafted names.
@@ -70,14 +83,16 @@ function _showError(message, textStatus, errorThrown) {
   }));
 }
 
-function _disableReloads() {
-  _reloadingDisabled += 1;
+// Whether a rename box is open is DERIVED from the DOM rather than remembered, so there is no
+// pairing to get wrong and nothing to leak: if the box is destroyed by a listing, the next question
+// simply answers "no". That is what makes this self-healing where the counter was not — a missed
+// flush leaves a stale listing until the next reload, not a permanently frozen page.
+function _editorIsOpen() {
+  return $("#listing").find("form input[name=value]").length > 0;
 }
 
-function _enableReloads() {
-  _reloadingDisabled -= 1;
-  
-  if (_pendingReloads.length > 0) {
+function _flushPendingReloads() {
+  if ((_pendingReloads.length > 0) && !_reloadInFlight && !_editorIsOpen()) {
     _reload(_pendingReloads.shift());
   }
 }
@@ -91,14 +106,14 @@ function _reload(path) {
 
   _requestedPath = path;
 
-  if (_reloadingDisabled) {
+  if (_reloadInFlight || _editorIsOpen()) {
     if ($.inArray(path, _pendingReloads) < 0) {
       _pendingReloads.push(path);
     }
     return;
   }
-  
-  _disableReloads();
+
+  _reloadInFlight = true;
   $.ajax({
     url: 'list',
     type: 'GET',
@@ -178,14 +193,14 @@ function _reload(path) {
         var name = $(this).parent().parent().data("name");
         return (name === undefined || name === null) ? revert : String(name);
       },
-      onedit: function(settings, original) {
-        _disableReloads();
-      },
+      // Nothing to disable on edit any more — _editorIsOpen() sees the box itself. These only
+      // flush, and do it after the current turn so jeditable has removed the form first; asking
+      // while it is still in the DOM would answer "still editing" and skip the flush.
       onsubmit: function(settings, original) {
-        _enableReloads();
+        setTimeout(_flushPendingReloads, 0);
       },
       onreset: function(settings, original) {
-        _enableReloads();
+        setTimeout(_flushPendingReloads, 0);
       },
       tooltip: 'Click to rename...'
     });
@@ -228,7 +243,8 @@ function _reload(path) {
     
     $(document).scrollTop(scrollPosition);
   }).always(function() {
-    _enableReloads();
+    _reloadInFlight = false;
+    _flushPendingReloads();
   });
 }
 


### PR DESCRIPTION
The last item on your decision list. A listing arriving while the rename box is open froze the page
**permanently** — it stopped tracking the share, and no later change (SSE, Refresh, navigation) ever
moved it again.

### What's actually wrong

`_reloadingDisabled` was a **counter that two independent parties incremented and decremented**:
`_reload()` around its own request, and the rename box between `onedit` and `onsubmit`/`onreset`.

A counter like that is only ever as correct as its least reliable decrement — and this one has now
failed **twice, for two unrelated reasons**:

1. Already recorded in the file: a throw skipped the release.
2. This one: with a reload **in flight**, the box is opened (count 2); the listing lands and
   `$("#listing").empty()` **destroys the box**, so jeditable's `onsubmit`/`onreset` never fire and
   that increment is never matched. The request's own release takes it to 1, where it stays.

### ⚠️ Why the obvious repair is worse

Decrementing by the number of destroyed editors trips over jeditable's default `onblur: 'cancel'`,
which fires `onreset` **as well** — so the same teardown can decrement twice, the counter goes
**negative**, and `if (_reloadingDisabled)` is just as truthy. Identical wedge, harder to see.

### So the counter is gone, not repaired

- Re-entrancy is a **boolean owned solely by `_reload()`**, cleared in its `.always()` — which jQuery
  always runs.
- Whether an editor is open is **derived from the DOM**, not remembered. No pairing to get wrong,
  nothing to leak: if a box is destroyed, the next question simply answers "no".

That buys the property the old design structurally could not have — **self-healing**. A missed flush
now leaves a stale listing until the next reload, rather than a permanently frozen page.

### Verification

Driven in Chromium with the reload **deliberately held in flight** via a delayed route, so the box
can be opened underneath it — the ordering the wedge actually requires.

```
unfixed:  box opened mid-flight: yes   destroyed by the listing: yes   -> WEDGED
fixed:    box opened mid-flight: yes   destroyed by the listing: yes   -> healthy
```

Worth recording: my **first** probe opened the box *before* starting the reload, and measured correct
queueing rather than the bug — a green that meant nothing. The ordering is the whole finding.

PR #51's three UI fixes were re-checked in the same run and all still hold: seven tabs responsive,
deep links and reloads staying in the subfolder, rename box leaving a CR-bearing name alone.

**122 tests, 0 failures**, all eight trace suites, Release builds for all three platforms.
