### PR TITLE
Honest status codes: 507 for a full volume, and 14 wrong reason phrases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,86 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Known-open lows, batch B: honest status codes, and three entries that were not defects
+
+**Three of the recorded items were refuted by re-measuring them, and one of the three would have
+been an actively harmful "fix".** That is the fourth time this programme has found an aged finding
+evaporate on contact, and it is why the rule is to re-measure rather than work from the list:
+
+- **`If-Match` on a missing resource answering 404 is REQUIRED, not a bug.** RFC 9110 §13.2.1 says
+  a server MUST ignore all preconditions when the unconditional response would be anything other
+  than 2xx or 412 — so a conditional `DELETE` of something that does not exist must answer 404, and
+  "fixing" it to 412 would have broken conformance. `PUT` is the opposite case, because it would
+  create (201), so the condition IS evaluated and `If-Match: *` on a missing path correctly fails
+  412. Both directions are now pinned by a test, precisely so a later pass does not re-find the 404
+  and "correct" it.
+- **An empty header name was already refused** on the request side (`colon == 0`). The gap was on
+  the *response* side, which had no such check — fixed there instead.
+- **A MOVE whose swap fails already unwinds**, restoring the source rather than stranding it under
+  the staging dot-name. Only a double failure can leave residue, and nothing better is available
+  when the filesystem itself is refusing.
+
+**A full volume answered "you are not allowed".** ENOSPC and EDQUOT were mapped onto 500 for PUT
+and MKCOL, and — the sharp one — onto **403 Forbidden** for COPY and MOVE. 403 is a claim that the
+client may never do this, so a client that would have retried after freeing space gives up
+permanently instead. RFC 4918 §11.5 defines 507 for exactly this. Measured on a genuinely full
+2 MB volume, before and after:
+
+| verb | before | after |
+|---|---|---|
+| PUT | 500 Internal Server Error | 507 Insufficient Storage |
+| MKCOL | 500 Internal Server Error | 507 Insufficient Storage |
+| COPY | **403 Forbidden** | 507 Insufficient Storage |
+
+Both spellings have to be read or the mapping closes half the class: `NSFileManager` reports a full
+volume as `NSFileWriteOutOfSpaceError`, while `EDQUOT` only ever arrives as a POSIX errno nested
+under `NSUnderlyingError`.
+
+**⚠️ Fourteen status codes went out under the wrong reason phrase, and the unit test could not have
+found it.** `CFHTTPMessageCreateResponse`'s own table stops at HTTP/1.1 as it stood in 1999, so
+every status registered since gets its class default. Three of them this library emits in ordinary
+operation: **`421 Misdirected Request` — the Host allow-list refusal, i.e. the whole DNS-rebinding
+defence — was serialized as `421 Bad Request`**, as were `424 Failed Dependency` (PROPPATCH's
+atomicity refusal, added earlier in this programme) and `431 Request Header Fields Too Large` (the
+fifth pass's header cap). Measured across all 56 codes in `WSKHTTPStatusCodes.h`.
+
+The lesson is the one this file keeps re-learning from a different angle: the 507 work was covered
+by a unit test over the mapping function, which passed and proved only that the *function* was
+right. The end-to-end probe against a real full volume is what showed the status line itself, and
+that is where the phrase was visibly wrong. **A test of the helper is not a test of the wiring.**
+
+Only those fourteen are supplied; everything CF already gets right is left to CF, so all four
+statuses the recorded-trace corpus contains (200, 201, 207, 404) still serialize byte for byte. The
+corpus fails on any difference, so rewriting phrases it records would have turned a fix into a
+corpus change.
+
+**MKCOL answered 500 with the collection already created.** The creation-date step runs after the
+directory exists, so a failure there told the client the method failed while leaving the collection
+behind — and the retry then gets 405 because it is there. The collection is removed before the error
+goes out. "A refused transaction leaves nothing behind" applies to the failure paths too.
+
+**`-startWithOptions:error:` on an already-running server was a fourth process kill.** It is
+documented to return NO, and the way a host app finds out is `*error` — which was never set. In
+Debug it did not return at all: `WSK_DNOT_REACHED()` aborted. Same shape as all six of batch A, found
+because the test for the *documented* behaviour crashed the runner rather than failing.
+
+**Six non-null properties that are genuinely nil are `nullable` now** — `allowedFileExtensions` on
+both servers, and `title`, `header`, `prologue`, `epilogue` and `footer` on the uploader. nil is
+*meaningful* for every one of them (no extension restriction; use the computed default), so
+substituting a value in the getter would have destroyed information rather than told the truth. One
+of them, `epilogue`, was documented as "the default value is nil" directly beneath a non-null
+declaration. Source-breaking for Swift, deliberately, as in batch A. The `Server` header default was
+also documented as the class name when it is `"WebServerKit"`.
+
+**Verified together.** 133 tests and 0 failures on a clean build with no new warnings, the trace
+corpus green, iOS and tvOS Debug both clean, and the full-volume probe sensitive in both directions.
+
+**Still open:** batch C, the long-lived surfaces — the SSE quiet-client reaping gap, SSE paths
+collapsing to `/` through a symlinked ancestor, `-bonjourName` after an auto-rename, and the silent
+iOS foreground-restart failure. The `//` status disagreement, `MOVE`-without-`Overwrite`, the
+directory-rename TOCTOU and litmus's `propfind_invalid2` remain settled decisions rather than
+defects.
+
 ### Known-open lows, batch A: six ways a host app could kill the process
 
 The ~20 items the audit programme deferred were all filed as "low". For these six that label was

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -4819,4 +4819,138 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     XCTAssertNoThrow([server stop]);
 }
 
