### PR TITLE
Closed six known-open lows that were each a process kill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,80 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Known-open lows, batch A: six ways a host app could kill the process
+
+The ~20 items the audit programme deferred were all filed as "low". For these six that label was
+measuring the wrong axis: they are low in **reachability** — each needs a host app to use a
+documented API in a documented way — not in consequence. **Four of the six kill the process**, and
+the proof is how the regression tests behaved against the unfixed tree: they did not fail, they
+crashed the test runner four separate times and the suite reported `Executed 0 tests, with 0
+failures`. That is the third time this file has recorded that exact trap. Read the executed count.
+
+**`+responseWithFile:` is declared `nullable` and raised instead.** `-fileSystemRepresentation`
+raises `NSInvalidArgumentException` for an empty or NUL-bearing receiver rather than returning
+NULL, and the raise escapes through the host app's handler into the connection. Any handler that
+builds a path from request input can reach both spellings. This is the same shape the eleventh pass
+fixed in `+responseWithJSONObject:` — **the fourth time a fix for the nil/NUL class has failed to
+reach every site the value can arrive by**, which is now this codebase's single most repeated
+defect. The NUL check is kept even though `open(2)` would truncate there anyway: truncating makes
+the server act on a prefix of what was asked for, which is refused everywhere else here.
+
+**A `WSKMatchBlock` inspecting the request it just built SEGV'd.** The connection populates a
+request's addresses *after* the match block returns, so inside the block they are nil — and
+`WSKStringFromSockAddr` reads `addr->sa_len` before `getnameinfo` can fail, so there is nothing to
+fail closed on. Inspecting the request is the match block's entire job. It now returns the same
+`@""` it already returned for a `getnameinfo` failure, so no caller needs a new case, and
+`localAddressData`/`remoteAddressData` are **`nullable`** now because they genuinely are in that
+window. Source-breaking for Swift, deliberately — the same call as the `WSKFileResponse` validators.
+
+**The public date functions crashed unless a server had been created first.** `WSKFormatRFC822`,
+`WSKParseRFC822`, `WSKFormatISO8601` and `WSKParseISO8601` `dispatch_sync` on a queue only built by
+`WSKInitializeFunctions`, which ran only from `+[WSKWebServer initialize]` — so calling any of the
+four before touching the server class was an immediate crash. Carried in this file as known-open
+since the sixth pass. Now `dispatch_once`, called lazily from each of the four. The main-thread
+assertion is gone with it: `NSDateFormatter` has been safe to build off the main thread for many
+releases, and `dispatch_once` removes the race the assertion stood in for.
+
+**⚠️ The in-suite test for that one cannot regress-guard it, and it would have been easy to claim
+otherwise.** XCTest runs one process in alphabetical order, so in a full-suite run some earlier
+test has already messaged `WSKWebServer` and the formatters exist by the time it runs — it only
+exercised the lazy path because it happened to run in *isolation*. The real oracle is
+out-of-process: a binary that links the framework and names `WSKWebServer` nowhere. Fixed library
+prints OK; unfixed exits **139 (SIGSEGV)**. Kept in the scratch harness, not the suite, because it
+needs its own link line.
+
+**Date preconditions failed OPEN for two of the three formats RFC 9110 requires.** Only IMF-fixdate
+parsed, so an `If-Modified-Since`, `If-Unmodified-Since` or `If-Range` carrying an RFC 850 or
+`asctime()` date parsed to nil and the precondition was treated as *absent* — a validator failing in
+the permissive direction. Both are parsed now (never formatted; senders must still emit
+IMF-fixdate). Two details that are easy to get wrong: RFC 9110 §5.6.7's two-digit-year rule is
+exactly a window opening 50 years ago, which is what `twoDigitStartDate` is set to; and `asctime()`
+pads a single-digit day to width two ("Sun Nov  6"), which `d` does not absorb, so runs of spaces are
+collapsed rather than the pattern being loosened.
+
+**Two `WSK_DNOT_REACHED()` sites punished the careful host app.** `addGETHandlerForBasePath:`
+enforced an *undocumented* leading/trailing-slash precondition by aborting in Debug with no
+diagnostic and, in Release, registering nothing and returning — so every request 404'd with no clue
+why. Neither spelling is ambiguous, so both are normalized now. And `-stop` on a server whose start
+**failed** aborted a Debug build, which is precisely what an error path does right after
+`-startWithOptions:error:` returns NO; it is idempotent tidy-up now. While in the header, the
+base-path handler's documented no-match status was corrected from 401 to the 404 it actually
+returns.
+
+**Verified together, not per-fix.** 127 tests and 0 failures on a clean build with no new warnings,
+the trace corpus green, iOS and tvOS Debug both building with 0 warnings, and the date oracle
+sensitive in both directions. The full-suite run is the load-bearing one: per-fix greens are what
+let two regressions ride `main` through three CI runs earlier in this programme.
+
+**Still open:** the remaining lows, which split into batch B (status-code and documentation honesty
+— `If-Match` on a missing resource answering 404 not 412, ENOSPC/EROFS answering 500/403 not 507,
+MKCOL's 500-after-create, empty header names, the six non-null-but-nil properties on the uploader
+and DAV server, `-startWithOptions:error:` not setting `*error`) and batch C (the long-lived
+surfaces — the SSE quiet-client reaping gap, SSE paths collapsing to `/` through a symlinked
+ancestor, `-bonjourName` after an auto-rename, the silent iOS foreground-restart failure). The `//`
+status disagreement, `MOVE`-without-`Overwrite` and the directory-rename TOCTOU remain settled
+decisions rather than defects.
+
 ### The reload guard was a counter two parties shared, and it has now wedged twice
 
 A listing arriving while the rename box is open froze the page permanently: it stopped tracking the
