### PR TITLE
Fixed four regressions the top-down audit found in my own batches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,90 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Sixteenth pass: it was not green, and four of the findings were mine
+
+A full top-down re-run at the owner's request, to see whether the tree finally came back clean after
+the three known-open-low batches. It did not: **17 confirmed findings, 5 refuted, across 8 lenses
+with 22 skeptics and none dead** — the coverage counters are reported explicitly this time, because
+the twelfth pass returned `CLEAN` when every one of its verifiers had died.
+
+**Four of the seventeen were regressions from the three batches that had just landed.** This entry
+fixes those four; the rest are recorded for the cleanup.
+
+**⚠️ The uploader initializer was made to kill the process — by the very session that fixed that
+class.** Batch C added `realpath([_uploadDirectory fileSystemRepresentation], ...)` with no guard,
+and `-fileSystemRepresentation` raises for an empty or NUL-bearing receiver. That is the **fifth
+recurrence** of this codebase's most repeated defect, the first that was self-inflicted, and it
+landed three files from the comment in `WSKFileResponse.m` explaining the exact hazard. Nothing
+about knowing a rule prevents breaking it somewhere else.
+
+**A validator that failed OPEN was replaced by one that fails CLOSED.** Batch A's new RFC 850 and
+asctime patterns are parsed by ICU, which accepts 1–3 digits for a `yyyy` field and 1 for `yy`, so
+`Sun Nov  6 08:49:37 94` parsed to the year **0094** rather than failing. Such a date precedes every
+real mtime, so an `If-Unmodified-Since` carrying it produced a **permanent 412 that no retry could
+ever satisfy**, where RFC 9110 §13.1.4 requires an unparseable date to be ignored. Measured 412/412/412
+against 204/204/204 at the pre-batch commit. The fix anchors the calendar year rather than tightening
+three ICU patterns, and applies to **all three** spellings rather than the two where it was noticed —
+"closed at one of the sites the rule applies to" being the shape that keeps recurring here.
+
+**Rejecting a non-date became linear in its length.** Two extra formatter passes plus a whole-string
+double-space collapse, all inside the single process-wide serial queue that also serializes the
+`Date` header of *every* response — 74× baseline, 1.48 ms of exclusive CPU at the 64 KB header cap,
+and `If-Modified-Since` is parsed for every request before any handler or authentication runs. A
+length precheck restores constant-time rejection; no legal HTTP-date exceeds 33 characters. Pinned by
+a test with a deliberately loose bound (2000 rejections under 2 s, against 3.78 s unfixed) so it
+catches the class without flaking under load.
+
+**`webServerDidStop:` was delivered twice for one stop.** `-_stop` already posts it; batch C added a
+second, synchronous, so the duplicate arrived *first* and inverted the ordering against
+`-webServerDidDisconnect:`. The added call is now gone. **⚠️ And the claim that justified it was
+false:** that entry asserted `-isRunning` and `-serverURL` "still answer as though it were serving",
+which the skeptic measured on both trees, 7/7, as reporting stopped. **Sixth time this file has
+asserted a property the code did not have.**
+
+**A guard that quoted the whole rule and enforced one spelling of it.** Batch B's empty-header-name
+check cited RFC 9112 §5 `field-name = 1*tchar` and then rejected only the empty string. A name
+beginning with a space serializes as an obs-fold continuation and is therefore appended to the
+**preceding header's value** — measured against the real `Date` header — and interior spaces, tabs
+and non-ASCII went out verbatim. The request parser's own `tchar` predicate is now **shared** rather
+than restated, in `WSKFunctions`, so the two sites cannot drift.
+
+**⚠️ Verification limit, stated rather than papered over.** The duplicate-`webServerDidStop:` fix is
+`#if TARGET_OS_IPHONE`, so the Mac suite is structurally blind to it, and the failure regime could
+not be re-synthesized on demand: `-_stop` releases the listening descriptors before `-_start:` runs,
+so exhausting file descriptors beforehand always lands in the SUCCESS regime, where both trees report
+one stop and the measurement discriminates nothing. Two probe attempts did exactly that and were
+discarded. What IS established: the skeptic pinned the duplicate to that line by measuring the
+synchronous phase (tip `stops=1` before the run loop drained, baseline `stops=0`), and exactly one
+delivery site now remains in the tree. The after-state is *not* measured, and this entry does not
+claim it is.
+
+**Five findings were refuted** by the skeptics, including one that would have broken conformance had
+it been "fixed". Combined with batches B and C that is **nine refuted against sixteen real** — a
+recorded finding in this project is roughly a 2-in-3 shot, so reproduce before fixing.
+
+**Verified together.** 138 tests and 0 failures on a clean build with no new warnings — including one
+nullable-to-nonnull warning this change introduced and removed before shipping — the trace corpus
+green, and iOS and tvOS Debug both clean.
+
+**Still open, and now the argument for the cleanup rather than another pass.** Thirteen confirmed
+findings are left, all pre-existing and mostly low: MKCOL answering 500 rather than RFC 4918 §9.3.1's
+405 on an existing collection (**medium — rclone cannot copy into any existing folder**, and the
+error body leaks the server-side path); a 403 where a 404 belongs when a parent collection is absent
+(same rclone breakage); `WSKDataRequest.text` and `.jsonObject` aborting for exactly the case their
+header documents as returning nil; `addHandlerForMethod:path:` aborting in Debug and registering
+nothing in Release for a missing leading slash — the identical shape batch A fixed one method away;
+`OPTIONS` omitting PROPPATCH from `Allow`; LOCK/UNLOCK 405s carrying no `Allow`; the SSE prefix test
+having no separator boundary; `_resolvedUploadDirectory` being captured once so the batch C fix
+reverts if the share's realpath changes; and a symlinked share receiving no `NSFilePresenter` events
+at all.
+
+**The rate is not falling, and the reason is now measured.** Each batch of fixes has introduced
+roughly one new defect per five it closed, clustered in exactly what the fix touched. Auditing harder
+does not converge while that holds. Every one of the four regressions above came from adding a guard
+or a call without asking what it now refuses, duplicates, or costs — so the next work is the deferred
+structural cleanup, starting from the rules that have more than one implementation.
+
 ### Known-open lows, batch C: the long-lived surfaces, and live updates that were broken by default
 
 **⚠️ The headline finding is far broader than the entry that predicted it.** It was carried as "SSE

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -5001,4 +5001,84 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     return result;
 }
 
