### PR TITLE
Cleanup phase 1: the survey found live bugs before moving a line of code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,56 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Structural cleanup, phase 1: the survey found live bugs before it moved a line of code
+
+The cleanup deferred since the fourteenth pass began, deliberately, with a **read-only inventory**:
+seven lenses over every rule implemented in more than one place. That ordering was the whole point —
+a mechanical sweep is exactly when a check quietly stops being enforced, and unifying two copies
+before knowing which one is *correct* cements whichever spelling was read first.
+
+**72 rules inventoried; 23 of them already disagree.** Those are not cleanup, they are latent
+defects, and four were measured from the network before anything was touched. All four reproduced.
+
+**A root-dotted `WSKOption_AllowedHostNames` entry admitted NOTHING — not even its own spelling.**
+The two sides of the allow-list had drifted: the check side strips the DNS root label from the
+incoming `Host`, the config side only lowercased the entry. So `puck.tailnet.ts.net.` — how DNS
+canonically writes a fully-qualified name — matched neither `puck.tailnet.ts.net.` (stripped on
+arrival) nor `puck.tailnet.ts.net`, and **every request answered 421**. That is the one option a
+Tailscale deployment is *required* to set, so it presents as "the server just doesn't work" in
+Shape A's only deployment. Measured 421/421 before, 200/200 after. The rule now has one home,
+`WSKHostNameWithoutRootLabel`, used by both sides.
+
+**All three listings advertised entries every handler refuses.** `WSKServableFileTypeAtPath` tested
+containment and never hiddenness, so a link whose own name carries no dot but which resolves inside
+a dot-directory was listed and then answered 403. Measured: listed YES, `GET` 403. This is the
+"advertise iff served" rule the sixth, eighth and fifteenth passes each restored in one direction or
+another, back in a third.
+
+**The uploader's follow-resolver had no NUL guard**, where DAV's has one *inside* the resolver under
+a comment saying it lives there "so a verb added later cannot forget it". Six per-endpoint
+pre-checks compensated, so behaviour matched only because every current caller remembered. Moved
+inside. No behaviour change today; what it removes is the requirement that the next endpoint
+remembers, which is how `POST /delete path=/Keep%00/x` once destroyed `/Keep`.
+
+**Two confirmed and deliberately NOT fixed here.** The uploader's read endpoints stat before
+resolving, so `404`-vs-`403` is an existence oracle for paths outside the share (measured: 403 when
+the out-of-share target exists, 404 when it does not; `/list` leaks the same way with 400/404) — a
+small reordering, but it belongs with the resolver unification rather than as a spot fix. And the
+extension allow-list judges the **alias** name in listings and the **resolved target's** name on
+access (measured: `alias.txt -> real.bin` listed then 403; `alias.bin -> real.txt` unlisted then
+served 200). That one is a **semantics decision, not a defect fix** — the "symlinks are aliases"
+ruling says a destructive verb acts on the named entry, but a *read* through an alias discloses the
+target, so judging the alias name alone would be a disclosure. The fail-closed answer is to require
+both names to pass, and that is the owner's call, exactly as the source/destination semantics were.
+
+**Verified together.** 140 tests and 0 failures on a clean build with no new warnings, the trace
+corpus green, and the probe sensitive in both directions on both fixes.
+
+**Phase 2 is the 48 rules that agree but are duplicated** — the safe half, where a mistake surfaces
+as a test failure rather than a behaviour change. Phase 3 is the API-shape debt (including the
+target visibility that would let several symbols leave the public `WSKFunctions.h`) and consolidating
+this file.
+
 ### Sixteenth pass: it was not green, and four of the findings were mine
 
 A full top-down re-run at the owner's request, to see whether the tree finally came back clean after

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -5081,4 +5081,66 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     }
 }
 