@@ -652,7 +726,8 @@ aborts a Debug build inside `WSKInitializeFunctions` (and `+initialize` is inher
 `WSKWebServer` first does not protect a subclass); `-stop` after a *failed* start aborts a Debug
 build, with no public way to tell that state from a stoppable one; and
 `-startWithOptions:error:` returns NO without setting `*error` when the server is already running.
-Also carried forward and re-confirmed 10/10: `WSKFormatRFC822` before any server exists still
+Also carried forward and re-confirmed 10/10 (**closed in batch A of the known-open lows, above**):
+`WSKFormatRFC822` before any server exists still
 crashes.
 
 ### Tenth audit pass: the scan that was meant to end the programme, and did not
@@ -1129,7 +1204,8 @@ suppressed. Fix it off the wire method if it ever becomes reachable.
 
 Carried forward from the sixth pass, both still true and both pre-existing: `bootstrap.css`
 requests `.woff`/`.woff2` glyphicons that are not in the bundle (a 404 on every page load;
-browsers fall back to the `.ttf` that ships), and `WSKFormatRFC822`/`WSKParseRFC822` are public
+browsers fall back to the `.ttf` that ships), and — **closed in batch A of the known-open lows,
+above** — `WSKFormatRFC822`/`WSKParseRFC822` are public
 but `dispatch_sync` on a queue only created by `+[WSKWebServer initialize]`, so calling either
 before any server exists crashes.
 
@@ -1253,6 +1329,7 @@ its terminator.
 **Still open:** nothing from this pass's findings. Noted but deliberately untouched, both
 pre-existing: `bootstrap.css` requests `.woff`/`.woff2` glyphicons that are not in the bundle
 (a 404 on every page load; browsers fall back to the `.ttf` that ships), and
+**closed in batch A of the known-open lows, above** —
 `WSKFormatRFC822`/`WSKParseRFC822` are public but `dispatch_sync` on a queue only created by
 `+[WSKWebServer initialize]`, so calling either before any server exists crashes.
 

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -4718,4 +4718,105 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     XCTAssertEqualObjects([[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding], @"chunkchunkchunk");
 }
 