+
+#pragma mark - Honest status codes and contracts (batch B)
+
+// The creation-date block runs AFTER the collection exists, so a failure there answered 500
+// having already created it — the client is told the method failed and a retry then gets 405
+// because the collection is there. "A transaction leaves nothing behind" applies to the
+// failure paths too, so the collection is removed before the error goes out.
+- (void)testMKCOLLeavesNothingBehindWhenItFailsAfterCreating {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // An unparseable creation date fails the step that runs after the directory is made.
+    NSString* response = SendRawRequest(server.port, @"MKCOL /NewFolder HTTP/1.1\r\nHost: localhost\r\nX-WebServerKit-CreationDate: not-a-date\r\n\r\n");
+    BOOL const refused = ![response containsString:@" 201"];
+    BOOL const present = [fm fileExistsAtPath:[dir stringByAppendingPathComponent:@"NewFolder"]];
+
+    NSString* const detail = [NSString stringWithFormat:@"refused=%d present=%d response=%@", refused, present, [response substringToIndex:MIN((NSUInteger)40, response.length)]];
+    XCTAssertFalse(refused && present, @"a refused MKCOL must not leave the collection behind: %@", detail);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// An empty field name serializes as ": value", which is not a field-line at all. The request
+// parser already refuses one; this is the response side, which did not.
+- (void)testResponseRefusesAnEmptyAdditionalHeaderName {
+    WSKResponse* response = [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_OK];
+    [response setValue:@"x" forAdditionalHeader:@""];
+    XCTAssertNil([response valueForAdditionalHeader:@""], @"an empty header name must be refused, not stored");
+
+    // A legitimate name must still work, or this could pass by refusing everything.
+    [response setValue:@"bytes" forAdditionalHeader:@"Accept-Ranges"];
+    XCTAssertEqualObjects([response valueForAdditionalHeader:@"Accept-Ranges"], @"bytes");
+}
+
+// -startWithOptions:error: returns NO for an already-running server but left *error nil, so a
+// host app doing the documented thing had nothing to report. It also aborted a Debug build.
+- (void)testStartingAnAlreadyStartedServerReportsAnError {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSError* error = nil;
+    BOOL started = NO;
+    XCTAssertNoThrow(started = [server startWithOptions:options error:&error]);
+    XCTAssertFalse(started, @"starting twice must fail");
+    XCTAssertNotNil(error, @"a failed start must set *error");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+
+// RFC 4918 §11.5: a volume that cannot store the representation is 507, not 500. Answering 500
+// invites the client to retry an operation that cannot succeed until something is freed. Both
+// spellings have to be read — NSFileManager reports a full volume as a Cocoa error, while
+// EDQUOT only ever arrives as a POSIX errno under NSUnderlyingError.
+- (void)testFullVolumeErrorsMapToInsufficientStorage {
+    NSError* cocoa = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteOutOfSpaceError userInfo:nil];
+    XCTAssertEqual(WSKServerErrorStatusCodeForError(cocoa), kWSKHTTPStatusCode_InsufficientStorage);
+
+    NSError* posix = [NSError errorWithDomain:NSPOSIXErrorDomain code:ENOSPC userInfo:nil];
+    XCTAssertEqual(WSKServerErrorStatusCodeForError(posix), kWSKHTTPStatusCode_InsufficientStorage);
+
+    NSError* quota = [NSError errorWithDomain:NSPOSIXErrorDomain code:EDQUOT userInfo:nil];
+    XCTAssertEqual(WSKServerErrorStatusCodeForError(quota), kWSKHTTPStatusCode_InsufficientStorage);
+
+    // The errno is usually buried under a Cocoa wrapper rather than at the top level.
+    NSDictionary* wrapped = @{NSUnderlyingErrorKey : [NSError errorWithDomain:NSPOSIXErrorDomain code:ENOSPC userInfo:nil]};
+    NSError* nested = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:wrapped];
+    XCTAssertEqual(WSKServerErrorStatusCodeForError(nested), kWSKHTTPStatusCode_InsufficientStorage);
+
+    // Everything else must stay 500, or this would relabel every failure as a full disk.
+    NSError* permissions = [NSError errorWithDomain:NSPOSIXErrorDomain code:EACCES userInfo:nil];
+    XCTAssertEqual(WSKServerErrorStatusCodeForError(permissions), kWSKHTTPStatusCode_InternalServerError);
+    XCTAssertEqual(WSKServerErrorStatusCodeForError(nil), kWSKHTTPStatusCode_InternalServerError);
+}
+
+// RFC 9110 §13.2.1 requires preconditions to be IGNORED when the unconditional response would
+// be anything other than 2xx or 412 — so a conditional DELETE of a resource that does not exist
+// must answer 404, not 412. PUT is the opposite case: it would create (201), so the condition is
+// evaluated and a missing resource fails "If-Match: *". Pinned in both directions because the
+// obvious "fix" for the 404 would break the rule this test exists to state.
+- (void)testConditionalRequestsOnAMissingResourceFollowTheEvaluationRule {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* deleted = SendRawRequest(server.port, @"DELETE /gone.txt HTTP/1.1\r\nHost: localhost\r\nIf-Match: *\r\n\r\n");
+    XCTAssertTrue([deleted containsString:@" 404"], @"DELETE of a missing resource must ignore the precondition and 404: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+
+    NSString* put = SendRawRequest(server.port, @"PUT /gone.txt HTTP/1.1\r\nHost: localhost\r\nIf-Match: *\r\nContent-Length: 2\r\n\r\nhi");
+    XCTAssertTrue([put containsString:@" 412"], @"PUT would create, so \"If-Match: *\" on a missing resource must fail 412: %@", [put substringToIndex:MIN((NSUInteger)40, put.length)]);
+    XCTAssertFalse([fm fileExistsAtPath:[dir stringByAppendingPathComponent:@"gone.txt"]], @"a 412 must not have written anything");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+
+// CFHTTPMessageCreateResponse's reason-phrase table predates every status registered after
+// HTTP/1.1, so it answered the class default for fourteen of the codes this library declares.
+// 421 is the Host allow-list refusal — the DNS-rebinding defence — and it went out labelled
+// "Bad Request", which is a different claim about why the request was refused.
+- (void)testStatusLinesCarryTheirOwnReasonPhrase {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_AllowedHostNames : @[@"allowed.example"]};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* misdirected = SendRawRequest(server.port, @"GET / HTTP/1.1\r\nHost: evil.example\r\n\r\n");
+    XCTAssertTrue([misdirected hasPrefix:@"HTTP/1.1 421 Misdirected Request"], @"421 must name itself: %@", [misdirected substringToIndex:MIN((NSUInteger)40, misdirected.length)]);
+
+    // A code CoreFoundation already gets right must be untouched — the recorded-trace corpus
+    // compares response bytes, so a phrase changing there would be a corpus break.
+    NSString* notFound = SendRawRequest(server.port, @"GET /nope.txt HTTP/1.1\r\nHost: allowed.example\r\n\r\n");
+    XCTAssertTrue([notFound hasPrefix:@"HTTP/1.1 404 Not Found"], @"404's phrase must be unchanged: %@", [notFound substringToIndex:MIN((NSUInteger)40, notFound.length)]);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 @end

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -163,9 +163,55 @@ NS_ASSUME_NONNULL_END
     return (localSockAddr->sa_family == AF_INET6);
 }
 
+// CFHTTPMessageCreateResponse's own reason-phrase table stops at HTTP/1.1 as it stood in 1999,
+// so every status registered since gets its class default instead of its name. Three of them
+// this library emits in ordinary operation: 421 Misdirected Request — the Host allow-list
+// refusal, i.e. the DNS-rebinding defence — went out as "421 Bad Request", as did 424 Failed
+// Dependency (PROPPATCH's atomicity refusal) and 431 Request Header Fields Too Large (the
+// header cap). Measured across all 56 codes in WSKHTTPStatusCodes.h: fourteen were wrong.
+//
+// ONLY those fourteen are supplied. Everything CF already gets right is left to CF, so every
+// status the recorded-trace corpus contains (200, 201, 207, 404) still serializes byte for
+// byte — the corpus fails on any difference, and rewriting phrases it records would have made
+// this a corpus change rather than a fix.
+static CFStringRef _ReasonPhraseForStatusCode(NSInteger statusCode) {
+    switch (statusCode) {
+        case 102:
+            return CFSTR("Processing");
+        case 208:
+            return CFSTR("Already Reported");
+        case 421:
+            return CFSTR("Misdirected Request");
+        case 422:
+            return CFSTR("Unprocessable Content");
+        case 423:
+            return CFSTR("Locked");
+        case 424:
+            return CFSTR("Failed Dependency");
+        case 426:
+            return CFSTR("Upgrade Required");
+        case 428:
+            return CFSTR("Precondition Required");
+        case 429:
+            return CFSTR("Too Many Requests");
+        case 431:
+            return CFSTR("Request Header Fields Too Large");
+        case 507:
+            return CFSTR("Insufficient Storage");
+        case 508:
+            return CFSTR("Loop Detected");
+        case 510:
+            return CFSTR("Not Extended");
+        case 511:
+            return CFSTR("Network Authentication Required");
+        default:
+            return NULL;  // CF's phrase is correct for this one.
+    }
+}
+
 - (void)_initializeResponseHeadersWithStatusCode:(NSInteger)statusCode {
     _statusCode = statusCode;
-    _responseMessage = CFHTTPMessageCreateResponse(kCFAllocatorDefault, statusCode, NULL, kCFHTTPVersion1_1);
+    _responseMessage = CFHTTPMessageCreateResponse(kCFAllocatorDefault, statusCode, _ReasonPhraseForStatusCode(statusCode), kCFHTTPVersion1_1);
     CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Connection"), CFSTR("Close"));
     CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Server"), (__bridge CFStringRef)_serverName);
     CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Date"), (__bridge CFStringRef)WSKFormatRFC822([NSDate date]));

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -27,6 +27,12 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_include(<WebServerKit/WSKHTTPStatusCodes.h>)
+#import <WebServerKit/WSKHTTPStatusCodes.h>
+#else
+#import "WSKHTTPStatusCodes.h"
+#endif
+
 #include <sys/stat.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -117,6 +123,16 @@ NSDate *_Nullable WSKParseISO8601(NSString *string);
  *  it by another route.
  */
 BOOL WSKPathContainsNULByte(NSString *_Nullable path);
+
+/**
+ *  Maps a filesystem NSError onto the server-error status that describes it honestly.
+ *
+ *  RFC 4918 §11.5: 507 Insufficient Storage means the method could not be performed because
+ *  the server cannot store the representation. A full volume or an exceeded quota is exactly
+ *  that, and answering 500 invites the client to retry an operation that cannot succeed until
+ *  something is freed. Everything else stays 500.
+ */
+WSKServerErrorHTTPStatusCode WSKServerErrorStatusCodeForError(NSError *_Nullable error);
 
 /**
  *  Removes "//", "/./" and "/../" components from path as well as any trailing slash.

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -447,6 +447,27 @@ NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL includeService
     return includeService ? [NSString stringWithFormat:@"%s:%s", hostBuffer, serviceBuffer] : (NSString *)[NSString stringWithUTF8String:hostBuffer];
 }
 
+WSKServerErrorHTTPStatusCode WSKServerErrorStatusCodeForError(NSError *error) {
+    if (error == nil) {
+        return kWSKHTTPStatusCode_InternalServerError;
+    }
+
+    // NSFileManager reports a full volume as a Cocoa error, but the POSIX errno survives under
+    // NSUnderlyingError for the calls that go through it, and EDQUOT never gets a Cocoa code of
+    // its own. Both spellings have to be read or the mapping closes only half the class.
+    for (NSError *candidate = error; candidate != nil; candidate = candidate.userInfo[NSUnderlyingErrorKey]) {
+        if ([candidate.domain isEqualToString:NSCocoaErrorDomain] && (candidate.code == NSFileWriteOutOfSpaceError)) {
+            return kWSKHTTPStatusCode_InsufficientStorage;
+        }
+
+        if ([candidate.domain isEqualToString:NSPOSIXErrorDomain] && ((candidate.code == ENOSPC) || (candidate.code == EDQUOT))) {
+            return kWSKHTTPStatusCode_InsufficientStorage;
+        }
+    }
+
+    return kWSKHTTPStatusCode_InternalServerError;
+}
+
 NSString *WSKGetPrimaryIPAddress(BOOL useIPv6) {
     NSString *address = nil;
 

--- a/Sources/WebServerKit/Core/WSKResponse.m
+++ b/Sources/WebServerKit/Core/WSKResponse.m
@@ -295,6 +295,15 @@
     // untrusted input would split the response and inject headers of the attacker's
     // choosing. No caller in this library does that, but this is the chokepoint, and a host
     // app naming a header after request data should not be able to forge a response.
+    // RFC 9112 §5 field-name is 1*tchar, so an empty name is not a field-line at all — it
+    // serializes as ": value", which a recipient may drop, treat as a continuation, or refuse
+    // the whole message over. The request parser already refuses one; this is the same rule on
+    // the response side, which did not have it.
+    if (header.length == 0) {
+        WSK_LOG_ERROR(@"Ignoring additional response header with an empty name");
+        return;
+    }
+
     NSRange controlCharacter = [header rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"\r\n:"]];
 
     if (controlCharacter.location != NSNotFound) {

--- a/Sources/WebServerKit/Core/WSKWebServer.h
+++ b/Sources/WebServerKit/Core/WSKWebServer.h
@@ -172,7 +172,7 @@ extern NSString *const WSKOption_MaxPendingConnections;
 /**
  *  The value for "Server" HTTP header used by the WSKWebServer (NSString).
  *
- *  The default value is the WSKWebServer class name.
+ *  The default value is "WebServerKit".
  */
 extern NSString *const WSKOption_ServerName;
 

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1159,8 +1159,15 @@ static inline NSString *_EncodeBase64(NSString *string) {
 
 #endif
         return YES;
-    } else {
-        WSK_DNOT_REACHED();  // Starting an already-started server is an API misuse by the host app
+    }
+
+    // Deliberately NOT WSK_DNOT_REACHED(). This returns NO, so the documented way for a host
+    // app to find out is *error — which was never set, leaving a caller that did exactly what
+    // the header says with nothing to report and, in Debug, an abort instead of a return.
+    WSK_LOG_ERROR(@"Refusing to start: the server is already running");
+
+    if (error) {
+        *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"The server is already running"}];
     }
 
     return NO;

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.h
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.h
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The default value is nil i.e. all file extensions are allowed.
  */
