### PR TITLE
Gave the four-times-recurring destroy-vetting walk one home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,40 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Cleanup phase 2, continued: the four-times-recurring walk gets one home
+
+**The recursive-destroy vetting walk was two implementations, comments and all.** DAV's
+`-_firstUnvettableItemAtPath:isDirectory:` and an inline walk in the uploader's `deleteItem:` — and
+the DAV comment openly said it "mirrors `-[WSKWebUploader deleteItem:]`", a self-documented second
+copy of a security rule. Four separate audit lenses reported it independently, which is itself worth
+noting: nothing else in the inventory drew that much agreement.
+
+This is **the class that has recurred four times** (eighth, tenth, thirteenth and fifteenth passes):
+a recursive DELETE or an overwrite destroying files that a direct request refuses, most recently
+measured at 60/60. It is now `WSKFirstUnvettableItemAtPath`, called by both. **Both copies were
+wrong simultaneously the last time** — the `-skipDescendants` handling — which is the sharpest
+possible argument for one home: the fifteenth pass had to find and fix the identical bug twice.
+
+Both judgement calls move with it and are documented at the shared site: dot-names and their
+descendants are skipped whatever `allowHiddenItems` says (a `.DS_Store` sits in every macOS folder
+and its empty `pathExtension` is in no allow-list, so vetting them would make ordinary directories
+permanently undeletable), and an extensionless file IS vetted, because a direct DELETE of it is
+already refused.
+
+**Same-file detection is shared too** — `WSKPathsNameTheSameFile`, verified byte-identical in both
+servers first. It is the whole of the protection against a self-move deleting the only copy of a
+file, including the case-variant pair that is one file on a case-insensitive volume.
+
+**An inventory finding that resolved itself.** The survey flagged `WSKResolvedPathHasHiddenComponent`
+as a DEAD helper sitting beside eleven live inline spellings of the same rule — exactly the trap this
+file names ("an unused second implementation of a security rule sitting beside the live one is a trap
+for whoever needs that check next"). It is no longer dead: phase 1's fix to
+`WSKServableFileTypeAtPath` gave it its first caller. Recorded because the survey ran one commit
+earlier, which is a reminder that an inventory ages like any other finding.
+
+**Verified together.** 141 tests and 0 failures on a clean build with no new warnings, the trace
+corpus green, iOS and tvOS Debug clean. 94 lines left the two servers.
+
 ### Cleanup phase 2: the four resolver copies are one, and an oracle whose cause was not what the survey said
 
 **The largest duplication in the library is gone.** `-_namedEntryPathForRelativePath:hidden:` and

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -193,6 +193,33 @@ NSString *_Nullable WSKResolvedPathForRelativePath(NSString *relativePath, NSStr
 NSString *_Nullable WSKNamedEntryPathForRelativePath(NSString *relativePath, NSString *directory, BOOL allowHiddenItems, BOOL *_Nullable outHidden);
 
 /**
+ *  The first subtree member a destructive verb must NOT be allowed to destroy, or nil if the whole
+ *  tree is safe to remove.
+ *
+ *  A recursive DELETE, or an overwrite, must refuse anything a DIRECT request would refuse — or the
+ *  same request means two different things depending on how it is spelled. That class has recurred
+ *  FOUR times in this project (eighth, tenth, thirteenth and fifteenth passes), most recently
+ *  measured at 60/60 destroyed, so the walk lives in one place now rather than once per server.
+ *
+ *  Two judgement calls are baked in, both load-bearing. Dot-names and their descendants are skipped
+ *  whatever `allowHiddenItems` says: a ".DS_Store" sits in every macOS folder and its empty
+ *  pathExtension is in no allow-list, so vetting them would make ordinary directories permanently
+ *  undeletable. And an extensionless file IS vetted, because a direct DELETE of it is already
+ *  refused.
+ */
+NSString *_Nullable WSKFirstUnvettableItemAtPath(NSString *absolutePath, BOOL isDirectory, NSArray<NSString *> *_Nullable allowedExtensions);
+
+/**
+ *  Do two paths name the same file on disk?
+ *
+ *  Compares file resource identifiers (inode + volume), so it also catches the case-variant pair
+ *  "File.txt"/"file.txt" that is ONE file on a case-insensitive volume. That is the whole of the
+ *  protection against a self-move: an unconditional "remove the destination, then move" with
+ *  `Overwrite: T` deleted the only copy of the file when the two paths resolved to it.
+ */
+BOOL WSKPathsNameTheSameFile(NSString *path1, NSString *path2);
+
+/**
  *  Maps a filesystem NSError onto the server-error status that describes it honestly.
  *
  *  RFC 4918 §11.5: 507 Insufficient Storage means the method could not be performed because

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -837,6 +837,61 @@ NSString *WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL al
 // variable it already used — chosen over rewriting the downstream uses because it makes "I missed
 // one" structurally impossible, which is the failure mode that would matter most here.
 
+BOOL WSKPathsNameTheSameFile(NSString *path1, NSString *path2) {
+    if ([path1 isEqualToString:path2]) {
+        return YES;
+    }
+
+    id identifier1 = nil;
+    id identifier2 = nil;
+    return [[NSURL fileURLWithPath:path1] getResourceValue:&identifier1 forKey:NSURLFileResourceIdentifierKey error:NULL] &&
+           [[NSURL fileURLWithPath:path2] getResourceValue:&identifier2 forKey:NSURLFileResourceIdentifierKey error:NULL] &&
+           identifier1 && [(NSObject *)identifier1 isEqual:identifier2];
+}
+
+NSString *WSKFirstUnvettableItemAtPath(NSString *absolutePath, BOOL isDirectory, NSArray<NSString *> *allowedExtensions) {
+    if (allowedExtensions == nil) {
+        return nil;  // No restriction configured: nothing to vet against.
+    }
+
+    if (!isDirectory) {
+        NSString *const itemName = [absolutePath lastPathComponent];
+        return WSKNamePassesExtensionAllowList(itemName, allowedExtensions) ? nil : itemName;
+    }
+
+    NSDirectoryEnumerator<NSString *> *const enumerator = [[NSFileManager defaultManager] enumeratorAtPath:absolutePath];
+
+    for (NSString *subpath in enumerator) {
+        NSString *const subpathType = [enumerator fileAttributes][NSFileType];
+
+        if ([[subpath lastPathComponent] hasPrefix:@"."]) {
+            // -skipDescendants is defined for the most recently returned SUBDIRECTORY. Calling it
+            // for a dot-named FILE popped the enclosing level instead, so every entry after the
+            // first dot-name in that directory's readdir order was never vetted — and a
+            // ".DS_Store" sits in every Finder-touched folder, sorting early. Measured: with an
+            // allow-list of "txt", DELETE of a collection holding "sub/{.DS_Store,id_rsa}"
+            // answered 204 and destroyed id_rsa, 60/60, while the same file addressed directly is
+            // refused 403. The top level of the addressed collection is immune, which is exactly
+            // why the existing tests could not see it. Only a dot-named DIRECTORY may be skipped
+            // wholesale — that part is deliberate and still holds.
+            if ([subpathType isEqualToString:NSFileTypeDirectory]) {
+                [enumerator skipDescendants];
+            }
+
+            continue;
+        }
+
+        // An extensionless file ("README", "LICENSE") is vetted like any other: a direct DELETE of
+        // it is already refused, so letting a recursive delete destroy it would make the same
+        // request mean two different things.
+        if ([subpathType isEqualToString:NSFileTypeRegular] && !WSKNamePassesExtensionAllowList(subpath, allowedExtensions)) {
+            return subpath;
+        }
+    }
+
+    return nil;
+}
+
 NSString *WSKNamedEntryPathForRelativePath(NSString *relativePath, NSString *directory, BOOL allowHiddenItems, BOOL *outHidden) {
     if (WSKPathContainsNULByte(relativePath)) {
         return nil;

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -325,43 +325,7 @@ static BOOL _EntityTagMatchesList(BOOL resourceExists, NSString *currentTag, NSS
 // make ordinary folders permanently undeletable. And an extensionless file ("README") is vetted
 // like any other, because addressing it directly is already refused.
 - (nullable NSString *)_firstUnvettableItemAtPath:(NSString *)absolutePath isDirectory:(BOOL)isDirectory {
-    if (_allowedFileExtensions == nil) {
-        return nil;
-    }
-
-    if (!isDirectory) {
-        NSString *const itemName = [absolutePath lastPathComponent];
-        return [self _checkFileExtension:itemName] ? nil : itemName;
-    }
-
-    NSDirectoryEnumerator<NSString *> *const enumerator = [[NSFileManager defaultManager] enumeratorAtPath:absolutePath];
-
-    for (NSString *subpath in enumerator) {
-        NSString *const subpathType = [enumerator fileAttributes][NSFileType];
-
-        if ([[subpath lastPathComponent] hasPrefix:@"."]) {
-            // -skipDescendants is defined for the most recently returned SUBDIRECTORY. Calling it
-            // for a dot-named FILE popped the enclosing level instead, so every entry after the
-            // first dot-name in that directory's readdir order was never vetted — and a
-            // ".DS_Store" sits in every Finder-touched folder, sorting early. Measured: with an
-            // allow-list of "txt", DELETE of a collection holding "sub/{.DS_Store,id_rsa}"
-            // answered 204 and destroyed id_rsa, 60/60, while the same file addressed directly
-            // is refused 403. The top level of the addressed collection is immune, which is
-            // exactly why the existing tests could not see it. Only a dot-named DIRECTORY may be
-            // skipped wholesale — that part is deliberate and still holds.
-            if ([subpathType isEqualToString:NSFileTypeDirectory]) {
-                [enumerator skipDescendants];
-            }
-
-            continue;
-        }
-
-        if ([subpathType isEqualToString:NSFileTypeRegular] && ![self _checkFileExtension:subpath]) {
-            return subpath;
-        }
-    }
-
-    return nil;
+    return WSKFirstUnvettableItemAtPath(absolutePath, isDirectory, _allowedFileExtensions);
 }
 
 // Hidden-item protection has to cover every component of the path, not only the leaf:
@@ -962,15 +926,7 @@ static NSString *const kDAVAllowedMethods = @"OPTIONS, HEAD, GET, PUT, DELETE, M
 // Whether two paths refer to the same underlying file — either identical strings, or
 // (on a case-insensitive volume) different spellings that resolve to a single inode.
 - (BOOL)_fileAtPath:(NSString *)path1 isSameAsPath:(NSString *)path2 {
-    if ([path1 isEqualToString:path2]) {
-        return YES;
-    }
-
-    id identifier1 = nil;
-    id identifier2 = nil;
-    return [[NSURL fileURLWithPath:path1] getResourceValue:&identifier1 forKey:NSURLFileResourceIdentifierKey error:NULL] &&
-           [[NSURL fileURLWithPath:path2] getResourceValue:&identifier2 forKey:NSURLFileResourceIdentifierKey error:NULL] &&
-           identifier1 && [(NSObject *)identifier1 isEqual:identifier2];
+    return WSKPathsNameTheSameFile(path1, path2);
 }
 
 - (WSKResponse *)performCOPY:(WSKRequest *)request isMove:(BOOL)isMove {

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -1034,15 +1034,7 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
 // volume), so it also catches the case-variant pair "File.txt"/"file.txt" that resolves
 // to one file on a case-insensitive volume. Same approach as WSKWebDAVServer's MOVE/COPY.
 - (BOOL)_fileAtPath:(NSString *)path1 isSameAsPath:(NSString *)path2 {
-    if ([path1 isEqualToString:path2]) {
-        return YES;
-    }
-
-    id identifier1 = nil;
-    id identifier2 = nil;
-    return [[NSURL fileURLWithPath:path1] getResourceValue:&identifier1 forKey:NSURLFileResourceIdentifierKey error:NULL] &&
-           [[NSURL fileURLWithPath:path2] getResourceValue:&identifier2 forKey:NSURLFileResourceIdentifierKey error:NULL] &&
-           identifier1 && [(NSObject *)identifier1 isEqual:identifier2];
+    return WSKPathsNameTheSameFile(path1, path2);
 }
 
 - (NSString *)_uniquePathForPath:(NSString *)path {
@@ -1557,45 +1549,18 @@ static NSString *_OriginAuthority(NSString *value) {
     BOOL removed;
 
     @synchronized(_fileOperationLock) {
-        // Deleting a directory removes its whole subtree, which must not become a way to
-        // destroy files that a direct delete would refuse. The extension check above only
-        // applies to files, so vet the contents before removing a directory.
-        if (isDirectory && _allowedFileExtensions) {
-            NSDirectoryEnumerator<NSString *> *const enumerator = [[NSFileManager defaultManager] enumeratorAtPath:absolutePath];
+        // Deleting a directory removes its whole subtree, which must not become a way to destroy
+        // files that a direct delete would refuse. The extension check above only applies to the
+        // item itself, so vet the contents first.
+        //
+        // Shared with WebDAV rather than spelled again here: this walk was a second implementation
+        // of the same rule, comments and all, and "a rule closed in one server and not the other"
+        // is the class that has recurred FOUR times in this project — including through this exact
+        // walk, where the -skipDescendants handling was wrong in both copies simultaneously.
+        NSString *const unvettable = WSKFirstUnvettableItemAtPath(absolutePath, isDirectory, _allowedFileExtensions);
 
-            for (NSString *subpath in enumerator) {
-                // Skip dot-names — and everything under them — whatever -allowHiddenItems
-                // says. They are incidental metadata rather than content the allow-list is
-                // meant to protect (a ".DS_Store" sits in every macOS folder, and its empty
-                // pathExtension is in no allow-list), so vetting them would make ordinary
-                // directories permanently undeletable. Note this cannot use the shared rule,
-                // which reports NO for everything once hidden items are allowed.
-                NSString *const subpathType = [enumerator fileAttributes][NSFileType];
-
-                if ([[subpath lastPathComponent] hasPrefix:@"."]) {
-                    // -skipDescendants is defined for the most recently returned SUBDIRECTORY.
-                    // Calling it for a dot-named FILE popped the enclosing level instead, so every
-                    // entry after the first dot-name in that directory's readdir order was never
-                    // vetted at all — and a ".DS_Store" sits in every Finder-touched folder. The
-                    // top level of the addressed collection is immune, which is exactly why the
-                    // existing fixtures could not see it: they put the unvettable file there.
-                    // Only a dot-named DIRECTORY may be skipped wholesale.
-                    if ([subpathType isEqualToString:NSFileTypeDirectory]) {
-                        [enumerator skipDescendants];
-                    }
-
-                    continue;
-                }
-
-                // An extensionless file ("README", "LICENSE") is vetted like any other: a
-                // direct DELETE of it is already refused, so letting a recursive delete
-                // destroy it would make the same request mean two different things. Refusing
-                // the folder is the honest answer — the client is told exactly which entry
-                // blocked it and can remove that first.
-                if ([subpathType isEqualToString:NSFileTypeRegular] && ![self _checkFileExtension:subpath]) {
-                    return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed: it contains \"%@\"", relativePath, subpath];
-                }
-            }
+        if (unvettable) {
+            return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not allowed: it contains \"%@\"", relativePath, unvettable];
         }
 
         // -removeItemAtPath: deletes as it walks and stops at the first member it cannot unlink,


### PR DESCRIPTION
## The walk that has broken four times

The recursive-destroy vetting walk existed twice — DAV's `-_firstUnvettableItemAtPath:isDirectory:` and an inline walk in the uploader's `deleteItem:` — with near-identical comments. The DAV one openly said it *"mirrors `-[WSKWebUploader deleteItem:]`"*: a self-documented second implementation of a security rule.

**Four separate inventory lenses reported it independently.** Nothing else in the survey drew that much agreement.

This is the class that has recurred **four times** (eighth, tenth, thirteenth, fifteenth passes): a recursive DELETE or overwrite destroying files that a direct request refuses — most recently measured at **60/60 destroyed**.

**The clinching detail: both copies were wrong simultaneously the last time.** The `-skipDescendants` bug (calling it for a dot-named *file* pops the enclosing level, so everything after the first `.DS_Store` went unvetted) existed in both, so the fifteenth pass had to find and fix the identical defect twice. That is the strongest possible argument for one home.

Both judgement calls move with it and are documented at the shared site:
- dot-names and their descendants are skipped whatever `allowHiddenItems` says — a `.DS_Store` sits in every macOS folder and its empty `pathExtension` is in no allow-list, so vetting them would make ordinary directories permanently undeletable;
- an extensionless file **is** vetted, because a direct DELETE of it is already refused.

## Same-file detection shared too

`WSKPathsNameTheSameFile`, verified byte-identical in both servers before merging. It's the whole of the protection against a self-move deleting the only copy of a file, including the case-variant pair that is one file on a case-insensitive volume.

## An inventory finding that resolved itself

The survey flagged `WSKResolvedPathHasHiddenComponent` as a **dead** helper sitting beside eleven live inline spellings of the same rule — exactly the trap `CLAUDE.md` names: *"an unused second implementation of a security rule sitting beside the live one is a trap for whoever needs that check next."*

It's no longer dead. Phase 1's fix to `WSKServableFileTypeAtPath` gave it its first caller. Recorded because the survey ran one commit earlier — an inventory ages like any other finding, which is the same lesson the backlog taught.

## Verification

- **141 tests, 0 failures** on a clean build
- **0 new warnings**
- Trace corpus green
- iOS and tvOS Debug: exit 0, 0 warnings

```
Sources/WebServerKitDAV/WSKWebDAVServer.m       2 +  46 -
Sources/WebServerKitUploader/WSKWebUploader.m  13 +  48 -
```

Behaviour is unchanged by construction: both copies were verified identical before merging.