### PR TITLE
The extension allow-list now judges both names a symlink presents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,46 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Cleanup phase 2, first rule: the extension allow-list now judges BOTH names a symlink presents
+
+**A decided semantics question, not a defect fix**, and the first of the 48 duplicated-but-agreeing
+rules the phase 1 survey inventoried — except this pair did not agree. A symlink presents two names:
+the one the client used and the one the bytes live under. Listings vetted the alias; access vetted
+the resolved target. Measured with `allowedFileExtensions = ["txt"]`:
+
+    alias.txt -> real.bin    listed YES,  GET 403
+    alias.bin -> real.txt    listed no,   GET 200
+
+**The ruling is that both must pass**, which is the fail-closed reading. The alternatives were put
+side by side and rejected on their measured consequences: judging the **alias alone** is the most
+faithful reading of the "symlinks are aliases" semantics, but a *read* through an alias hands over
+the target's bytes, so `alias.txt -> id_rsa` becomes servable and the allow-list stops being a
+control for reads at all. Judging the **target alone** is safe for reads but contradicts the
+destructive-verb semantics already chosen, where a verb acts on the entry the client named.
+
+The accepted cost, recorded because it will be noticed: a link named `.txt` pointing at a file whose
+own extension is not allow-listed stops being servable. Both refusals and the case that must keep
+working are pinned by one test that asserts, for five entries, that **the listing and the handler
+never disagree** — which is the property, rather than any particular verdict.
+
+**The rule has one home**, `WSKEntryPassesExtensionAllowList`, and both servers' `-_checkFileExtension:`
+now delegate to `WSKNamePassesExtensionAllowList` rather than each spelling `containsObject:` over a
+lowercased `pathExtension`.
+
+**⚠️ The resolved name is derived from the resolution the listing ALREADY performed.** A caller that
+resolved a second time to learn the target's name would be making two observations of a filesystem
+that need not agree — the class the eighth pass closed and this file names as the general form that
+will recur. `WSKServableFileTypeAtPath` therefore hands the resolved leaf back through an out-param
+instead, and the base-path index (which has no allow-list) passes NULL.
+
+**Verified together.** 141 tests and 0 failures on a clean build with no new warnings, the trace
+corpus green, iOS and tvOS Debug clean, and the probe sensitive in both directions.
+
+**Phase 2 continues** with the remaining 47 rules, which unlike this one already agree — so a
+mistake there surfaces as a test failure rather than a behaviour change. The uploader's read
+endpoints stat before resolving (an existence oracle for paths outside the share) is carried into it
+as part of the resolver unification.
+
 ### Structural cleanup, phase 1: the survey found live bugs before it moved a line of code
 
 The cleanup deferred since the fourteenth pass began, deliberately, with a **read-only inventory**:

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -5143,4 +5143,49 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+
+// A symlink presents TWO names to the extension allow-list: the one the client used and the one the
+// bytes live under. They were judged inconsistently — listings vetted the alias, access vetted the
+// resolved target — so with ["txt"], "alias.txt -> real.bin" was advertised then refused 403 and
+// "alias.bin -> real.txt" was hidden then served 200. Both must now pass, which is the fail-closed
+// reading: judging the alias alone would make "alias.txt -> id_rsa" servable.
+- (void)testExtensionAllowListJudgesBothNamesASymlinkPresents {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    [@"binary" writeToFile:[dir stringByAppendingPathComponent:@"real.bin"] atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [@"text" writeToFile:[dir stringByAppendingPathComponent:@"real.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [fm createSymbolicLinkAtPath:[dir stringByAppendingPathComponent:@"alias.txt"] withDestinationPath:[dir stringByAppendingPathComponent:@"real.bin"] error:NULL];
+    [fm createSymbolicLinkAtPath:[dir stringByAppendingPathComponent:@"alias.bin"] withDestinationPath:[dir stringByAppendingPathComponent:@"real.txt"] error:NULL];
+    // The case that must KEEP working: both names allow-listed.
+    [fm createSymbolicLinkAtPath:[dir stringByAppendingPathComponent:@"good.txt"] withDestinationPath:[dir stringByAppendingPathComponent:@"real.txt"] error:NULL];
+
+    WSKWebUploader* uploader = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    uploader.allowedFileExtensions = @[ @"txt" ];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([uploader startWithOptions:options error:NULL]);
+
+    NSString* listing = SendRawRequest(uploader.port, @"GET /list?path=%2F HTTP/1.1\r\nHost: localhost\r\n\r\n");
+
+    // Each row: name, must the listing advertise it, must the handler serve it.
+    NSArray* rows = @[ @[ @"alias.txt", @NO ], @[ @"alias.bin", @NO ], @[ @"good.txt", @YES ], @[ @"real.txt", @YES ], @[ @"real.bin", @NO ] ];
+
+    for (NSArray* row in rows) {
+        NSString* name = row[0];
+        BOOL expected = [row[1] boolValue];
+        NSString* request = [NSString stringWithFormat:@"GET /download?path=%%2F%@ HTTP/1.1\r\nHost: localhost\r\n\r\n", name];
+        NSString* download = SendRawRequest(uploader.port, request);
+
+        BOOL const advertised = [listing containsString:name];
+        BOOL const served = [download containsString:@" 200"];
+        NSString* const detail = [NSString stringWithFormat:@"%@: advertised=%d served=%d expected=%d", name, advertised, served, expected];
+
+        // The property that matters most: the listing and the handler must never disagree.
+        XCTAssertEqual(advertised, served, @"listing must agree with the handler — %@", detail);
+        XCTAssertEqual(served, expected, @"wrong verdict — %@", detail);
+    }
+
+    [uploader stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 @end

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -149,6 +149,29 @@ BOOL WSKIsHeaderTokenString(NSString *_Nullable string);
 NSString *WSKHostNameWithoutRootLabel(NSString *host);
 
 /**
+ *  Does a single name satisfy an extension allow-list? A nil list means "no restriction".
+ *
+ *  The rule itself, in one place: both servers' -_checkFileExtension: delegate here.
+ */
+BOOL WSKNamePassesExtensionAllowList(NSString *name, NSArray<NSString *> *_Nullable allowedExtensions);
+
+/**
+ *  Does an ENTRY satisfy the allow-list, judged by BOTH names it presents?
+ *
+ *  A symlink has two: the name the client used, and the name the bytes actually live under. Those
+ *  were judged inconsistently — listings vetted the alias, access vetted the resolved target — so
+ *  with a list of ["txt"], "alias.txt -> real.bin" was advertised and then refused 403, while
+ *  "alias.bin -> real.txt" was hidden and then served 200.
+ *
+ *  BOTH must pass. That is the fail-closed reading and the owner's decision: judging the alias
+ *  alone would make "alias.txt -> id_rsa" servable, which turns the allow-list into decoration for
+ *  reads; judging the target alone contradicts the "symlinks are aliases" semantics a destructive
+ *  verb already follows. Pass nil for resolvedName when there is no second name (a regular file, or
+ *  a caller with only one to offer), which is exactly the single-name rule.
+ */
+BOOL WSKEntryPassesExtensionAllowList(NSString *namedName, NSString *_Nullable resolvedName, NSArray<NSString *> *_Nullable allowedExtensions);
+
+/**
  *  Maps a filesystem NSError onto the server-error status that describes it honestly.
  *
  *  RFC 4918 §11.5: 507 Insufficient Storage means the method could not be performed because
@@ -261,7 +284,7 @@ NSString *_Nullable WSKResolveNamedEntryWithinDirectory(NSString *path, NSString
  *  advertised and then refused on access, which is the same disagreement with the sign flipped. A
  *  dangling link resolves to nothing and is likewise not classified.
  */
-NSString *_Nullable WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL allowHiddenItems);
+NSString *_Nullable WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL allowHiddenItems, NSString *_Nullable __autoreleasing *_Nullable outResolvedName);
 
 NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory);
 

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -485,6 +485,23 @@ NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL includeService
     return includeService ? [NSString stringWithFormat:@"%s:%s", hostBuffer, serviceBuffer] : (NSString *)[NSString stringWithUTF8String:hostBuffer];
 }
 
+BOOL WSKNamePassesExtensionAllowList(NSString *name, NSArray<NSString *> *allowedExtensions) {
+    return (allowedExtensions == nil) || [allowedExtensions containsObject:[[name pathExtension] lowercaseString]];
+}
+
+BOOL WSKEntryPassesExtensionAllowList(NSString *namedName, NSString *resolvedName, NSArray<NSString *> *allowedExtensions) {
+    if (!WSKNamePassesExtensionAllowList(namedName, allowedExtensions)) {
+        return NO;
+    }
+
+    // Only a link presents a second name, and only a differing one is worth asking about.
+    if ((resolvedName != nil) && ![resolvedName isEqualToString:namedName]) {
+        return WSKNamePassesExtensionAllowList(resolvedName, allowedExtensions);
+    }
+
+    return YES;
+}
+
 NSString *WSKHostNameWithoutRootLabel(NSString *host) {
     // Only one dot is stripped; "name.local.." remains malformed and is refused.
     return [host hasSuffix:@"."] ? [host substringToIndex:(host.length - 1)] : host;
@@ -751,7 +768,11 @@ NSString *WSKResolveWithinDirectory(NSString *path, NSString *directory, NSStrin
     return resolvedPath;
 }
 
-NSString *WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL allowHiddenItems) {
+NSString *WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL allowHiddenItems, NSString *__autoreleasing *outResolvedName) {
+    if (outResolvedName) {
+        *outResolvedName = nil;
+    }
+
     NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:NULL];
     NSString *const type = attributes[NSFileType];
 
@@ -778,6 +799,19 @@ NSString *WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL al
 
     if (stat([path fileSystemRepresentation], &info) != 0) {
         return nil;  // Dangling, or a loop: there is nothing to advertise.
+    }
+
+    // Derived from the resolution this function ALREADY performed. A caller that resolved again to
+    // learn the target's name would be making a second observation of a filesystem that need not
+    // agree with the first — the two-observations class the eighth pass closed and this file names
+    // as the general form that will recur.
+    if (outResolvedName) {
+        char resolvedBuffer[PATH_MAX];
+
+        if (realpath([path fileSystemRepresentation], resolvedBuffer) != NULL) {
+            NSString *const resolved = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:resolvedBuffer length:strlen(resolvedBuffer)];
+            *outResolvedName = [resolved lastPathComponent];
+        }
     }
 
     if ((info.st_mode & S_IFMT) == S_IFDIR) {

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1581,7 +1581,7 @@ static NSString *_EscapeHTMLString(NSString *string) {
             // eighth passes each fixed in the other direction. A link out of the served root, or
             // a dangling one, classifies as nothing and stays unlisted, because that is what the
             // handler would refuse.
-            NSString *const type = WSKServableFileTypeAtPath([path stringByAppendingPathComponent:entry], path, includeHiddenItems);
+            NSString *const type = WSKServableFileTypeAtPath([path stringByAppendingPathComponent:entry], path, includeHiddenItems, NULL);
 
             // Any process can delete the entry between the directory read above and this
             // stat, so a missing type is an ordinary race, not a logic error to assert on.

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -296,11 +296,13 @@ static BOOL _EntityTagMatchesList(BOOL resourceExists, NSString *currentTag, NSS
 }
 
 - (BOOL)_checkFileExtension:(NSString *)fileName {
-    if (_allowedFileExtensions && ![_allowedFileExtensions containsObject:[[fileName pathExtension] lowercaseString]]) {
-        return NO;
-    }
+    return WSKNamePassesExtensionAllowList(fileName, _allowedFileExtensions);
+}
 
-    return YES;
+// Both names an entry presents must satisfy the allow-list; see WSKEntryPassesExtensionAllowList.
+// `resolvedName` is nil for anything that is not a link, which reduces to the single-name rule.
+- (BOOL)_checkFileExtensionForName:(NSString *)namedName resolvedName:(nullable NSString *)resolvedName {
+    return WSKEntryPassesExtensionAllowList(namedName, resolvedName, _allowedFileExtensions);
 }
 
 // Whatever an operation is about to destroy has to be something the client could have destroyed
@@ -774,9 +776,14 @@ static NSString *const kDAVAllowedMethods = @"OPTIONS, HEAD, GET, PUT, DELETE, M
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
     }
 
-    NSString *const itemName = [absolutePath lastPathComponent];
+    // absolutePath is the RESOLVED location by now, so its leaf is the target's name. The name the
+    // client actually used has to be judged too, or a link is vetted by a different name here than
+    // in the listing that advertised it — measured as advertise-then-403 in one direction and
+    // hidden-then-200 in the other.
+    NSString *const itemName = [relativePath lastPathComponent];
+    NSString *const resolvedName = [absolutePath lastPathComponent];
 
-    if (isHidden || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    if (isHidden || (!isDirectory && ![self _checkFileExtensionForName:itemName resolvedName:resolvedName])) {
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Downloading \"%@\" is not allowed", relativePath];
     }
 
@@ -1349,11 +1356,12 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar *name
     if (escapedPath) {
         NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:itemPath error:NULL];
         // Classified by what a symlink points at, so the listing describes what is actually served.
-        NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory, _allowHiddenItems);
+        NSString *resolvedName = nil;
+        NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory, _allowHiddenItems, &resolvedName);
         BOOL isFile = [type isEqualToString:NSFileTypeRegular];
         BOOL isDirectory = [type isEqualToString:NSFileTypeDirectory];
 