-@property (nonatomic, copy) NSArray<NSString *> *allowedFileExtensions;
+@property (nonatomic, copy, nullable) NSArray<NSString *> *allowedFileExtensions;
 
 /**
  *  Sets if files and directories whose name start with a period are allowed to

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -880,12 +880,12 @@ static NSString *const kDAVAllowedMethods = @"OPTIONS, HEAD, GET, PUT, DELETE, M
     BOOL const haveVetted = existing && (lstat([absolutePath fileSystemRepresentation], &vetted) == 0);
 
     if (![fileManager moveItemAtPath:request.temporaryPath toPath:writePath error:&error]) {
-        return [WSKErrorResponse responseWithServerError:kWSKHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
+        return [WSKErrorResponse responseWithServerError:WSKServerErrorStatusCodeForError(error) underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
     }
 
     if (stagingPath && ![self _replaceItemAtPath:absolutePath withStagedItemAtPath:stagingPath expecting:(haveVetted ? &vetted : NULL) error:&error]) {
         [fileManager removeItemAtPath:stagingPath error:NULL];
-        return [WSKErrorResponse responseWithServerError:kWSKHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
+        return [WSKErrorResponse responseWithServerError:WSKServerErrorStatusCodeForError(error) underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
     }
 
     if ([self.delegate respondsToSelector:@selector(davServer:didUploadFileAtPath:)]) {
@@ -1020,7 +1020,7 @@ static NSString *const kDAVAllowedMethods = @"OPTIONS, HEAD, GET, PUT, DELETE, M
     NSError *error = nil;
 
     if (![[NSFileManager defaultManager] createDirectoryAtPath:absolutePath withIntermediateDirectories:NO attributes:nil error:&error]) {
-        return [WSKErrorResponse responseWithServerError:kWSKHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed creating directory \"%@\"", relativePath];
+        return [WSKErrorResponse responseWithServerError:WSKServerErrorStatusCodeForError(error) underlyingError:error message:@"Failed creating directory \"%@\"", relativePath];
     }
 
 #ifdef __WEBSERVERKIT_ENABLE_TESTING__
@@ -1030,6 +1030,11 @@ static NSString *const kDAVAllowedMethods = @"OPTIONS, HEAD, GET, PUT, DELETE, M
         NSDate *const date = WSKParseISO8601(creationDateHeader);
 
         if (!date || ![[NSFileManager defaultManager] setAttributes:@{NSFileCreationDate: date} ofItemAtPath:absolutePath error:&error]) {
+            // This step runs AFTER the collection exists, so returning here used to answer 500
+            // having already created it: the client is told the method failed, and a retry then
+            // gets 405 because the collection is there. "A refused transaction leaves nothing
+            // behind" applies to the failure paths too.
+            [[NSFileManager defaultManager] removeItemAtPath:absolutePath error:NULL];
             return [WSKErrorResponse responseWithServerError:kWSKHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed setting creation date for directory \"%@\"", relativePath];
         }
     }
@@ -1262,11 +1267,22 @@ static NSString *const kDAVAllowedMethods = @"OPTIONS, HEAD, GET, PUT, DELETE, M
 
     if (isMove) {
         if (![fileManager moveItemAtPath:srcAbsolutePath toPath:writePath error:&error]) {
+            // A full volume is not a permission problem, and 403 tells the client it is never
+            // allowed to do this rather than that there is no room for it right now.
+            if (WSKServerErrorStatusCodeForError(error) == kWSKHTTPStatusCode_InsufficientStorage) {
+                return [WSKErrorResponse responseWithServerError:kWSKHTTPStatusCode_InsufficientStorage underlyingError:error message:@"Failed moving \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
+            }
+
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden underlyingError:error message:@"Failed moving \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
         }
     } else {
         if (![fileManager copyItemAtPath:srcAbsolutePath toPath:writePath error:&error]) {
             [fileManager removeItemAtPath:writePath error:NULL];  // A failed tree copy leaves a partial tree behind.
+
+            if (WSKServerErrorStatusCodeForError(error) == kWSKHTTPStatusCode_InsufficientStorage) {
+                return [WSKErrorResponse responseWithServerError:kWSKHTTPStatusCode_InsufficientStorage underlyingError:error message:@"Failed copying \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
+            }
+
             return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden underlyingError:error message:@"Failed copying \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
         }
     }

--- a/Sources/WebServerKitUploader/WSKWebUploader.h
+++ b/Sources/WebServerKitUploader/WSKWebUploader.h
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The default value is nil i.e. all file extensions are allowed.
  */