+
+#pragma mark - Regressions from the audit batches (self-inflicted)
+
+// Batch C added realpath([_uploadDirectory fileSystemRepresentation], ...) to the initializer with
+// no guard — and -fileSystemRepresentation RAISES for an empty or NUL-bearing receiver. That is
+// precisely the class batch A existed to close, re-opened three files from the comment explaining
+// it. Fifth recurrence of this codebase's most repeated defect, and the first self-inflicted one.
+- (void)testUploaderInitDoesNotRaiseForAnUnusablePath {
+    XCTAssertNoThrow([[WSKWebUploader alloc] initWithUploadDirectory:@""]);
+
+    unichar const nulBearing[] = {'/', 't', 'm', 'p', '/', 0, 'x'};
+    NSString* nulPath = [NSString stringWithCharacters:nulBearing length:(sizeof(nulBearing) / sizeof(nulBearing[0]))];
+    XCTAssertNoThrow([[WSKWebUploader alloc] initWithUploadDirectory:nulPath]);
+
+    // An ordinary share must still resolve, or this could pass by refusing everything.
+    NSString* dir = MakeTempDirectory();
+    WSKWebUploader* ok = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    XCTAssertNotNil(ok);
+    [[NSFileManager defaultManager] removeItemAtPath:dir error:NULL];
+}
+
+// RFC 9110 §13.1.4: a recipient MUST IGNORE a precondition whose value is not a valid HTTP-date.
+// Batch A's new RFC 850 and asctime patterns are parsed by ICU, which accepts 1-3 digits for a
+// "yyyy" field and 1 for "yy" — so a malformed value parsed to a first- or second-century date
+// instead of nil. That date precedes every real mtime, so If-Unmodified-Since failed and NO retry
+// could ever succeed. A validator that failed OPEN was replaced by one that fails CLOSED.
+- (void)testMalformedHTTPDatesAreIgnoredRatherThanParsedToAncientYears {
+    XCTAssertNil(WSKParseRFC822(@"Sun Nov  6 08:49:37 94"), @"a 2-digit asctime year is not an HTTP-date");
+    XCTAssertNil(WSKParseRFC822(@"Sun Nov  6 08:49:37 199"), @"a 3-digit asctime year is not an HTTP-date");
+    XCTAssertNil(WSKParseRFC822(@"Sunday, 06-Nov-9 08:49:37 GMT"), @"a 1-digit RFC 850 year is not an HTTP-date");
+
+    // The three legal spellings must still parse, or this closes the hole by breaking the feature.
+    NSDate* expected = [NSDate dateWithTimeIntervalSince1970:784111777.0];
+    for (NSString* legal in @[ @"Sun, 06 Nov 1994 08:49:37 GMT", @"Sunday, 06-Nov-94 08:49:37 GMT", @"Sun Nov  6 08:49:37 1994" ]) {
+        NSDate* parsed = WSKParseRFC822(legal);
+        XCTAssertNotNil(parsed, @"must still parse: %@", legal);
+        XCTAssertEqualWithAccuracy([parsed timeIntervalSince1970], [expected timeIntervalSince1970], 0.5, @"%@", legal);
+    }
+}
+
+// Batch A's two extra formatter passes and a whole-string double-space collapse made rejecting a
+// non-date LINEAR in its length — 74x at the 64 KB header cap — inside the single process-wide
+// serial queue that also serializes the Date header of every response. If-Modified-Since is parsed
+// for every request, so no handler and no authentication is needed to reach it.
+//
+// The bound is deliberately loose (a 74x regression is ~1.5 ms per call, so 2000 calls would take
+// ~3 s) because timing assertions flake under load; it catches the class, not a percentage.
+- (void)testRejectingALongNonDateStaysCheap {
+    NSMutableString* padding = [NSMutableString string];
+    while (padding.length < 60000) {
+        [padding appendString:@"  "];  // Double spaces: the input that triggered the collapse.
+    }
+
+    NSDate* started = [NSDate date];
+    for (NSUInteger i = 0; i < 2000; i++) {
+        XCTAssertNil(WSKParseRFC822(padding));
+    }
+    NSTimeInterval elapsed = -[started timeIntervalSinceNow];
+    XCTAssertLessThan(elapsed, 2.0, @"2000 rejections of a 60 KB non-date took %.2fs; rejection must not be linear in length", elapsed);
+}
+
+// The batch B guard cited RFC 9112 §5 field-name = 1*tchar and then rejected only the EMPTY
+// spelling. A name beginning with a space serializes as an obs-fold continuation line, so it is
+// appended to the PRECEDING header's value — measured against the real Date header. Closing one
+// spelling of a rule while quoting the whole rule is this codebase's most repeated shape.
+- (void)testResponseRefusesAHeaderNameThatIsNotAToken {
+    WSKResponse* response = [WSKResponse responseWithStatusCode:kWSKHTTPStatusCode_OK];
+
+    for (NSString* illegal in @[ @"", @" X-Folded", @"X-A B", @"X-Tab\tName", @"X-Üni", @"X-Trailing " ]) {
+        [response setValue:@"INJECTED" forAdditionalHeader:illegal];
+        XCTAssertNil([response valueForAdditionalHeader:illegal], @"a non-token header name must be refused: \"%@\"", illegal);
+    }
+
+    // Every character the token rule allows must still work.
+    for (NSString* legal in @[ @"Accept-Ranges", @"X-Custom_Header", @"X-A.B", @"X-1234", @"!#$%&'*+-.^_`|~" ]) {
+        [response setValue:@"ok" forAdditionalHeader:legal];
+        XCTAssertEqualObjects([response valueForAdditionalHeader:legal], @"ok", @"a legal token name must be accepted: \"%@\"", legal);
+    }
+}
+
 @end

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -922,33 +922,6 @@ static NSString *_WithoutRootLabel(NSString *host) {
 }
 
 // RFC 9112 §5.1: tchar, the only characters legal in a field name or a method.