+
+#pragma mark - Cleanup phase 1: rules that had drifted apart
+
+// The two sides of the Host allow-list disagreed: the CHECK side strips the DNS root label from
+// the incoming header, the CONFIG side did not strip it from a WSKOption_AllowedHostNames entry.
+// So an entry written as a fully-qualified name matched NOTHING — not even its own spelling — and
+// every request answered 421. That is the one option a Tailscale deployment is required to set.
+- (void)testAllowedHostNameEntryIsHonouredWithOrWithoutItsRootLabel {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    [@"served" writeToFile:[dir stringByAppendingPathComponent:@"x.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_AllowedHostNames : @[ @"puck.tailnet.ts.net." ]};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* dotted = SendRawRequest(server.port, @"GET /x.txt HTTP/1.1\r\nHost: puck.tailnet.ts.net.\r\n\r\n");
+    XCTAssertTrue([dotted containsString:@" 200"], @"the entry's own spelling must be admitted: %@", [dotted substringToIndex:MIN((NSUInteger)40, dotted.length)]);
+
+    NSString* plain = SendRawRequest(server.port, @"GET /x.txt HTTP/1.1\r\nHost: puck.tailnet.ts.net\r\n\r\n");
+    XCTAssertTrue([plain containsString:@" 200"], @"the spelling browsers send must be admitted: %@", [plain substringToIndex:MIN((NSUInteger)40, plain.length)]);
+
+    // A name that is genuinely not on the list must still be refused, or this passes by admitting all.
+    NSString* other = SendRawRequest(server.port, @"GET /x.txt HTTP/1.1\r\nHost: evil.example\r\n\r\n");
+    XCTAssertTrue([other containsString:@" 421"], @"an unlisted name must still be refused: %@", [other substringToIndex:MIN((NSUInteger)40, other.length)]);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// "Advertise iff served": WSKServableFileTypeAtPath tested containment and not hiddenness, so a
+// link whose own name carries no dot but which resolves INSIDE a dot-directory was advertised by
+// all three listings and then refused 403 by every handler. Measured before the fix.
+- (void)testListingDoesNotAdvertiseALinkResolvingIntoAHiddenDirectory {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    NSString* hidden = [dir stringByAppendingPathComponent:@".hidden"];
+    [fm createDirectoryAtPath:hidden withIntermediateDirectories:YES attributes:nil error:NULL];
+    [@"secret" writeToFile:[hidden stringByAppendingPathComponent:@"f.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [fm createSymbolicLinkAtPath:[dir stringByAppendingPathComponent:@"pub.txt"] withDestinationPath:[hidden stringByAppendingPathComponent:@"f.txt"] error:NULL];
+    [@"ordinary" writeToFile:[dir stringByAppendingPathComponent:@"plain.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+
+    WSKWebUploader* uploader = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([uploader startWithOptions:options error:NULL]);
+
+    NSString* listing = SendRawRequest(uploader.port, @"GET /list?path=%2F HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    NSString* download = SendRawRequest(uploader.port, @"GET /download?path=%2Fpub.txt HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+    BOOL const advertised = [listing containsString:@"pub.txt"];
+    BOOL const served = [download containsString:@" 200"];
+    NSString* const detail = [NSString stringWithFormat:@"advertised=%d served=%d", advertised, served];
+    XCTAssertEqual(advertised, served, @"a listing must advertise an entry if and only if the handler serves it: %@", detail);
+
+    // An ordinary file must still be listed, or this could pass by listing nothing.
+    XCTAssertTrue([listing containsString:@"plain.txt"], @"ordinary entries must still be advertised");
+
+    [uploader stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 @end

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -237,14 +237,6 @@ static BOOL _IsIPAddressLiteral(NSString *host) {
 // only defence against DNS rebinding: once a page on evil.example repoints its DNS here, the
 // browser treats it as same-origin, so CORS, Origin comparison and CSRF tokens are all
 // satisfied — but the browser still sends the name the page was loaded from. See
-// WSKOption_AllowedHostNames.
-// "name.local." and "name.local" are the same host: the trailing dot is the DNS root label,
-// which a user typing a fully-qualified name, a canonicalizing client library, or curl will
-// all send. Refusing it answered 421 for the server's own mDNS name and read as "the server
-// just doesn't work". Only one dot is stripped; "name.local.." remains malformed.
-static NSString *_WithoutRootLabel(NSString *host) {
-    return [host hasSuffix:@"."] ? [host substringToIndex:(host.length - 1)] : host;
-}
 
 - (WSKResponse *)_rejectIfHostNotAllowed {
     NSString *const hostHeader = _request.headers[@"Host"];
@@ -286,7 +278,7 @@ static NSString *_WithoutRootLabel(NSString *host) {
     // Strip the DNS root label from the *name*, not from the end of the whole value, so
     // "name.local.:8080" normalizes as well as "name.local.".
     BOOL const isBracketed = [normalized hasPrefix:@"["];
-    name = _WithoutRootLabel(name);
+    name = WSKHostNameWithoutRootLabel(name);
 
     // An allow-list entry may pin a port ("files.example:8080"), and such an entry is
     // deliberately honoured verbatim — including its port — so rebuild the canonical

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -139,6 +139,16 @@ BOOL WSKIsHeaderTokenCharacter(unsigned char character);
 BOOL WSKIsHeaderTokenString(NSString *_Nullable string);
 
 /**
+ *  Strips one trailing DNS root-label dot. "name.local." and "name.local" are the same host.
+ *
+ *  Shared because the two sides of the Host allow-list disagreed: the CHECK side stripped it from
+ *  the incoming header while the CONFIG side did not strip it from a WSKOption_AllowedHostNames
+ *  entry, so an entry written as a fully-qualified name — which is how DNS writes one — matched
+ *  nothing at all and every request answered 421.
+ */
+NSString *WSKHostNameWithoutRootLabel(NSString *host);
+
+/**
  *  Maps a filesystem NSError onto the server-error status that describes it honestly.
  *
  *  RFC 4918 §11.5: 507 Insufficient Storage means the method could not be performed because
@@ -251,7 +261,7 @@ NSString *_Nullable WSKResolveNamedEntryWithinDirectory(NSString *path, NSString
  *  advertised and then refused on access, which is the same disagreement with the sign flipped. A
  *  dangling link resolves to nothing and is likewise not classified.
  */
-NSString *_Nullable WSKServableFileTypeAtPath(NSString *path, NSString *directory);
+NSString *_Nullable WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL allowHiddenItems);
 
 NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory);
 

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -485,6 +485,11 @@ NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL includeService
     return includeService ? [NSString stringWithFormat:@"%s:%s", hostBuffer, serviceBuffer] : (NSString *)[NSString stringWithUTF8String:hostBuffer];
 }
 
+NSString *WSKHostNameWithoutRootLabel(NSString *host) {
+    // Only one dot is stripped; "name.local.." remains malformed and is refused.
+    return [host hasSuffix:@"."] ? [host substringToIndex:(host.length - 1)] : host;
+}
+
 BOOL WSKIsHeaderTokenCharacter(unsigned char character) {
     if (((character >= 'a') && (character <= 'z')) || ((character >= 'A') && (character <= 'Z')) || ((character >= '0') && (character <= '9'))) {
         return YES;
@@ -746,7 +751,7 @@ NSString *WSKResolveWithinDirectory(NSString *path, NSString *directory, NSStrin
     return resolvedPath;
 }
 
-NSString *WSKServableFileTypeAtPath(NSString *path, NSString *directory) {
+NSString *WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL allowHiddenItems) {
     NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:NULL];
     NSString *const type = attributes[NSFileType];
 
@@ -757,6 +762,15 @@ NSString *WSKServableFileTypeAtPath(NSString *path, NSString *directory) {
     // Judge the link by what it points at, and only when that is something this server would
     // actually serve: inside the directory, and a regular file or a directory itself.
     if (!WSKResolvedPathIsWithinDirectory(path, directory)) {
+        return nil;
+    }
+
+    // Containment was tested and hiddenness was not, so a link whose own name carries no dot but
+    // which resolves inside a dot-directory was ADVERTISED by all three listings and then refused
+    // 403 by every handler — measured. "Advertise iff served" is the rule the sixth, eighth and
+    // fifteenth passes each restored in one direction or the other; this is the half that judged
+    // only containment.
+    if (!allowHiddenItems && WSKResolvedPathHasHiddenComponent(path, directory)) {
         return nil;
     }
 

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -879,19 +879,24 @@ static inline NSString *_EncodeBase64(NSString *string) {
     NSString *const advertisedName = (bonjourName.length ? bonjourName : _serverName);
 
     if (advertisedName.length) {
-        [allowedHostNames addObject:[[advertisedName stringByAppendingString:@".local"] lowercaseString]];
+        [allowedHostNames addObject:[WSKHostNameWithoutRootLabel([advertisedName stringByAppendingString:@".local"]) lowercaseString]];
     }
 
     NSString *const machineName = [[NSProcessInfo processInfo] hostName];  // Typically "<device>.local"
 
     if (machineName.length) {
         // A trailing dot makes an mDNS name fully qualified; browsers send it without.
-        [allowedHostNames addObject:[[machineName hasSuffix:@"."] ? [machineName substringToIndex:(machineName.length - 1)] : machineName lowercaseString]];
+        [allowedHostNames addObject:[WSKHostNameWithoutRootLabel(machineName) lowercaseString]];
     }
 
+    // Normalized through the SAME helper the check side uses. Previously these entries were only
+    // lowercased, while the incoming Host had its root label stripped — so an entry written as a
+    // fully-qualified name ("puck.tailnet.ts.net.") could never match anything, and the server
+    // answered 421 to every request. That is the one option a Tailscale deployment is REQUIRED to
+    // set, so the failure presents as "the server just doesn't work".
     for (NSString *name in (NSArray *)_GetOption(_options, WSKOption_AllowedHostNames, @[])) {
         if ([name isKindOfClass:[NSString class]] && name.length) {
-            [allowedHostNames addObject:[name lowercaseString]];
+            [allowedHostNames addObject:[WSKHostNameWithoutRootLabel(name) lowercaseString]];
         }
     }
 
@@ -1576,7 +1581,7 @@ static NSString *_EscapeHTMLString(NSString *string) {
             // eighth passes each fixed in the other direction. A link out of the served root, or
             // a dangling one, classifies as nothing and stays unlisted, because that is what the
             // handler would refuse.
-            NSString *const type = WSKServableFileTypeAtPath([path stringByAppendingPathComponent:entry], path);
+            NSString *const type = WSKServableFileTypeAtPath([path stringByAppendingPathComponent:entry], path, includeHiddenItems);
 
             // Any process can delete the entry between the directory read above and this
             // stat, so a missing type is an ordinary race, not a logic error to assert on.

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -1349,7 +1349,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
     if (escapedPath) {
         NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:itemPath error:NULL];
         // Classified by what a symlink points at, so the listing describes what is actually served.
-        NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory);
+        NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory, _allowHiddenItems);
         BOOL isFile = [type isEqualToString:NSFileTypeRegular];
         BOOL isDirectory = [type isEqualToString:NSFileTypeDirectory];
 

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -1033,6 +1033,15 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 }
 
 - (nullable NSString *)_resolvedPathForRelativePath:(NSString *)relativePath hidden:(BOOL *)outHidden {
+    // The refusal lives HERE, not only in the callers, so a verb added later cannot forget it —
+    // which is exactly where DAV's equivalent puts it. Every current caller pre-checks as well, so
+    // this changes no behaviour today; what it removes is the requirement that the next one
+    // remembers. WSKNormalizePath truncates at a NUL, and acting on the truncated prefix is how
+    // "POST /delete path=/Keep%00/nonexistent" once destroyed /Keep and answered success.
+    if (WSKPathContainsNULByte(relativePath)) {
+        return nil;
+    }
+
     NSString *const normalizedPath = WSKNormalizePath(relativePath);
     NSString *resolvedRelativePath = nil;
     NSString *const resolvedPath = WSKResolveWithinDirectory([_uploadDirectory stringByAppendingPathComponent:normalizedPath], _uploadDirectory, &resolvedRelativePath);
@@ -1211,7 +1220,7 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
             NSString *const itemPath = [absolutePath stringByAppendingPathComponent:item];
             NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:itemPath error:NULL];
             // Classified by what a symlink points at, so the listing describes what is served.
-            NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory);
+            NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory, _allowHiddenItems);
             // A symlink's own attributes report the length of its target PATH, not the file, so
             // ask again through the link for anything classified as a regular file.
             NSString *const rawType = attributes[NSFileType];


### PR DESCRIPTION
The deferred structural cleanup starts with a **read-only inventory** — seven lenses over every rule implemented in more than one place. That ordering is the whole point: a mechanical sweep is exactly when a check quietly stops being enforced, and unifying two copies before knowing which is *correct* cements whichever spelling was read first.

**72 rules inventoried. 23 already disagree** — those are latent defects, not cleanup. Four were measured from the network before anything was touched. All four reproduced.

## Fixed here

**A root-dotted `AllowedHostNames` entry admitted nothing — not even its own spelling.**

The two sides of the allow-list had drifted: the check side strips the DNS root label from the incoming `Host`; the config side only lowercased the entry. So `puck.tailnet.ts.net.` — how DNS canonically writes an FQDN — matched neither the arriving stripped form nor itself, and **every request answered 421**.

That is the one option a Tailscale deployment is *required* to set, so it presents as "the server just doesn't work" in Shape A's only deployment.

```
before:  Host: puck.tailnet.ts.net.  -> 421      Host: puck.tailnet.ts.net -> 421
after:   Host: puck.tailnet.ts.net.  -> 200      Host: puck.tailnet.ts.net -> 200
```

One home now — `WSKHostNameWithoutRootLabel`, used by both sides.

**All three listings advertised entries every handler refuses.** `WSKServableFileTypeAtPath` tested containment and never hiddenness, so a link whose own name carries no dot but which resolves inside a dot-directory was listed and then answered 403. Measured: listed YES, `GET` 403. This is the "advertise iff served" rule the sixth, eighth and fifteenth passes each restored — back in a third direction.

**The uploader's follow-resolver had no NUL guard**, where DAV's sits *inside* the resolver under a comment saying it lives there "so a verb added later cannot forget it". Six per-endpoint pre-checks compensated, so behaviour matched only because every current caller remembered. Moved inside — no behaviour change today; what it removes is the requirement that the next endpoint remembers, which is how `POST /delete path=/Keep%00/x` once destroyed `/Keep`.

## Confirmed and deliberately NOT fixed

**The uploader's read endpoints stat before resolving**, so `404`-vs-`403` is an existence oracle for paths outside the share:

```
/download  out-of-share target EXISTS: 403    ABSENT: 404
/list      out-of-share target EXISTS: 400    ABSENT: 404
```

DAV gets this right and documents it; the uploader even disagrees with *itself* (its `deleteItem` resolves first). It's a small reordering, but it belongs with the resolver unification in phase 2 rather than as a spot fix.

**The extension allow-list judges different names in listings and on access** — the alias name when listing, the resolved target's name when serving:

```
alias.txt -> real.bin :  listed YES,  download 403
alias.bin -> real.txt :  listed no,   download 200
```

⚠️ **This one is a semantics decision, not a defect fix, and it needs your call.** The "symlinks are aliases" ruling says a *destructive* verb acts on the named entry — but a **read** through an alias discloses the target, so judging the alias name alone would turn `alias.txt -> id_rsa` into a disclosure. The fail-closed answer is to require *both* names to pass, which refuses both rows above and makes listings and access agree. That's the same shape as the source/destination decision you made before, so I've left it to you rather than defaulting it.

## Verification

- **140 tests, 0 failures** on a clean build
- **0 new warnings**
- Trace corpus green — load-bearing here, since this changes what PROPFIND lists
- Probe sensitive in both directions on both fixes

## What's next

**Phase 2** — the 48 rules that agree but are duplicated. The safe half: both copies already give the same answer, so a mistake surfaces as a test failure rather than a behaviour change.

**Phase 3** — the API-shape debt, including the target visibility that would let `WSKEntityTagForFileInfo`, `WSKLastModifiedDateIsSealed` and friends leave the public `WSKFunctions.h`, plus consolidating `CLAUDE.md`.