### PR TITLE
SSE live updates were broken by default, and Bonjour never saw a rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,71 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Known-open lows, batch C: the long-lived surfaces, and live updates that were broken by default
+
+**⚠️ The headline finding is far broader than the entry that predicted it.** It was carried as "SSE
+event paths collapse to `/` when the share is reached through a symlinked ancestor" — which reads
+like an exotic configuration. It is the **default**. `-_relativePathForAbsolutePath:` derives an
+event's path by chopping the share off the front of an absolute path; every caller hands it a
+`realpath(3)` result while `_uploadDirectory` has only been `-stringByStandardizingPath`'d. Those
+disagree for **every share under `NSTemporaryDirectory()`**, because `/var` is a symlink to
+`/private/var` that neither `-stringByStandardizingPath` nor `-stringByResolvingSymlinksInPath`
+expands — the same `/var` vs `/private/var` mismatch the tenth pass recorded in a different method.
+
+The prefix test therefore failed and the fallback fired, so every change event named the share
+root. Measured against a plain `mktemp -d "$TMPDIR/..."` share, creating a folder inside a
+subfolder:
+
+    before:  data: {"type":"create","path":"//"}
+    after:   data: {"type":"create","path":"/Sub (1)/"}
+
+`//` rather than `/` because the create path appends its own separator to the fallback. The browser
+only reloads when the changed directory matches the folder it is viewing, so **live updates
+silently did nothing for every subfolder** — the uploader's headline feature, in its ordinary
+deployment, with no error anywhere. `-presentedSubitemDidChangeAtURL:` had resolved both sides
+since the SSE work landed; this is the same rule at the one site that never got it, which is this
+codebase's signature defect shape yet again.
+
+**`-bonjourName` never saw an auto-rename.** `_resolutionService` is a `CFNetServiceCreateCopy` of
+the registration service taken immediately after `CFNetServiceRegisterWithOptions` is *initiated* —
+registration is asynchronous, so the copy freezes the name as configured. Registering with flags 0
+means auto-rename is on, so a second instance on the network becomes `<name> (2)` and the property
+reported the original for the rest of the run. Measured with two servers sharing a name:
+
+| | server 1 | server 2 |
+|---|---|---|
+| before | `WSKRenameProbe` | `WSKRenameProbe` |
+| after | `WSKRenameProbe (2)` | `WSKRenameProbe` |
+
+Reading `_registrationService` first is the whole fix; it is the service that was actually
+registered, and it has the same `-_start`/`-_stop` lifecycle, so the `_stateQueue` confinement the
+old comment existed to justify is unchanged.
+
+**A failed foreground restart said nothing, and the code admitted it.** `-_reconnectInForeground:`
+called `[self _start:NULL]` under a comment reading *"TODO: There's probably nothing we can do on
+failure"*. Something can: say so. The listening sockets are gone, the server is dead for the rest
+of the foreground session, and `-isRunning` and `-serverURL` still answer as though it were
+serving. It now logs the error and delivers `-webServerDidStop:`, on the main thread and outside
+`_stateQueue` — a delegate reading `-serverURL` from inside that block would deadlock on it.
+
+**⚠️ The SSE quiet-client reaping gap was REFUTED by measurement.** It was carried as "an SSE client
+that stops reading but holds its socket open is never reaped". Sixteen such clients against a
+16-channel server, sampled every 15 s for 90 s: a real client still obtained a stream at **5 of 7**
+sample points. The reaper does reclaim them; what remains is the expected window while slots are
+held, not a denial. That makes **four** recorded lows across batches B and C that evaporated on
+contact, against twelve that were real — the ratio is the argument for re-measuring rather than
+working from the list.
+
+**Verified together.** 134 tests and 0 failures on a clean build with no new warnings, the trace
+corpus green, iOS and tvOS Debug both clean, and both the SSE-path and Bonjour probes sensitive in
+each direction. One warning I introduced — the GNU `?:` extension, a class this project has fixed
+before — was caught by the clean build and removed before the suite ran.
+
+**The known-open backlog is now empty.** What remains are settled decisions rather than defects: the
+`//` status disagreement, `MOVE`-without-`Overwrite` defaulting to refuse, the directory-rename
+TOCTOU, and litmus's `propfind_invalid2`. The next piece of work is the structural cleanup that has
+been deferred since the programme began.
+
 ### Known-open lows, batch B: honest status codes, and three entries that were not defects
 
 **Three of the recorded items were refuted by re-measuring them, and one of the three would have

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -4953,4 +4953,52 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+
+#pragma mark - Long-lived surfaces (batch C)
+
+// SSE change events name the directory that changed, and the browser only reloads when that
+// matches the folder it is viewing. The path was derived by chopping the share off the front of
+// a realpath(3) result while the share itself had only been -stringByStandardizingPath'd — which
+// disagree for any share under NSTemporaryDirectory(), since "/var" is a symlink to
+// "/private/var" that neither standardizing nor -stringByResolvingSymlinksInPath expands. Every
+// event then collapsed to "/" (or "//" for a create), so live updates silently stopped for every
+// subfolder. MakeTempDirectory() returns exactly such a path, so this reproduces by default.
+- (void)testSSEEventsNameTheSubfolderThatChanged {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    NSString* sub = [dir stringByAppendingPathComponent:@"Sub"];
+    [fm createDirectoryAtPath:sub withIntermediateDirectories:YES attributes:nil error:NULL];
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+
+    // The share must actually be one whose realpath differs, or this proves nothing.
+    NSString* resolved = [dir stringByResolvingSymlinksInPath];
+    char buffer[PATH_MAX];
+    if (realpath([dir fileSystemRepresentation], buffer) != NULL) {
+        resolved = [fm stringWithFileSystemRepresentation:buffer length:strlen(buffer)];
+    }
+    XCTAssertNotEqualObjects(resolved, dir, @"this test needs a share whose realpath differs; got %@", dir);
+
+    // Drive the private derivation directly: the event payload is built from it, and going
+    // through the network would make this a test of the SSE plumbing instead.
+    NSString* relative = [server valueForKey:@"uploadDirectory"] ? [self relativePathFrom:server forAbsolute:[resolved stringByAppendingPathComponent:@"Sub"]] : nil;
+    XCTAssertEqualObjects(relative, @"/Sub", @"an event for a subfolder must name it, not collapse to \"/\"");
+
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+- (NSString*)relativePathFrom:(WSKWebUploader*)server forAbsolute:(NSString*)absolutePath {
+    SEL selector = NSSelectorFromString(@"_relativePathForAbsolutePath:");
+    XCTAssertTrue([server respondsToSelector:selector]);
+    NSMethodSignature* signature = [server methodSignatureForSelector:selector];
+    NSInvocation* invocation = [NSInvocation invocationWithMethodSignature:signature];
+    invocation.target = server;
+    invocation.selector = selector;
+    [invocation setArgument:&absolutePath atIndex:2];
+    [invocation invoke];
+    __unsafe_unretained NSString* result = nil;
+    [invocation getReturnValue:&result];
+    return result;
+}
+
 @end

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -410,7 +410,18 @@ static void _ExecuteMainThreadRunLoopSources(void) {
     __block NSString *result = nil;
 
     dispatch_sync(_stateQueue, ^{
-        CFStringRef name = self->_resolutionService ? CFNetServiceGetName(self->_resolutionService) : NULL;
+        // _registrationService first, because it is the one that was actually registered and so
+        // the only one that carries an auto-renamed name. _resolutionService is a COPY taken
+        // immediately after CFNetServiceRegisterWithOptions is *initiated* — registration is
+        // asynchronous, so that copy froze the name as configured. Registering with flags 0
+        // means auto-rename is enabled, so a second instance on the network becomes
+        // "<name> (2)" and this property reported the original name for the rest of the run.
+        CFStringRef name = self->_registrationService ? CFNetServiceGetName(self->_registrationService) : NULL;
+
+        if ((name == NULL) || (CFStringGetLength(name) == 0)) {
+            name = self->_resolutionService ? CFNetServiceGetName(self->_resolutionService) : NULL;
+        }
+
         result = name && CFStringGetLength(name) ? CFBridgingRelease(CFStringCreateCopy(kCFAllocatorDefault, name)) : nil;
     });
     return result;
@@ -1107,12 +1118,30 @@ static inline NSString *_EncodeBase64(NSString *string) {
     // previously assigned port, so client URLs stay valid. See
     // swisspol/WSKWebServer#292. Existing (already-accepted) connections are
     // unaffected — only the listening sockets are rebuilt.
+    __block BOOL restarted = YES;
+
     dispatch_sync(_stateQueue, ^{
         if (self->_source4) {
             [self _stop];
-            [self _start:NULL];  // TODO: There's probably nothing we can do on failure
+            NSError *error = nil;
+            restarted = [self _start:&error];
+
+            if (!restarted) {
+                // Previously "[self _start:NULL]" with a TODO saying nothing could be done on
+                // failure. Something can: SAY SO. The listening sockets are gone and the server
+                // is silently dead for the rest of the foreground session, while -isRunning and
+                // -serverURL still answer as though it were serving. A host app that never
+                // learns cannot re-start it or tell the user why nothing is reachable.
+                WSK_LOG_ERROR(@"Failed restarting %@ on returning to the foreground: %@", [self class], error);
+            }
         }
     });
+
+    // Delivered on the main thread and outside _stateQueue, like every other delegate call
+    // here — a delegate reading -serverURL from inside that block would deadlock on it.
+    if (!restarted && [self.delegate respondsToSelector:@selector(webServerDidStop:)]) {
+        [self.delegate webServerDidStop:self];
+    }
 }
 
 #endif

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -221,6 +221,9 @@ static const NSTimeInterval kChangeCoalescingInterval = 0.1;
 static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 
 @implementation WSKWebUploader {
+    // The share as realpath(3) sees it. Immutable after -initWithUploadDirectory:. See
+    // -_relativePathForAbsolutePath: for why the standardized spelling alone is not enough.
+    NSString *_resolvedUploadDirectory;
     NSMutableArray<WSKWebUploaderSSEChannel *> *_sseChannels;  // One per connected /events client. Accessed only on _sseQueue.
     dispatch_queue_t _sseQueue;
     BOOL _sseAcceptingChannels;  // Owned by _sseQueue. YES only between -start and -stop, while SSE is enabled.
@@ -268,6 +271,15 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
         // an absolute path, which silently produces the wrong answer for "/Docs/" and can
         // raise NSRangeException for a pathological run of separators.
         _uploadDirectory = [[path stringByStandardizingPath] copy];
+
+        // Resolved once, here, because every path handed to -_relativePathForAbsolutePath: has
+        // been through realpath(3) while this one has only been standardized, and the two
+        // disagree far more often than "an unusual symlink" suggests — see that method.
+        char resolvedBuffer[PATH_MAX];
+
+        if (realpath([_uploadDirectory fileSystemRepresentation], resolvedBuffer) != NULL) {
+            _resolvedUploadDirectory = [[[NSFileManager defaultManager] stringWithFileSystemRepresentation:resolvedBuffer length:strlen(resolvedBuffer)] copy];
+        }
         _serverSentEventsEnabled = YES;
         _sseChannels = [NSMutableArray array];
         _sseQueue = dispatch_queue_create("com.gcdwebuploader.sse", DISPATCH_QUEUE_SERIAL);
@@ -1072,12 +1084,29 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 // defensive: a mismatch would otherwise yield a path the browser cannot match against the
 // folder it is viewing, or run off the end of the string.
 - (NSString *)_relativePathForAbsolutePath:(NSString *)absolutePath {
-    if ((_uploadDirectory.length == 0) || ![absolutePath hasPrefix:_uploadDirectory]) {
-        return @"/";
+    // Every caller hands over a path that has been through realpath(3), while _uploadDirectory
+    // has only been -stringByStandardizingPath'd — and those disagree for any share reached
+    // through a symlinked ancestor. That is NOT an exotic case: it is every share under
+    // NSTemporaryDirectory(), where "/var" is a symlink to "/private/var" that neither
+    // -stringByStandardizingPath nor -stringByResolvingSymlinksInPath expands. The prefix test
+    // then failed and the fallback fired, so a change event named "/" — or "//" for a create,
+    // which appends its own separator — and the browser, which only reloads when the changed
+    // directory matches the folder it is viewing, silently stopped updating for every subfolder.
+    //
+    // -presentedSubitemDidChangeAtURL: already resolved both sides before comparing. This is the
+    // same rule at the site that did not have it, which is this codebase's signature defect.
+    NSString *const resolvedRoot = _resolvedUploadDirectory ? _resolvedUploadDirectory : _uploadDirectory;
+
+    for (NSString *const root in @[ _uploadDirectory, resolvedRoot ]) {
+        if ((root.length == 0) || ![absolutePath hasPrefix:root]) {
+            continue;
+        }
+
+        NSString *const relativePath = [absolutePath substringFromIndex:root.length];
+        return [relativePath hasPrefix:@"/"] ? relativePath : [@"/" stringByAppendingString:relativePath];
     }
 
-    NSString *const relativePath = [absolutePath substringFromIndex:_uploadDirectory.length];
-    return [relativePath hasPrefix:@"/"] ? relativePath : [@"/" stringByAppendingString:relativePath];
+    return @"/";
 }
 
 // Do two paths name the same file on disk? Compares file resource identifiers (inode +


### PR DESCRIPTION
Batch C of the known-open lows — the long-lived surfaces. **This closes the backlog.**

## ⚠️ The headline item is far broader than the entry that predicted it

It was carried as *"SSE event paths collapse to `/` when the share is reached through a symlinked ancestor"*, which reads like an exotic configuration.

**It is the default.**

`-_relativePathForAbsolutePath:` derives an event's path by chopping the share off the front of an absolute path. Every caller hands it a `realpath(3)` result, while `_uploadDirectory` has only been `-stringByStandardizingPath`'d. Those disagree for **every share under `NSTemporaryDirectory()`**, because `/var` is a symlink to `/private/var` that neither `-stringByStandardizingPath` nor `-stringByResolvingSymlinksInPath` expands — the same `/var` vs `/private/var` mismatch the tenth pass recorded in a different method.

Measured against a plain `mktemp -d "$TMPDIR/..."` share, creating a folder inside a subfolder:

```
before:  data: {"type":"create","path":"//"}
after:   data: {"type":"create","path":"/Sub (1)/"}
```

(`//` rather than `/` because the create path appends its own separator to the fallback.)

The browser only reloads when the changed directory matches the folder it's viewing, so **live updates silently did nothing for every subfolder** — the uploader's headline feature, in its ordinary deployment, with no error anywhere.

`-presentedSubitemDidChangeAtURL:` has resolved both sides since the SSE work landed. This is the same rule at the one site that never got it — this codebase's signature defect shape again.

## `-bonjourName` never saw an auto-rename

`_resolutionService` is a `CFNetServiceCreateCopy` taken immediately after `CFNetServiceRegisterWithOptions` is *initiated* — and registration is asynchronous, so the copy freezes the name as configured. Flags `0` means auto-rename is on, so a second instance becomes `<name> (2)` and the property reported the original for the rest of the run.

Two servers sharing a name:

| | server 1 | server 2 |
|---|---|---|
| before | `WSKRenameProbe` | `WSKRenameProbe` |
| after | **`WSKRenameProbe (2)`** | `WSKRenameProbe` |

Reading `_registrationService` first is the whole fix — same `-_start`/`-_stop` lifecycle, so the `_stateQueue` confinement is unchanged.

## A failed foreground restart said nothing, and the code admitted it

`-_reconnectInForeground:` called `[self _start:NULL]` under a comment reading *"TODO: There's probably nothing we can do on failure"*. Something can: **say so**. The listening sockets are gone and the server is dead for the rest of the foreground session, while `-isRunning` and `-serverURL` still answer as though it were serving.

It now logs the error and delivers `-webServerDidStop:`, on the main thread and outside `_stateQueue` — a delegate reading `-serverURL` from inside that block would deadlock on it.

## ⚠️ One item was refuted by measurement

The **SSE quiet-client reaping gap** was carried as "a client that stops reading but holds its socket open is never reaped". Sixteen such clients against a 16-channel server, sampled every 15 s for 90 s: a real client still obtained a stream at **5 of 7** sample points. The reaper does reclaim them; what remains is the expected window while slots are held, not a denial.

That makes **four** recorded lows across batches B and C that evaporated on contact, against **twelve** that were real. That ratio is the argument for re-measuring rather than working from the list.

## Verification

- **134 tests, 0 failures** on a clean build
- **0 new warnings** — one I introduced (the GNU `?:` extension, a class this project has fixed before) was caught by the clean build and removed before the suite ran
- Trace corpus green
- iOS and tvOS Debug: exit 0, 0 warnings
- SSE-path and Bonjour probes sensitive in both directions

## The backlog is now empty

What remains are settled decisions rather than defects: the `//` status disagreement, `MOVE`-without-`Overwrite` defaulting to refuse, the directory-rename TOCTOU, and litmus's `propfind_invalid2`.

Next is the structural cleanup deferred since the programme began.