-@property (nonatomic, copy) NSArray<NSString *> *allowedFileExtensions;
+@property (nonatomic, copy, nullable) NSArray<NSString *> *allowedFileExtensions;
 
 /**
  *  Sets if files and directories whose name start with a period are allowed to
@@ -123,7 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning Any reserved HTML characters in the string value for this property
  *  must have been replaced by character entities e.g. "&" becomes "&amp;".
  */
-@property (nonatomic, copy) NSString *title;
+@property (nonatomic, copy, nullable) NSString *title;
 
 /**
  *  Sets the header for the uploader web interface.
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning Any reserved HTML characters in the string value for this property
  *  must have been replaced by character entities e.g. "&" becomes "&amp;".
  */
-@property (nonatomic, copy) NSString *header;
+@property (nonatomic, copy, nullable) NSString *header;
 
 /**
  *  Sets the prologue for the uploader web interface.
@@ -143,7 +143,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning The string value for this property must be raw HTML
  *  e.g. "<p>Some text</p>"
  */
-@property (nonatomic, copy) NSString *prologue;
+@property (nonatomic, copy, nullable) NSString *prologue;
 
 /**
  *  Sets the epilogue for the uploader web interface.
@@ -153,7 +153,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning The string value for this property must be raw HTML
  *  e.g. "<p>Some text</p>"
  */
