### PR TITLE
Closed the existence oracle at its real cause, without breaking creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,46 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### The existence oracle closed at its real cause, and the fallback it lives in proved intact
+
+The oracle the fifteenth-pass inventory blamed on stat-before-resolve, and which reordering those
+endpoints did NOT close. The real cause is `_RealPath`: when `realpath(3)` fails it resolves the
+PARENT and appends the raw leaf — the branch that lets a `PUT` or `MKCOL` to a not-yet-existing name
+resolve at all. **A dangling symlink also fails `realpath`**, so it took the same branch and resolved
+to a location *inside* the share, which made the answer depend on whether the link's target existed:
+
+    GET escaping link, target EXISTS : 403
+    GET escaping link, target ABSENT : 404
+
+An entry that exists and cannot be resolved now fails closed. Both spellings answer 403.
+
+**⚠️ The important half of this change is what it does NOT break.** The fallback is load-bearing —
+without it every `PUT` and `MKCOL` of a new name fails — so the probe measured six operations that
+must survive alongside the two that must change, and the regression test asserts all of them. A
+guard justified by one failure mode has to be checked against everything it then refuses; that rule
+was written here after two self-inflicted over-refusals, and this is the first change made under it
+deliberately.
+
+| | before | after |
+|---|---|---|
+| escaping link, target exists | 403 | 403 |
+| escaping link, target absent | **404** | **403** |
+| PUT to a brand-new path | 201 | 201 |
+| PUT to a new path in a subfolder | 201 | 201 |
+| MKCOL a brand-new collection | 201 | 201 |
+| PUT over an existing file | 204 | 204 |
+| GET an ordinary file | 200 | 200 |
+| MOVE to a brand-new name | 201 | 201 |
+| dangling link inside the share | 404 | 403 |
+| symlink loop | 404 | 403 |
+
+The last two are the only other behaviour change, and neither was ever served — a `PUT` through a
+dangling link already answered 500, so no working operation is lost and only the status moves, in
+the honest direction.
+
+**Verified together.** 142 tests and 0 failures on a clean build with no new warnings, the trace
+corpus green, iOS and tvOS Debug clean.
+
 ### Cleanup phase 2, continued: the four-times-recurring walk gets one home
 
 **The recursive-destroy vetting walk was two implementations, comments and all.** DAV's

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -5188,4 +5188,55 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+
+// _RealPath falls back to "resolve the parent, append the leaf" when realpath(3) fails, which is
+// what lets a PUT to a not-yet-existing path resolve at all. A DANGLING symlink also fails
+// realpath, so it took that branch and resolved INSIDE the share — making 404-vs-403 an existence
+// oracle for the filesystem outside it: 403 when an escaping link's target existed, 404 when it
+// did not. An entry that exists and cannot be resolved now fails closed.
+//
+// The second half of this test is the one that matters: the fallback must keep working, because a
+// guard justified by one failure mode has to be checked against everything it then refuses.
+- (void)testUnresolvableEntriesFailClosedWithoutBreakingCreation {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    NSString* share = [root stringByAppendingPathComponent:@"share"];
+    NSString* outside = [root stringByAppendingPathComponent:@"outside"];
+    [fm createDirectoryAtPath:[share stringByAppendingPathComponent:@"sub"] withIntermediateDirectories:YES attributes:nil error:NULL];
+    [fm createDirectoryAtPath:outside withIntermediateDirectories:YES attributes:nil error:NULL];
+    [@"out" writeToFile:[outside stringByAppendingPathComponent:@"exists.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [@"in" writeToFile:[share stringByAppendingPathComponent:@"real.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL];
+    [fm createSymbolicLinkAtPath:[share stringByAppendingPathComponent:@"esc-exists"] withDestinationPath:[outside stringByAppendingPathComponent:@"exists.txt"] error:NULL];
+    [fm createSymbolicLinkAtPath:[share stringByAppendingPathComponent:@"esc-absent"] withDestinationPath:[outside stringByAppendingPathComponent:@"absent.txt"] error:NULL];
+
+    WSKWebDAVServer* dav = [[WSKWebDAVServer alloc] initWithUploadDirectory:share];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([dav startWithOptions:options error:NULL]);
+
+    NSString* present = SendRawRequest(dav.port, @"GET /esc-exists HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    NSString* absent = SendRawRequest(dav.port, @"GET /esc-absent HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    NSString* presentStatus = [present substringWithRange:NSMakeRange(9, 3)];
+    NSString* absentStatus = [absent substringWithRange:NSMakeRange(9, 3)];
+    NSString* detail = [NSString stringWithFormat:@"target-exists=%@ target-absent=%@", presentStatus, absentStatus];
+    XCTAssertEqualObjects(presentStatus, absentStatus, @"the status must not reveal whether a file outside the share exists: %@", detail);
+    XCTAssertEqualObjects(presentStatus, @"403", @"an escaping link must be refused: %@", detail);
+
+    // The fallback exists so a path that does not exist yet can be created. If this regresses,
+    // every PUT and MKCOL of a new name breaks — which is far worse than the oracle.
+    NSArray* creations = @[ @[ @"PUT /brand-new.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\n\r\nhi", @"201" ],
+                            @[ @"PUT /sub/nested.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\n\r\nhi", @"201" ],
+                            @[ @"MKCOL /brand-new-dir HTTP/1.1\r\nHost: localhost\r\n\r\n", @"201" ],
+                            @[ @"PUT /real.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\n\r\nhi", @"204" ],
+                            @[ @"GET /real.txt HTTP/1.1\r\nHost: localhost\r\n\r\n", @"200" ] ];
+
+    for (NSArray* row in creations) {
+        NSString* reply = SendRawRequest(dav.port, row[0]);
+        NSString* status = (reply.length > 12) ? [reply substringWithRange:NSMakeRange(9, 3)] : reply;
+        XCTAssertEqualObjects(status, row[1], @"the not-yet-exists fallback must keep working: %@ -> %@", [row[0] substringToIndex:MIN((NSUInteger)24, [row[0] length])], status);
+    }
+
+    [dav stop];
+    [fm removeItemAtPath:root error:NULL];
+}
+
 @end

--- a/Sources/WebServerKit/Core/WSKFunctions.m
+++ b/Sources/WebServerKit/Core/WSKFunctions.m
@@ -729,6 +729,26 @@ static NSString *_RealPath(NSString *path) {
         return [fileManager stringWithFileSystemRepresentation:buffer length:strlen(buffer)];
     }
 
+    // realpath(3) failed. Normally that means the path does not exist YET — a PUT or MKCOL to a new
+    // name — and resolving the parent then appending the leaf is exactly right for it. That branch
+    // is why this function has a fallback at all, so it must keep working.
+    //
+    // An entry that EXISTS and still fails realpath is a different thing: a dangling symlink, a
+    // loop, or a component that cannot be traversed. Treating one as "a new path inside the share"
+    // resolved it to a location inside, and the answer then depended on whether the link's target
+    // existed — 403 when it did, 404 when it did not — which is an existence oracle for the
+    // filesystem OUTSIDE the share, reachable through any escaping link in the served content.
+    //
+    // Fail closed: the entry is there and cannot be resolved, so it cannot be acted on. Measured
+    // effect beyond closing the oracle: a dangling link and a symlink loop answer 403 rather than
+    // 404. Neither was ever served, and a PUT through a dangling link answered 500 before, so no
+    // working operation is lost — only the status changes, in the honest direction.
+    struct stat entryInfo;
+
+    if (lstat([path fileSystemRepresentation], &entryInfo) == 0) {
+        return nil;
+    }
+
     NSString *const parent = [path stringByDeletingLastPathComponent];
 
     if ((parent.length == 0) || [parent isEqualToString:path]) {


### PR DESCRIPTION
The oracle the inventory blamed on stat-before-resolve — and which reordering those endpoints **did not** close.

## The real cause

`_RealPath` falls back to "resolve the PARENT and append the raw leaf" when `realpath(3)` fails. That branch is what lets a `PUT` or `MKCOL` to a not-yet-existing name resolve at all, so it has to stay.

But a **dangling** symlink also fails `realpath`, so it took the same branch and resolved to a location *inside* the share — which made the answer depend on whether the link's target existed:

```
GET escaping link, target EXISTS : 403
GET escaping link, target ABSENT : 404
```

An entry that exists and cannot be resolved (dangling link, loop, untraversable component) now fails closed. Both spellings answer 403.

## ⚠️ The half that matters more is what this does NOT break

The fallback is load-bearing — remove it carelessly and every `PUT` and `MKCOL` of a new name fails. So the probe measured **six operations that must survive** alongside the two that must change, and the regression test asserts all of them:

| | before | after |
|---|---|---|
| escaping link, target exists | 403 | 403 |
| escaping link, target absent | **404** | **403** |
| `PUT` to a brand-new path | 201 | 201 |
| `PUT` to a new path in a subfolder | 201 | 201 |
| `MKCOL` a brand-new collection | 201 | 201 |
| `PUT` over an existing file | 204 | 204 |
| `GET` an ordinary file | 200 | 200 |
| `MOVE` to a brand-new name | 201 | 201 |
| dangling link inside the share | 404 | 403 |
| symlink loop | 404 | 403 |

The last two are the only other behaviour change. Neither was ever served, and a `PUT` through a dangling link already answered 500 — so no working operation is lost; only the status moves, in the honest direction.

**A guard justified by one failure mode has to be checked against everything it then refuses.** That rule was written into `CLAUDE.md` after two self-inflicted over-refusals earlier in this programme. This is the first change made under it deliberately, and the test encodes it: five of its assertions exist purely to catch over-refusal.

## Verification

- **142 tests, 0 failures** on a clean build — re-run after rebasing onto `main`
- **0 new warnings**
- Trace corpus green
- iOS and tvOS Debug: exit 0, 0 warnings
- Probe sensitive in both directions

## Note on branching

This was committed while #65 was still open and deliberately **held** rather than stacked, then rebased onto `main` once #65 landed. Verified not-stacked before pushing — and #65's landing was confirmed by grepping `main` for the code, not by trusting the PR status, after `merge-base --is-ancestor` gave a misleading NO from a deleted remote ref.