-        if ((isFile && [self _checkFileExtension:itemPath]) || isDirectory) {
+        if ((isFile && [self _checkFileExtensionForName:[itemPath lastPathComponent] resolvedName:resolvedName]) || isDirectory) {
             [xmlString appendString:@"<D:response>"];
             [xmlString appendFormat:@"<D:href>%@</D:href>", escapedPath];
 

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -958,11 +958,13 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 @implementation WSKWebUploader (Methods)
 
 - (BOOL)_checkFileExtension:(NSString *)fileName {
-    if (_allowedFileExtensions && ![_allowedFileExtensions containsObject:[[fileName pathExtension] lowercaseString]]) {
-        return NO;
-    }
+    return WSKNamePassesExtensionAllowList(fileName, _allowedFileExtensions);
+}
 
-    return YES;
+// Both names an entry presents must satisfy the allow-list; see WSKEntryPassesExtensionAllowList.
+// `resolvedName` is nil for anything that is not a link, which reduces to the single-name rule.
+- (BOOL)_checkFileExtensionForName:(NSString *)namedName resolvedName:(nullable NSString *)resolvedName {
+    return WSKEntryPassesExtensionAllowList(namedName, resolvedName, _allowedFileExtensions);
 }
 
 // -allowHiddenItems was only ever enforced on the leaf component, so a hidden
@@ -1220,7 +1222,8 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
             NSString *const itemPath = [absolutePath stringByAppendingPathComponent:item];
             NSDictionary *const attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:itemPath error:NULL];
             // Classified by what a symlink points at, so the listing describes what is served.
-            NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory, _allowHiddenItems);
+            NSString *resolvedName = nil;
+            NSString *const type = WSKServableFileTypeAtPath(itemPath, _uploadDirectory, _allowHiddenItems, &resolvedName);
             // A symlink's own attributes report the length of its target PATH, not the file, so
             // ask again through the link for anything classified as a regular file.
             NSString *const rawType = attributes[NSFileType];
