### PR TITLE
Moved three security-shaped path helpers off the public header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,48 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Cleanup phase 3, group A: three security-shaped functions leave the public header
+
+The public `WSKFunctions.h` had grown to **27 declarations**, and the memory note carried the reason
+as "ten are public solely because the SPM sibling targets cannot see `WSKPrivate.h`". Measuring the
+actual usage split it three ways instead, which makes the work tractable in pieces rather than as
+one breaking change:
+
+- **eleven the siblings genuinely use** — the resolvers, the vetting walk, the allow-list predicates,
+  same-file detection. These are the ones that need the target-visibility change, and they are still
+  public.
+- **seven core-only utilities** — MIME type, URL escaping, primary IP, the header-token predicates,
+  the root-label helper. No build-graph work needed; some are plausibly legitimate public API, so
+  they are a judgement call rather than an obvious removal.
+- **three used nowhere outside `WSKFunctions.m`** — `WSKResolvedPathIsWithinDirectory`,
+  `WSKResolvedPathRelativeToDirectory`, `WSKResolvedPathHasHiddenComponent`. **This change.**
+
+**⚠️ A claim of mine was wrong and it would have changed the fix.** I first reported these three as
+having "zero callers anywhere", from a grep that excluded `WSKFunctions.m` — where all of them are in
+fact called. The honest statement is "no caller *outside* that file", which makes them internal
+helpers exposed publicly, not dead code. Delete was never the right answer; relocating is.
+
+**And `static` was not the right answer either**, for a reason only a full-repo grep surfaces:
+`WSKResolvedPathIsWithinDirectory` has **eleven assertions in `Framework/Tests.m`**, which test the
+containment predicate directly and are worth keeping. So all three move to `WSKPrivate.h`, which
+`Tests.m` already imports — off the public surface, still linkable by the suite.
+
+**Two documentation defects went with them.** The doc block describing
+`WSKResolvedPathRelativeToDirectory` was stranded above a *different* declaration (its own had none),
+which the inventory flagged as "a future editor fixes the wrong function to match the wrong comment".
+And `WSKPathIsInsideDirectory`'s `@warning` told callers to "pair it with
+WSKResolvedPathIsWithinDirectory() before acting on a path that came from a client" — the library's
+own documentation recommending the **two-observation pattern** that `WSKResolveWithinDirectory()`
+exists to replace, and that was measured serving content from outside the root in 24% of requests. It
+now points at the resolve-once function.
+
+**Verified together.** 142 tests and 0 failures on a clean build with no new warnings — including the
+eleven assertions that `static` would have broken — plus `swift build` clean (the sibling targets
+resolve headers through the symlink farm, so SPM is the check that matters for a header move), the
+trace corpus green, and iOS and tvOS Debug clean.
+
+**Groups B and C remain**, and C is the one carrying the target-visibility decision.
+
 ### The existence oracle closed at its real cause, and the fallback it lives in proved intact
 
 The oracle the fifteenth-pass inventory blamed on stat-before-resolve, and which reordering those

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -240,39 +240,15 @@ NSString *WSKNormalizePath(NSString *path);
  *  file operations from ever targeting the served root directory, e.g. when a
  *  client-supplied relative path collapses to the empty string.
  *
- *  @warning This is a purely textual comparison and does not resolve symlinks. Pair
- *  it with WSKResolvedPathIsWithinDirectory() before acting on a path that
- *  came from a client.
+ *  @warning This is a purely textual comparison and does not resolve symlinks, so it is NOT a
+ *  containment check on its own. For a path that came from a client, use
+ *  WSKResolveWithinDirectory() — it resolves once and reports containment from that single
+ *  observation, which is what the two-observation pattern this warning used to recommend got
+ *  wrong.
  */
 BOOL WSKPathIsInsideDirectory(NSString *path, NSString *directory);
 
-/**
- *  Returns YES if `path`, with all symlinks resolved, is `directory` itself or a
- *  location inside it. Resolves intermediate path components, and works for a path
- *  that does not exist yet (e.g. an upload destination) by resolving its parent.
- *
- *  Symlinks are invisible to the textual checks: WSKNormalizePath() strips
- *  ".." before any file is touched, and WSKPathIsInsideDirectory() compares
- *  path text, but lstat(), open() and NSFileManager all follow symlinks found in
- *  intermediate components. A symlink placed inside the served directory by some other
- *  means — another app, a restored backup, a synced volume — could therefore be
- *  traversed out of it. A symlink whose target stays inside the directory still
- *  resolves inside and remains usable.
- *
- *  Returns NO if either path cannot be resolved, so callers fail closed.
- */
-BOOL WSKResolvedPathIsWithinDirectory(NSString *path, NSString *directory);
 
-/**
- *  Returns `path` resolved and expressed relative to `directory` resolved, or nil if it does
- *  not resolve inside `directory` — which is exactly the condition
- *  WSKResolvedPathIsWithinDirectory() reports, so that function is now a wrapper around this
- *  one and the two cannot drift apart.
- *
- *  Relative to the *resolved* root, deliberately: the root itself may live under a hidden
- *  directory (NSTemporaryDirectory() under a sandboxed app commonly does), and a caller
- *  examining the absolute resolved path would then judge every file it serves to be hidden.
- */
 /**
  *  Resolves `path` ONCE and reports everything a caller needs from that single observation:
  *  returns the fully resolved absolute location if it is inside `directory` (or is `directory`
@@ -334,21 +310,7 @@ NSString *_Nullable WSKResolveNamedEntryWithinDirectory(NSString *path, NSString
  */
 NSString *_Nullable WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL allowHiddenItems, NSString *_Nullable __autoreleasing *_Nullable outResolvedName);
 
-NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory);
 
-/**
- *  Returns YES if `path`, once symlinks are resolved, lies under a component starting with "."
- *  relative to `directory`.
- *
- *  A textual test on the path a client sent cannot see this: a symlink named `pub` pointing at
- *  `.git` yields the request path "/pub/config", which carries no dot, while containment passes
- *  too because the target is inside the served root. Both servers' hidden-item rules were
- *  therefore satisfied by a path whose bytes live inside a dot-directory.
- *
- *  Returns NO for a path that does not resolve inside `directory` at all — that is containment's
- *  business, and reporting it as "hidden" here would mislabel an escape attempt.
- */
-BOOL WSKResolvedPathHasHiddenComponent(NSString *path, NSString *directory);
 
 /**
  *  Returns the strong entity tag this server issues for a file, derived from `stat(2)` fields.

--- a/Sources/WebServerKit/Core/WSKPrivate.h
+++ b/Sources/WebServerKit/Core/WSKPrivate.h
@@ -307,4 +307,46 @@ extern NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL include
 - (void)performClose;
 @end
 
+#pragma mark - Path resolution internals
+
+// These were declared in the PUBLIC WSKFunctions.h and are not used outside WSKFunctions.m — with
+// one exception: WSKResolvedPathIsWithinDirectory has eleven assertions in Framework/Tests.m, which
+// is why these move here rather than becoming static. Declaring an internal helper publicly binds
+// the library to a contract nobody asked for, and these three have security-shaped signatures that
+// invite a host app to build its own containment check out of them — the exact two-observation
+// pattern WSKResolveWithinDirectory() exists to replace.
+
+/**
+ *  Returns YES if `path`, with all symlinks resolved, is `directory` itself or a
+ *  location inside it. Resolves intermediate path components, and works for a path
+ *  that does not exist yet (e.g. an upload destination) by resolving its parent.
+ *
+ *  Symlinks are invisible to the textual checks: WSKNormalizePath() strips
+ *  ".." before any file is touched, and WSKPathIsInsideDirectory() compares
+ *  path text, but lstat(), open() and NSFileManager all follow symlinks found in
+ *  intermediate components. A symlink placed inside the served directory by some other
+ *  means — another app, a restored backup, a synced volume — could therefore be
+ *  traversed out of it. A symlink whose target stays inside the directory still
+ *  resolves inside and remains usable.
+ *
+ *  Returns NO if either path cannot be resolved, so callers fail closed.
+ */
+BOOL WSKResolvedPathIsWithinDirectory(NSString *path, NSString *directory);
+
+NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString *directory);
+
+/**
+ *  Returns YES if `path`, once symlinks are resolved, lies under a component starting with "."
+ *  relative to `directory`.
+ *
+ *  A textual test on the path a client sent cannot see this: a symlink named `pub` pointing at
+ *  `.git` yields the request path "/pub/config", which carries no dot, while containment passes
+ *  too because the target is inside the served root. Both servers' hidden-item rules were
+ *  therefore satisfied by a path whose bytes live inside a dot-directory.
+ *
+ *  Returns NO for a path that does not resolve inside `directory` at all — that is containment's
+ *  business, and reporting it as "hidden" here would mislabel an escape attempt.
+ */
+BOOL WSKResolvedPathHasHiddenComponent(NSString *path, NSString *directory);
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The public `WSKFunctions.h` had grown to **27 declarations**. The memory note carried the reason as *"ten are public solely because the SPM sibling targets cannot see `WSKPrivate.h`"* — measuring actual usage splits that three ways, which makes phase 3 tractable in pieces instead of as one breaking change:

| group | count | needs target-visibility change? |
|---|---|---|
| siblings genuinely use them | 11 | **yes** — still public, that's group C |
| core-only utilities | 7 | no — but some are plausibly legitimate public API |
| **used nowhere outside `WSKFunctions.m`** | **3** | **no — this PR** |

## ⚠️ A claim of mine was wrong, and it would have changed the fix

I first reported these three as having **"zero callers anywhere"**. That came from a grep that excluded `WSKFunctions.m` — where all three are in fact called (lines 805, 814, 1084, 1088). The honest statement is *"no caller **outside** that file"*: internal helpers exposed publicly, not dead code.

Delete was never the right answer. Relocating is.

## And `static` wasn't right either

Only a full-repo grep surfaces why: **`WSKResolvedPathIsWithinDirectory` has eleven assertions in `Framework/Tests.m`**, testing the containment predicate directly. Making it static would have broken the suite — and those assertions are worth keeping.

So all three move to `WSKPrivate.h`, which `Tests.m` already imports. Off the public surface, still linkable by the suite.

## Two documentation defects went with them

- The doc block describing `WSKResolvedPathRelativeToDirectory` was **stranded above a different declaration** (its own had none) — flagged in the inventory as "a future editor fixes the wrong function to match the wrong comment".
- `WSKPathIsInsideDirectory`'s `@warning` told callers to *"pair it with `WSKResolvedPathIsWithinDirectory()` before acting on a path that came from a client"* — **the library's own documentation recommending the two-observation pattern** that `WSKResolveWithinDirectory()` exists to replace, and which was measured serving content from outside the served root in 24% of requests. It now points at the resolve-once function.

## Verification

- **142 tests, 0 failures** on a clean build — including the eleven assertions `static` would have broken
- **0 new warnings**
- **`swift build` clean** — the sibling targets resolve headers through the symlink farm, so SPM is the check that actually matters for a header move
- Trace corpus green
- iOS and tvOS Debug: exit 0, 0 warnings

## Next

Group B (seven core-only utilities — judgement call on which are legitimate public API) and group C (eleven functions needing the target-visibility change, which is the breaking decision).