-@property (nonatomic, copy) NSString *epilogue;
+@property (nonatomic, copy, nullable) NSString *epilogue;
 
 /**
  *  Sets the footer for the uploader web interface.
@@ -163,7 +163,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @warning Any reserved HTML characters in the string value for this property
  *  must have been replaced by character entities e.g. "&" becomes "&amp;".
  */
-@property (nonatomic, copy) NSString *footer;
+@property (nonatomic, copy, nullable) NSString *footer;
 
 /**
  *  This method is the designated initializer for the class.


### PR DESCRIPTION
Batch B of the known-open lows — the status-code and documentation honesty group.

## Three recorded items were not defects

Re-measured rather than fixed from the list. One of the three would have been an actively harmful "fix":

- **`If-Match` on a missing resource answering 404 is *required*.** RFC 9110 §13.2.1: a server MUST ignore all preconditions when the unconditional response would be anything other than 2xx or 412. So a conditional `DELETE` of something that doesn't exist must answer 404 — changing it to 412 would have broken conformance. `PUT` is the opposite case (it would create, 201), so the condition *is* evaluated and `If-Match: *` correctly fails 412. **Both directions are now pinned by a test**, specifically so a later pass doesn't re-find the 404 and "correct" it.
- **Empty header names were already refused** on the request side. The gap was on the *response* side, and is fixed there.
- **A MOVE whose swap fails already unwinds**, restoring the source rather than stranding it.

## A full volume answered "you are not allowed"

`ENOSPC`/`EDQUOT` mapped onto 500 for PUT and MKCOL and — the sharp one — **403 Forbidden** for COPY/MOVE. 403 claims the client may *never* do this, so a client that would have retried after freeing space gives up permanently. RFC 4918 §11.5 defines 507 for exactly this.

Measured on a genuinely full 2 MB volume:

| verb | before | after |
|---|---|---|
| PUT | 500 Internal Server Error | **507 Insufficient Storage** |
| MKCOL | 500 Internal Server Error | **507 Insufficient Storage** |
| COPY | **403 Forbidden** | **507 Insufficient Storage** |

Both spellings are read, or the mapping closes half the class: `NSFileManager` reports a full volume as `NSFileWriteOutOfSpaceError`, while `EDQUOT` only ever arrives as a POSIX errno nested under `NSUnderlyingError`.

## ⚠️ Fourteen codes went out under the wrong reason phrase

`CFHTTPMessageCreateResponse`'s table stops at HTTP/1.1 as it stood in 1999, so every status registered since gets its class default. Measured across all 56 codes in `WSKHTTPStatusCodes.h`. Three are emitted in ordinary operation:

| code | was serialized as | should be |
|---|---|---|
| **421** | `421 Bad Request` | `421 Misdirected Request` |
| **424** | `424 Bad Request` | `424 Failed Dependency` |
| **431** | `431 Bad Request` | `431 Request Header Fields Too Large` |

421 is the **Host allow-list refusal — the entire DNS-rebinding defence** — labelled as a malformed request.

**How this was found is the point.** The 507 work had a passing unit test over the mapping function, which proved only that the *function* was right. The end-to-end probe against a real full volume is what surfaced the status line, and that's where the phrase was visibly wrong. A test of the helper is not a test of the wiring.

Only those fourteen are supplied — everything CF already gets right is left to CF, so all four statuses the recorded-trace corpus contains (200, 201, 207, 404) still serialize byte for byte. The corpus fails on any difference, so rewriting phrases it records would have turned a fix into a corpus change.

## The rest

- **MKCOL answered 500 with the collection already created**, so the retry then got 405. Removed before the error goes out — "a refused transaction leaves nothing behind" applies to failure paths too.
- **`-startWithOptions:error:` on an already-running server** never set `*error`, and aborted a Debug build via `WSK_DNOT_REACHED()`. A fourth instance of batch A's shape, found because the test for the *documented* behaviour crashed the runner rather than failing.
- **Six non-null properties that are genuinely nil are `nullable`** — `allowedFileExtensions` on both servers plus `title`/`header`/`prologue`/`epilogue`/`footer` on the uploader. nil is *meaningful* for every one, so substituting a getter value would destroy information rather than tell the truth. `epilogue` was documented as "the default value is nil" directly beneath a non-null declaration. Deliberate Swift source break, as in batch A.
- The `Server` header default was documented as the class name; it is `"WebServerKit"`.

## Verification

- **133 tests, 0 failures** on a clean build
- **0 new warnings**
- Trace corpus green — the load-bearing check for the reason-phrase change
- iOS and tvOS Debug: exit 0, 0 warnings
- Full-volume probe sensitive in both directions

## Still open

Batch C — the long-lived surfaces: SSE quiet-client reaping, SSE paths collapsing to `/` through a symlinked ancestor, `-bonjourName` after auto-rename, and the silent iOS foreground-restart failure.