@@ -1229,7 +1232,7 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
                                                 : attributes;
             NSNumber *const size = effective[NSFileSize];  // Nil if the item vanished between the listing and this stat; must not reach the literal below.
 
-            if ([type isEqualToString:NSFileTypeRegular] && size && [self _checkFileExtension:item]) {
+            if ([type isEqualToString:NSFileTypeRegular] && size && [self _checkFileExtensionForName:item resolvedName:resolvedName]) {
                 [array addObject:@{
                     @"path": [normalizedPath stringByAppendingPathComponent:item],
                     @"name": item,
@@ -1285,10 +1288,12 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 
     absolutePath = resolvedPath;
 
-    NSString *const fileName = [absolutePath lastPathComponent];
+    // As in DAV's GET: absolutePath is resolved by here, so judge the client's name too.
+    NSString *const fileName = [relativePath lastPathComponent];
+    NSString *const resolvedName = [absolutePath lastPathComponent];
 
-    if (![self _checkFileExtension:fileName]) {
-        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Downlading file name \"%@\" is not allowed", fileName];
+    if (![self _checkFileExtensionForName:fileName resolvedName:resolvedName]) {
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Downloading file name \"%@\" is not allowed", fileName];
     }
 
     if ([self.delegate respondsToSelector:@selector(webUploader:didDownloadFileAtPath:)]) {


### PR DESCRIPTION
Phase 2's first rule — and the one that needed your ruling, since it's a **semantics decision rather than a defect fix**.

## The drift

A symlink presents two names: the one the client used, and the one the bytes live under. Listings vetted the alias; access vetted the resolved target. Measured with `allowedFileExtensions = ["txt"]`:

```
alias.txt -> real.bin    listed YES,  GET 403
alias.bin -> real.txt    listed no,   GET 200
```

## The ruling: both must pass

The alternatives were put side by side and rejected on measured consequences:

- **Alias alone** is the most faithful reading of "symlinks are aliases" — but a *read* through an alias hands over the target's bytes, so `alias.txt -> id_rsa` becomes servable and the allow-list stops being a control for reads at all.
- **Target alone** is safe for reads but contradicts the destructive-verb semantics already chosen, where a verb acts on the entry the client named.

After:

```
alias.txt -> real.bin    listed no,   GET 403
alias.bin -> real.txt    listed no,   GET 403
good.txt  -> real.txt    listed YES,  GET 200
```

**Accepted cost, recorded because it will be noticed:** a link named `.txt` pointing at a file whose own extension is not allow-listed stops being servable.

## One home

`WSKEntryPassesExtensionAllowList` holds the rule; both servers' `-_checkFileExtension:` now delegate to the shared single-name predicate rather than each spelling `containsObject:` over a lowercased `pathExtension`.

## ⚠️ The resolved name comes from the resolution already performed

A caller that resolved a *second* time to learn the target's name would be making two observations of a filesystem that need not agree — the class the eighth pass closed and `CLAUDE.md` names as the general form that will recur. `WSKServableFileTypeAtPath` hands the resolved leaf back through an out-param instead; the base-path index (no allow-list) passes NULL.

## The test asserts the property, not the verdicts

For five entries it checks that **the listing and the handler never disagree**, plus the expected verdict for each — including `good.txt -> real.txt`, the case that must keep working, so this can't pass by refusing everything.

## Verification

- **141 tests, 0 failures** on a clean build
- **0 new warnings**
- Trace corpus green — load-bearing, since this changes what PROPFIND lists
- iOS and tvOS Debug: exit 0, 0 warnings
- Probe sensitive in both directions

## Next

The remaining **47** inventoried rules, which unlike this one already agree — so a mistake there surfaces as a test failure rather than a behaviour change. The uploader's stat-before-resolve existence oracle is carried into that work as part of the resolver unification.