+
+#pragma mark - Host-app API safety (batch A: the crashers)
+
+// +responseWithFile: is declared nullable, so a path it cannot use must come back nil.
+// -fileSystemRepresentation RAISES for an empty or NUL-bearing receiver, and the raise
+// escapes through a host app's handler into the connection, so this is a process kill
+// reachable from any handler that builds a path from client input. Same shape the
+// eleventh pass fixed in +responseWithJSONObject:, at a site that fix did not reach.
+- (void)testFileResponseReturnsNilRatherThanRaisingForAnUnusablePath {
+    XCTAssertNoThrow([WSKFileResponse responseWithFile:@""]);
+    XCTAssertNil([WSKFileResponse responseWithFile:@""]);
+
+    unichar const nulBearing[] = {'/', 't', 'm', 'p', '/', 0, 'x'};
+    NSString* nulPath = [NSString stringWithCharacters:nulBearing length:(sizeof(nulBearing) / sizeof(nulBearing[0]))];
+    XCTAssertNoThrow([WSKFileResponse responseWithFile:nulPath]);
+    XCTAssertNil([WSKFileResponse responseWithFile:nulPath]);
+
+    // The ordinary path must still work, or this could pass by refusing everything.
+    NSString* dir = MakeTempDirectory();
+    NSString* file = [dir stringByAppendingPathComponent:@"ok.txt"];
+    [@"hello" writeToFile:file atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    XCTAssertNotNil([WSKFileResponse responseWithFile:file]);
+    [[NSFileManager defaultManager] removeItemAtPath:dir error:NULL];
+}
+
+// A WSKMatchBlock builds the request, and the connection only populates its addresses
+// AFTER the block returns — so inside the block they are nil. Reading them there fed a
+// NULL sockaddr to WSKStringFromSockAddr, which dereferences addr->sa_len before it can
+// fail, i.e. SEGV rather than a nil. Inspecting the request is the match block's job.
+- (void)testRequestAddressAccessorsAreSafeBeforeTheServerPopulatesThem {
+    WSKRequest* request = [[WSKRequest alloc] initWithMethod:@"GET"
+                                                         url:[NSURL URLWithString:@"http://localhost/x"]
+                                                     headers:@{}
+                                                        path:@"/x"
+                                                       query:@{}];
+    XCTAssertNoThrow([request remoteAddressString]);
+    XCTAssertNoThrow([request localAddressString]);
+}
+
+// RFC 9110 s5.6.7 requires a recipient to accept all three HTTP-date formats. Only
+// IMF-fixdate parsed, so If-Modified-Since / If-Unmodified-Since / If-Range carrying the
+// obsolete spellings parsed to nil and the precondition was treated as ABSENT — a
+// conditional request failing open, which is the wrong direction for a validator.
+- (void)testHTTPDateParsingAcceptsAllThreeFormatsRFC9110Requires {
+    NSDate* expected = [NSDate dateWithTimeIntervalSince1970:784111777.0];  // Sun, 06 Nov 1994 08:49:37 GMT
+
+    NSDate* imf = WSKParseRFC822(@"Sun, 06 Nov 1994 08:49:37 GMT");
+    XCTAssertNotNil(imf, @"IMF-fixdate must parse");
+    XCTAssertEqualWithAccuracy([imf timeIntervalSince1970], [expected timeIntervalSince1970], 0.5);
+
+    NSDate* rfc850 = WSKParseRFC822(@"Sunday, 06-Nov-94 08:49:37 GMT");
+    XCTAssertNotNil(rfc850, @"RFC 850 date must parse");
+    XCTAssertEqualWithAccuracy([rfc850 timeIntervalSince1970], [expected timeIntervalSince1970], 0.5);
+
+    NSDate* asctime = WSKParseRFC822(@"Sun Nov  6 08:49:37 1994");
+    XCTAssertNotNil(asctime, @"asctime() date must parse");
+    XCTAssertEqualWithAccuracy([asctime timeIntervalSince1970], [expected timeIntervalSince1970], 0.5);
+
+    // Garbage must still be refused, or "accept everything" would pass the above.
+    XCTAssertNil(WSKParseRFC822(@"not a date at all"));
+    XCTAssertNil(WSKParseRFC822(@""));
+}
+
+// The trailing-slash precondition was undocumented and enforced by WSK_DNOT_REACHED():
+// abort with no diagnostic in Debug, and in Release it registered NOTHING and returned,
+// so every request 404'd with the host app given no clue why.
+- (void)testBasePathHandlerAcceptsABasePathWithoutATrailingSlash {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    [@"served" writeToFile:[dir stringByAppendingPathComponent:@"x.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    XCTAssertNoThrow([server addGETHandlerForBasePath:@"/files" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES]);
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* response = SendRawRequest(server.port, @"GET /files/x.txt HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([response containsString:@"200"], @"a base path without a trailing slash must still serve: %@", [response substringToIndex:MIN((NSUInteger)40, response.length)]);
+    XCTAssertTrue([response containsString:@"served"], @"the body must be the file's contents");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// -stop on a server whose start FAILED asserted _source4 != NULL, so the tidy-up an
+// error path would naturally do aborted a Debug build. Stopping something that never
+// started must be a no-op.
+- (void)testStopAfterAFailedStartIsANoOp {
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addDefaultHandlerForMethod:@"GET" requestClass:[WSKRequest class] processBlock:^WSKResponse*(WSKRequest* request) {
+        return [WSKDataResponse responseWithText:@"hi"];
+    }];
+
+    // Port 1 is privileged, so bind(2) fails for an unprivileged test process.
+    NSDictionary* privileged = @{WSKOption_Port : @1, WSKOption_BindToLocalhost : @YES};
+    XCTAssertFalse([server startWithOptions:privileged error:NULL]);
+    XCTAssertFalse(server.isRunning);
+    XCTAssertNoThrow([server stop]);
+    XCTAssertNoThrow([server stop]);
+}
+
 @end

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -118,33 +118,61 @@ NSUInteger WSKReservedMemoryLength(void) {
 @end
 
 static NSDateFormatter *_dateFormatterRFC822 = nil;
+// RFC 9110 s5.6.7 requires a recipient to accept all three HTTP-date formats. Only
+// IMF-fixdate was handled, so If-Modified-Since / If-Unmodified-Since / If-Range carrying
+// either obsolete spelling parsed to nil and the precondition was treated as ABSENT — a
+// conditional request failing OPEN, which is the wrong direction for a validator. Only
+// ever parsed with, never formatted: senders must emit IMF-fixdate.
+static NSDateFormatter *_dateFormatterRFC850 = nil;
+static NSDateFormatter *_dateFormatterAsctime = nil;
 static NSDateFormatter *_dateFormatterISO8601 = nil;
 static dispatch_queue_t _dateFormatterQueue = NULL;
 
-// TODO: Handle RFC 850 and ANSI C's asctime() format
-void WSKInitializeFunctions(void) {
-    WSK_DCHECK([NSThread isMainThread]);  // NSDateFormatter should be initialized on main thread
+// Idempotent and safe from any thread: everything here is built exactly once, under
+// dispatch_once, and read-only thereafter (all use is serialized on _dateFormatterQueue).
+//
+// It is called lazily from every function that touches a formatter, not only from
+// +[WSKWebServer initialize]. Previously it ran ONLY from there, so the public
+// WSKFormatRFC822 / WSKParseRFC822 / WSKFormatISO8601 / WSKParseISO8601 dispatch_sync'd on
+// a NULL queue — an immediate crash — for any host app that called one before touching the
+// server class at all. There is no longer a main-thread requirement: NSDateFormatter has
+// been safe to construct off the main thread for many OS releases, and dispatch_once
+// removes the race the old assertion was standing in for.
+static void _EnsureDateFormatters(void) {
+    static dispatch_once_t onceToken;
 
-    if (_dateFormatterRFC822 == nil) {
+    dispatch_once(&onceToken, ^{
         _dateFormatterRFC822 = [[NSDateFormatter alloc] init];
         _dateFormatterRFC822.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
         _dateFormatterRFC822.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'";
         _dateFormatterRFC822.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
-        WSK_DCHECK(_dateFormatterRFC822);
-    }
 
-    if (_dateFormatterISO8601 == nil) {
+        _dateFormatterRFC850 = [[NSDateFormatter alloc] init];
+        _dateFormatterRFC850.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+        _dateFormatterRFC850.dateFormat = @"EEEE',' dd'-'MMM'-'yy HH':'mm':'ss 'GMT'";
+        _dateFormatterRFC850.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+        // RFC 9110 s5.6.7: a two-digit year more than 50 years in the future means the most
+        // recent past year with those digits. A window opening 50 years ago is exactly that
+        // rule. Sampled once, which is right for a formatter built once — the boundary moves
+        // by a year annually and no HTTP client is sending dates near it.
+        _dateFormatterRFC850.twoDigitStartDate = [NSDate dateWithTimeIntervalSinceNow:-50.0 * 365.2425 * 24.0 * 60.0 * 60.0];
+
+        _dateFormatterAsctime = [[NSDateFormatter alloc] init];
+        _dateFormatterAsctime.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+        _dateFormatterAsctime.dateFormat = @"EEE MMM d HH':'mm':'ss yyyy";
+        _dateFormatterAsctime.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+
         _dateFormatterISO8601 = [[NSDateFormatter alloc] init];
         _dateFormatterISO8601.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
         _dateFormatterISO8601.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'+00:00'";
         _dateFormatterISO8601.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
-        WSK_DCHECK(_dateFormatterISO8601);
-    }
 
-    if (_dateFormatterQueue == NULL) {
         _dateFormatterQueue = dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL);
-        WSK_DCHECK(_dateFormatterQueue);
-    }
+    });
+}
+
+void WSKInitializeFunctions(void) {
+    _EnsureDateFormatters();
 }
 
 NSString *WSKNormalizeHeaderValue(NSString *value) {
@@ -237,6 +265,7 @@ NSStringEncoding WSKStringEncodingFromCharset(NSString *charset) {
 NSString *WSKFormatRFC822(NSDate *date) {
     __block NSString *string;
 
+    _EnsureDateFormatters();
     dispatch_sync(_dateFormatterQueue, ^{
         string = [_dateFormatterRFC822 stringFromDate:date];
     });
@@ -244,10 +273,27 @@ NSString *WSKFormatRFC822(NSDate *date) {
 }
 
 NSDate *WSKParseRFC822(NSString *string) {
+    if (string.length == 0) {
+        return nil;
+    }
+
     __block NSDate *date;
 
+    _EnsureDateFormatters();
     dispatch_sync(_dateFormatterQueue, ^{
         date = [_dateFormatterRFC822 dateFromString:string];
+
+        if (date == nil) {
+            date = [_dateFormatterRFC850 dateFromString:string];
+        }
+
+        if (date == nil) {
+            // asctime() pads a single-digit day to width two ("Sun Nov  6 ..."), which the
+            // "d" specifier does not absorb. Collapsing runs of spaces makes the one legal
+            // variant parse without loosening the pattern itself.
+            NSString *const collapsed = [string stringByReplacingOccurrencesOfString:@"  " withString:@" "];
+            date = [_dateFormatterAsctime dateFromString:collapsed];
+        }
     });
     return date;
 }
@@ -255,6 +301,7 @@ NSDate *WSKParseRFC822(NSString *string) {
 NSString *WSKFormatISO8601(NSDate *date) {
     __block NSString *string;
 
+    _EnsureDateFormatters();
     dispatch_sync(_dateFormatterQueue, ^{
         string = [_dateFormatterISO8601 stringFromDate:date];
     });
@@ -264,6 +311,7 @@ NSString *WSKFormatISO8601(NSDate *date) {
 NSDate *WSKParseISO8601(NSString *string) {
     __block NSDate *date;
 
+    _EnsureDateFormatters();
     dispatch_sync(_dateFormatterQueue, ^{
         date = [_dateFormatterISO8601 dateFromString:string];
     });
@@ -374,6 +422,16 @@ NSDictionary<NSString *, NSString *> *WSKParseURLEncodedForm(NSString *form) {
 NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL includeService) {
     char hostBuffer[NI_MAXHOST];
     char serviceBuffer[NI_MAXSERV];
+
+    // sa_len is read below before getnameinfo can fail, so a NULL address is a SEGV rather
+    // than an error return. It is reachable: a WSKRequest built by a WSKMatchBlock has no
+    // address data until the connection populates it AFTER the block returns, so a block
+    // that inspects the request it just built — which is the block's entire job — crashed
+    // the process. Same "" the getnameinfo failure below returns, so callers need no new
+    // case.
+    if (addr == NULL) {
+        return @"";
+    }
 
     // Always return on failure. Falling through would format two uninitialized stack
     // buffers into the result, leaking stack contents into logs — which is what happened

--- a/Sources/WebServerKit/Core/WSKRequest.h
+++ b/Sources/WebServerKit/Core/WSKRequest.h
@@ -187,7 +187,12 @@ extern NSString *const WSKRequestAttribute_RegexCaptures;
  *  Returns the address of the local peer (i.e. server) for the request
  *  as a raw "struct sockaddr".
  */
-@property (nonatomic, readonly) NSData *localAddressData;
+/**
+ *  Nil until the server populates it, which happens AFTER a WSKMatchBlock returns the
+ *  request — so a match block inspecting the request it just built sees nil here. The
+ *  string form below is non-null in that window and reports "".
+ */
+@property (nonatomic, readonly, nullable) NSData *localAddressData;
 
 /**
  *  Returns the address of the local peer (i.e. server) for the request
@@ -199,7 +204,7 @@ extern NSString *const WSKRequestAttribute_RegexCaptures;
  *  Returns the address of the remote peer (i.e. client) for the request
  *  as a raw "struct sockaddr".
  */
-@property (nonatomic, readonly) NSData *remoteAddressData;
+@property (nonatomic, readonly, nullable) NSData *remoteAddressData;
 
 /**
  *  Returns the address of the remote peer (i.e. client) for the request

--- a/Sources/WebServerKit/Core/WSKWebServer.h
+++ b/Sources/WebServerKit/Core/WSKWebServer.h
@@ -576,11 +576,15 @@ extern NSString *const WSKAuthenticationMethod_DigestAccess;
 /**
  *  Adds a handler to the server to respond to incoming "GET" HTTP requests
  *  with a case-insensitive path inside a base path with the corresponding file
- *  inside a local directory. If no local file matches the request path, a 401
+ *  inside a local directory. If no local file matches the request path, a 404
  *  HTTP status code is returned to the client.
  *
  *  The "indexFilename" argument allows to specify an "index" file name to use
  *  when the request path corresponds to a directory.
+ *
+ *  "basePath" is normalized: a missing leading or trailing "/" is added, so "files",
+ *  "/files" and "/files/" all register the same handler. An empty base path registers
+ *  nothing and logs an error.
  */
 - (void)addGETHandlerForBasePath:(NSString *)basePath directoryPath:(NSString *)directoryPath indexFilename:(nullable NSString *)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests;
 

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1226,9 +1226,12 @@ static inline NSString *_EncodeBase64(NSString *string) {
         }
 
         _options = nil;
-    } else {
-        WSK_DNOT_REACHED();  // Stopping a server that was never started is an API misuse by the host app
     }
+
+    // Deliberately NOT WSK_DNOT_REACHED(). -stop on a server that never started is what an
+    // error path naturally does — most obviously right after -startWithOptions:error:
+    // returned NO, which leaves _options nil — and aborting a Debug build for it punished
+    // exactly the careful host app. Idempotent tidy-up is the useful contract here.
 }
 
 - (void)stop {
@@ -1574,7 +1577,25 @@ static NSString *_EscapeHTMLString(NSString *string) {
 }
 
 - (void)addGETHandlerForBasePath:(NSString *)basePath directoryPath:(NSString *)directoryPath indexFilename:(NSString *)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests allowHiddenItems:(BOOL)allowHiddenItems {
-    if ([basePath hasPrefix:@"/"] && [basePath hasSuffix:@"/"]) {
+    // The leading and trailing slashes used to be an undocumented precondition enforced by
+    // WSK_DNOT_REACHED(): abort with no diagnostic in Debug, and in Release register
+    // NOTHING and return, so every request 404'd with the host app given no clue why.
+    // Neither spelling is ambiguous, so both are simply normalized. Only a genuinely
+    // unusable base path is refused now, and loudly.
+    if (basePath.length == 0) {
+        WSK_LOG_ERROR(@"Refusing to add a base-path handler: the base path is empty");
+        return;
+    }
+
+    if (![basePath hasPrefix:@"/"]) {
+        basePath = [@"/" stringByAppendingString:basePath];
+    }
+
+    if (![basePath hasSuffix:@"/"]) {
+        basePath = [basePath stringByAppendingString:@"/"];
+    }
+
+    {
         WSKWebServer *__unsafe_unretained server = self;
         [self
             addHandlerWithMatchBlock:^WSKRequest *(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery) {
@@ -1690,8 +1711,6 @@ static NSString *_EscapeHTMLString(NSString *string) {
 
                 return response;
             }];
-    } else {
-        WSK_DNOT_REACHED();
     }
 }
 

--- a/Sources/WebServerKit/Responses/WSKFileResponse.m
+++ b/Sources/WebServerKit/Responses/WSKFileResponse.m
@@ -139,6 +139,19 @@ static NSString *_EscapeExtValue(NSString *string) {
 
     _file = -1;  // Not 0, which is a legal descriptor -close must not close by accident
 
+    // -fileSystemRepresentation RAISES for an empty or NUL-bearing receiver rather than
+    // returning NULL, and this initializer is declared nullable, so the raise escaped
+    // through the host app's handler and killed the process. Both spellings are reachable
+    // from client input by any handler that builds a path from a request. Same shape the
+    // eleventh pass fixed in +responseWithJSONObject:, at a site that fix did not reach.
+    // The NUL check stays even though open(2) would truncate there anyway: truncating
+    // makes the server act on a prefix of what was asked for, which is the outcome this
+    // library refuses everywhere else.
+    if ((path.length == 0) || WSKPathContainsNULByte(path)) {
+        WSK_LOG_ERROR(@"Refusing to serve a file with an empty or NUL-bearing path");
+        return nil;
+    }
+
     // Open the file *once*, here, and derive contentLength, lastModifiedDate and the ETag
     // from an fstat() of that descriptor. The old lstat()-here plus open()-in--open: pair
     // walked the path twice with the whole runtime of the request handler in between, so a


### PR DESCRIPTION
The first batch of the ~20 items the audit programme deferred. All six were filed as **low**, which turned out to be measuring reachability rather than consequence — each needs a host app to use a documented API in a documented way, and **four of the six kill the process**.

The clearest evidence is how the regression tests behaved against the unfixed tree. They did not fail; they crashed the test runner four separate times, and the suite reported:

```
Executed 0 tests, with 0 failures
```

Third time this repo has hit that trap.

## What was wrong

| | Consequence |
|---|---|
| `+responseWithFile:` is declared `nullable` but `-fileSystemRepresentation` **raises** for an empty or NUL-bearing path | Uncaught exception escapes the handler — **process gone**. Fourth site of the nil/NUL class an earlier fix didn't reach. |
| A `WSKMatchBlock` reading the request it just built | **SEGV**. `WSKStringFromSockAddr` reads `addr->sa_len` before `getnameinfo` can fail, and the connection populates the addresses *after* the block returns. |
| The four public date functions before any server exists | **Crash** — `dispatch_sync` on a NULL queue. Known-open since the sixth pass. |
| `If-Modified-Since` / `If-Unmodified-Since` / `If-Range` with an RFC 850 or `asctime()` date | Parsed to nil, so the precondition read as **absent** — a validator failing *open*. |
| `addGETHandlerForBasePath:@"/files"` (no trailing slash) | **Abort** in Debug with no diagnostic; in Release, registers nothing and every request 404s. |
| `-stop` after `-startWithOptions:error:` returned NO | **Abort** in Debug — punishing exactly the host app that cleans up. |

## Notes on the fixes

- **Deliberate source break**: `localAddressData` / `remoteAddressData` become `nullable`, because they genuinely are nil in the match-block window. Same call as the `WSKFileResponse` validators.
- **RFC 9110 §5.6.7 detail**: the two-digit-year rule is exactly a window opening 50 years ago (`twoDigitStartDate`); and `asctime()` pads a single-digit day to width two (`Sun Nov  6`), which `d` does not absorb, so runs of spaces are collapsed rather than the pattern loosened.
- The main-thread assertion on the date formatters is gone — `dispatch_once` removes the race it stood in for.

## An honesty note on the date test

The in-suite test **cannot regress-guard** that fix. XCTest runs one process in alphabetical order, so by the time it runs an earlier test has messaged `WSKWebServer` and the formatters already exist — it only exercised the lazy path because it ran in isolation. The real oracle is out-of-process: a binary linking the framework that names `WSKWebServer` nowhere.

```
fixed:    OK: all four date functions worked with no server ever created
unfixed:  exit=139   (SIGSEGV)
```

It lives in the scratch harness rather than the suite, since it needs its own link line.

## Verification

Run together rather than per-fix — per-fix greens are what let two regressions ride `main` through three CI runs earlier in this programme.

- **127 tests, 0 failures** on a clean build (executed count 127, not 0)
- **0 new warnings**; only the two pre-existing XCTest link warnings
- Trace corpus (`Run-Tests.sh`, what CI runs): all tests completed successfully
- iOS and tvOS Debug: exit 0, 0 warnings each
- Date oracle sensitive in both directions

## Still open

Batch B (status-code and documentation honesty) and batch C (the long-lived surfaces — SSE reaping, symlinked-ancestor event paths, Bonjour auto-rename, silent iOS foreground-restart failure). The `//` status disagreement, `MOVE`-without-`Overwrite` and the directory-rename TOCTOU remain settled decisions rather than defects.