-static BOOL _IsHeaderTokenCharacter(unsigned char character) {
-    if (((character >= 'a') && (character <= 'z')) || ((character >= 'A') && (character <= 'Z')) || ((character >= '0') && (character <= '9'))) {
-        return YES;
-    }
-
-    switch (character) {
-        case '!':
-        case '#':
-        case '$':
-        case '%':
-        case '&':
-        case '\'':
-        case '*':
-        case '+':
-        case '-':
-        case '.':
-        case '^':
-        case '_':
-        case '`':
-        case '|':
-        case '~':
-            return YES;
-
-        default:
-            return NO;
-    }
-}
 
 // method SP request-target SP HTTP-version, with no room for interpretation. Without
 // this a request line is split on the first two spaces and whatever remains becomes part
@@ -979,7 +952,7 @@ static BOOL _ValidateRequestLine(const unsigned char *line, NSUInteger length) {
     }
 
     for (NSUInteger i = 0; i < firstSpace; i++) {
-        if (!_IsHeaderTokenCharacter(line[i])) {
+        if (!WSKIsHeaderTokenCharacter(line[i])) {
             return NO;
         }
     }
@@ -1076,7 +1049,7 @@ static BOOL _ValidateRequestHeaderBlock(const void *rawBytes, NSUInteger length)
             }
 
             for (NSUInteger j = 0; j < colon; j++) {
-                if (!_IsHeaderTokenCharacter(line[j])) {
+                if (!WSKIsHeaderTokenCharacter(line[j])) {
                     return NO;  // Includes whitespace before the colon
                 }
             }

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -125,6 +125,20 @@ NSDate *_Nullable WSKParseISO8601(NSString *string);
 BOOL WSKPathContainsNULByte(NSString *_Nullable path);
 
 /**
+ *  Is this byte legal in an HTTP field-name or method? RFC 9112 §5: field-name = 1*tchar.
+ *
+ *  Shared so the request parser and the response header setter cannot drift. A second
+ *  implementation of this rule beside the live one is the trap this codebase keeps falling into.
+ */
+BOOL WSKIsHeaderTokenCharacter(unsigned char character);
+
+/**
+ *  Does this string consist only of tchar, with at least one character? The whole field-name rule,
+ *  in one place.
+ */
+BOOL WSKIsHeaderTokenString(NSString *_Nullable string);
+
+/**
  *  Maps a filesystem NSError onto the server-error status that describes it honestly.
  *
  *  RFC 4918 §11.5: 507 Insufficient Storage means the method could not be performed because

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -127,6 +127,13 @@ static NSDateFormatter *_dateFormatterRFC850 = nil;
 static NSDateFormatter *_dateFormatterAsctime = nil;
 static NSDateFormatter *_dateFormatterISO8601 = nil;
 static dispatch_queue_t _dateFormatterQueue = NULL;
+// Anything earlier than this is not a date any HTTP client meant to send; see _EnsureDateFormatters.
+static NSTimeInterval _earliestPlausibleDate = 0.0;
+
+// The longest legal HTTP-date is the RFC 850 form with the longest weekday:
+// "Wednesday, 06-Nov-94 08:49:37 GMT" — 33 characters. The cap is deliberately loose; its job is
+// only to keep rejection CONSTANT-TIME, not to validate.
+static const NSUInteger kMaxHTTPDateLength = 64;
 
 // Idempotent and safe from any thread: everything here is built exactly once, under
 // dispatch_once, and read-only thereafter (all use is serialized on _dateFormatterQueue).
@@ -168,6 +175,22 @@ static void _EnsureDateFormatters(void) {
         _dateFormatterISO8601.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
 
         _dateFormatterQueue = dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL);
+
+        // ICU is lenient about digit COUNT: it accepts 1-3 digits for a "yyyy" field and 1 for
+        // "yy", so "Sun Nov  6 08:49:37 94" parsed to the year 94 AD instead of failing. Any such
+        // date precedes every real mtime, which turned an If-Unmodified-Since into a permanent 412
+        // that no retry could ever satisfy — a validator that failed OPEN replaced by one that
+        // failed CLOSED, which is the worse direction. RFC 9110 §13.1.4 requires an unparseable
+        // date to be IGNORED. Anchoring the calendar year is cheaper and less brittle than
+        // tightening three ICU patterns, and it covers all three spellings rather than the two
+        // that were noticed.
+        NSDateComponents *const earliest = [[NSDateComponents alloc] init];
+        earliest.year = 1000;
+        earliest.month = 1;
+        earliest.day = 1;
+        NSCalendar *const gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+        gregorian.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];  // Non-null, unlike +timeZoneWithAbbreviation:, and NSCalendar.timeZone is non-null.
+        _earliestPlausibleDate = [[gregorian dateFromComponents:earliest] timeIntervalSinceReferenceDate];
     });
 }
 
@@ -273,7 +296,14 @@ NSString *WSKFormatRFC822(NSDate *date) {
 }
 
 NSDate *WSKParseRFC822(NSString *string) {
-    if (string.length == 0) {
+    // Length is checked BEFORE any formatter runs, and this is load-bearing for more than tidiness.
+    // Adding the two fallback formatters made rejecting a non-date linear in its length — three
+    // full-string ICU passes plus a whole-string double-space collapse that allocates a copy —
+    // measured at 74x baseline (1.48 ms) for a value at the 64 KB header cap. All of it runs inside
+    // the single process-wide serial queue that also serializes the Date header of EVERY response,
+    // so the cost is stolen from other connections, and If-Modified-Since is parsed for every
+    // request before any handler or authentication runs. No legal HTTP-date exceeds 33 characters.
+    if ((string.length == 0) || (string.length > kMaxHTTPDateLength)) {
         return nil;
     }
 
@@ -293,6 +323,14 @@ NSDate *WSKParseRFC822(NSString *string) {
             // variant parse without loosening the pattern itself.
             NSString *const collapsed = [string stringByReplacingOccurrencesOfString:@"  " withString:@" "];
             date = [_dateFormatterAsctime dateFromString:collapsed];
+        }
+
+        // ICU's tolerance of short year fields turns malformed input into a first- or
+        // second-century date rather than nil. Applied to all three spellings, not only the two
+        // where it was noticed, because "closed at one of the sites the rule applies to" is this
+        // codebase's most reliable defect shape.
+        if ((date != nil) && ([date timeIntervalSinceReferenceDate] < _earliestPlausibleDate)) {
+            date = nil;
         }
     });
     return date;
@@ -445,6 +483,53 @@ NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL includeService
     }
 
     return includeService ? [NSString stringWithFormat:@"%s:%s", hostBuffer, serviceBuffer] : (NSString *)[NSString stringWithUTF8String:hostBuffer];
+}
+
+BOOL WSKIsHeaderTokenCharacter(unsigned char character) {
+    if (((character >= 'a') && (character <= 'z')) || ((character >= 'A') && (character <= 'Z')) || ((character >= '0') && (character <= '9'))) {
+        return YES;
+    }
+
+    switch (character) {
+        case '!':
+        case '#':
+        case '$':
+        case '%':
+        case '&':
+        case '\'':
+        case '*':
+        case '+':
+        case '-':
+        case '.':
+        case '^':
+        case '_':
+        case '`':
+        case '|':
+        case '~':
+            return YES;
+        default:
+            return NO;
+    }
+}
+
+BOOL WSKIsHeaderTokenString(NSString *string) {
+    // 1*tchar: at least one character, every one of them a tchar. Compared over UTF-8 bytes so a
+    // non-ASCII name fails on its lead byte rather than being silently truncated somewhere later.
+    NSData *const bytes = [string dataUsingEncoding:NSUTF8StringEncoding];
+
+    if (bytes.length == 0) {
+        return NO;
+    }
+
+    unsigned char const *const buffer = bytes.bytes;
+
+    for (NSUInteger i = 0; i < bytes.length; i++) {
+        if (!WSKIsHeaderTokenCharacter(buffer[i])) {
+            return NO;
+        }
+    }
+
+    return YES;
 }
 
 WSKServerErrorHTTPStatusCode WSKServerErrorStatusCodeForError(NSError *error) {

--- a/Sources/WebServerKit/Core/WSKResponse.m
+++ b/Sources/WebServerKit/Core/WSKResponse.m
@@ -295,18 +295,15 @@
     // untrusted input would split the response and inject headers of the attacker's
     // choosing. No caller in this library does that, but this is the chokepoint, and a host
     // app naming a header after request data should not be able to forge a response.
-    // RFC 9112 §5 field-name is 1*tchar, so an empty name is not a field-line at all — it
-    // serializes as ": value", which a recipient may drop, treat as a continuation, or refuse
-    // the whole message over. The request parser already refuses one; this is the same rule on
-    // the response side, which did not have it.
-    if (header.length == 0) {
-        WSK_LOG_ERROR(@"Ignoring additional response header with an empty name");
-        return;
-    }
-
-    NSRange controlCharacter = [header rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"\r\n:"]];
-
-    if (controlCharacter.location != NSNotFound) {
+    // RFC 9112 §5: field-name = 1*tchar. The previous guard quoted that rule and then enforced
+    // only the EMPTY spelling of it, which left every other violation reachable — most sharply a
+    // name beginning with a space, which serializes as an obs-fold continuation line and is
+    // therefore appended to the PRECEDING header's value (measured against the real Date header).
+    // An interior space, a tab and a non-ASCII name all went out verbatim too.
+    //
+    // WSKIsHeaderTokenString is the request parser's own rule, shared rather than restated: a
+    // second implementation of a rule beside the live one is what this file keeps getting wrong.
+    if (!WSKIsHeaderTokenString(header)) {
         WSK_LOG_ERROR(@"Ignoring additional response header with an invalid name \"%@\"", header);
         return;
     }

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1118,30 +1118,32 @@ static inline NSString *_EncodeBase64(NSString *string) {
     // previously assigned port, so client URLs stay valid. See
     // swisspol/WSKWebServer#292. Existing (already-accepted) connections are
     // unaffected — only the listening sockets are rebuilt.
-    __block BOOL restarted = YES;
-
     dispatch_sync(_stateQueue, ^{
         if (self->_source4) {
             [self _stop];
             NSError *error = nil;
-            restarted = [self _start:&error];
+            BOOL const restarted = [self _start:&error];
 
             if (!restarted) {
                 // Previously "[self _start:NULL]" with a TODO saying nothing could be done on
-                // failure. Something can: SAY SO. The listening sockets are gone and the server
-                // is silently dead for the rest of the foreground session, while -isRunning and
-                // -serverURL still answer as though it were serving. A host app that never
-                // learns cannot re-start it or tell the user why nothing is reachable.
+                // failure. Something can: log it. The listening sockets are gone and the server is
+                // dead for the rest of the foreground session, so an operator staring at an
+                // unreachable device otherwise has nothing at all to go on.
+                //
+                // Deliberately NOT a -webServerDidStop: call. -_stop above already posts one, so
+                // adding a second delivered TWO callbacks for one stop — and the added one fired
+                // synchronously, so it arrived FIRST and inverted the ordering against
+                // -webServerDidDisconnect:. The delegate could already tell this case apart
+                // without it: a failed restart delivers a stop with no matching start.
+                //
+                // The claim that justified that call — that -isRunning and -serverURL "still
+                // answer as though it were serving" — was measured FALSE on both trees, 7/7:
+                // both report stopped. Recorded here because this file has now overstated the
+                // code five times, and this is the correction.
                 WSK_LOG_ERROR(@"Failed restarting %@ on returning to the foreground: %@", [self class], error);
             }
         }
     });
-
-    // Delivered on the main thread and outside _stateQueue, like every other delegate call
-    // here — a delegate reading -serverURL from inside that block would deadlock on it.
-    if (!restarted && [self.delegate respondsToSelector:@selector(webServerDidStop:)]) {
-        [self.delegate webServerDidStop:self];
-    }
 }
 
 #endif

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -277,7 +277,13 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
         // disagree far more often than "an unusual symlink" suggests — see that method.
         char resolvedBuffer[PATH_MAX];
 
-        if (realpath([_uploadDirectory fileSystemRepresentation], resolvedBuffer) != NULL) {
+        // -fileSystemRepresentation RAISES for an empty or NUL-bearing receiver, and this line was
+        // added without that guard — re-opening, three files from the comment explaining it, the
+        // exact class the WSKFileResponse fix had just closed. Fifth recurrence of this codebase's
+        // most repeated defect. Leaving _resolvedUploadDirectory nil is already handled: the reader
+        // falls back to _uploadDirectory.
+        if ((_uploadDirectory.length > 0) && !WSKPathContainsNULByte(_uploadDirectory) &&
+            (realpath([_uploadDirectory fileSystemRepresentation], resolvedBuffer) != NULL)) {
             _resolvedUploadDirectory = [[[NSFileManager defaultManager] stringWithFileSystemRepresentation:resolvedBuffer length:strlen(resolvedBuffer)] copy];
         }
         _serverSentEventsEnabled = YES;


### PR DESCRIPTION
The full top-down re-run came back with **17 confirmed findings, not zero**. Coverage was honest — 8/8 lenses, 22 skeptics, none died, and the counters are reported explicitly because the twelfth pass once returned `CLEAN` when every verifier had died.

**Four of the seventeen were regressions from the three batches that had just landed.** This PR fixes those four plus one incomplete guard.

## The one that matters most

**The uploader initializer was made to kill the process — by the same session that fixed that class.**

Batch C added `realpath([_uploadDirectory fileSystemRepresentation], ...)` with no guard, and `-fileSystemRepresentation` raises for an empty or NUL-bearing receiver. That's the **fifth recurrence** of this codebase's most repeated defect, the first self-inflicted one, and it landed **three files from the comment in `WSKFileResponse.m` explaining the exact hazard**.

Knowing a rule does not prevent breaking it somewhere else. That is the whole argument for the cleanup.

## A validator that failed OPEN, replaced by one that fails CLOSED

Batch A's new RFC 850 / asctime patterns are parsed by ICU, which accepts 1–3 digits for a `yyyy` field:

```
Sun Nov  6 08:49:37 94   -> year 0094   (should be nil)
Sun Nov  6 08:49:37 199  -> year 0199
Sunday, 06-Nov-9 ...     -> year 0009
```

Such a date precedes every real mtime, so `If-Unmodified-Since` produced a **permanent 412 that no retry could ever satisfy** — where RFC 9110 §13.1.4 requires an unparseable date to be *ignored*. Measured `412/412/412` against `204/204/204` at the pre-batch commit.

The fix anchors the calendar year rather than tightening three ICU patterns, and applies to **all three** spellings — not just the two where it was noticed.

## Rejecting a non-date became linear in its length

Two extra formatter passes plus a whole-string double-space collapse, all inside the single process-wide serial queue that also serializes the `Date` header of **every** response. 74× baseline, **1.48 ms** of exclusive CPU at the 64 KB header cap — and `If-Modified-Since` is parsed for every request before any handler or authentication runs.

A length precheck restores constant-time rejection (no legal HTTP-date exceeds 33 characters). Pinned by a test with a deliberately loose bound — 2000 rejections under 2 s, against **3.78 s** unfixed — so it catches the class without flaking under load.

## `webServerDidStop:` delivered twice

`-_stop` already posts it; batch C added a second, *synchronously*, so the duplicate arrived **first** and inverted the ordering against `-webServerDidDisconnect:`.

⚠️ **And the claim that justified adding it was false.** That entry asserted `-isRunning` and `-serverURL` "still answer as though it were serving". The skeptic measured both trees, 7/7: both report stopped. Sixth time this file has asserted a property the code did not have — corrected in `CLAUDE.md`.

## A guard that quoted the whole rule and enforced one spelling

Batch B's empty-header-name check cited RFC 9112 §5 `field-name = 1*tchar` and then rejected only the empty string. A name beginning with a space serializes as an obs-fold continuation, so it is appended to the **preceding header's value** — measured against the real `Date` header. Interior spaces, tabs and non-ASCII went out verbatim too.

The request parser's own `tchar` predicate is now **shared** via `WSKFunctions` rather than restated, so the two sites cannot drift.

## ⚠️ Verification limit, stated rather than papered over

The duplicate-stop fix is `#if TARGET_OS_IPHONE`, so the Mac suite is structurally blind to it, and **the failure regime could not be re-synthesized**: `-_stop` releases the listening descriptors before `-_start:` runs, so exhausting file descriptors beforehand always lands in the SUCCESS regime — where both trees report one stop and the measurement discriminates nothing. Two probe attempts did exactly that and were discarded rather than reported as passes.

What *is* established: the audit skeptic pinned the duplicate to that line by measuring the synchronous phase (tip `stops=1` before the run loop drained, baseline `stops=0`), and exactly one delivery site now remains. **The after-state is not measured, and this PR does not claim it is.**

## Verification

- **138 tests, 0 failures** on a clean build
- **0 new warnings** — one nullable-to-nonnull warning introduced here was caught by the clean build and removed before shipping
- Trace corpus green
- iOS and tvOS Debug: exit 0, 0 warnings

## What this says about the programme

Five findings were refuted by the skeptics, one of which would have **broken conformance** had it been "fixed". Across batches B, C and this pass that is **nine refuted against sixteen real** — a recorded finding here is roughly a 2-in-3 shot, so reproduce before fixing.

Thirteen confirmed findings remain, all pre-existing and mostly low — the sharpest being **MKCOL answering 500 rather than 405 on an existing collection, which stops rclone copying into any existing folder** and leaks the server-side path into the error body.

Each batch of fixes has introduced roughly one new defect per five it closed, clustered in exactly what the fix touched. Auditing harder does not converge while that holds. Every one of the four regressions above came from adding a guard or a call without asking what it now refuses, duplicates, or costs — so the next work is the deferred structural cleanup, starting from the rules that have more than one implementation.