### PR TITLE
Moved the header-field and host-name rules off the public header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,32 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Cleanup phase 3, group B: the header-field and host-name rules go private
+
+Three more off the public surface — `WSKIsHeaderTokenCharacter`, `WSKIsHeaderTokenString` and
+`WSKHostNameWithoutRootLabel`. None has a caller outside the core target and none has a plausible
+host-app use: they exist because the request parser and the response serializer BOTH have to spell
+the same rule, which is why they were shared at all. Being shared between two files inside one
+target never required being public.
+
+The public `WSKFunctions.h` is now **21 declarations, down from 27**.
+
+**⚠️ One of the four approved for this batch was deliberately held back.** `WSKResolveWithinDirectory`
+was in the plan, and moving it would have left **three public doc comments naming a private symbol** —
+including the `@warning` on `WSKPathIsInsideDirectory` that the previous change had just rewritten to
+point at it as the resolve-once alternative. `WSKPathIsInsideDirectory` is used by both sibling
+targets, so it stays public until group C. Moving the resolver first would either strand those
+references or strip the only useful pointer out of a public warning, so it moves **with the rest of
+the resolver cluster** instead. Recorded because "do the approved thing" and "leave the docs
+coherent" genuinely conflicted here, and the smaller batch is the one that keeps both true.
+
+**Verified together.** 142 tests and 0 failures on a clean build with no new warnings, `swift build`
+clean, the trace corpus green, iOS and tvOS Debug clean.
+
+**Group C remains** — eleven functions the sibling targets genuinely use, which need the SPM target
+restructure so those targets can see `WSKPrivate.h`. That is the breaking change, and the last
+structural item.
+
 ### Cleanup phase 3, group A: three security-shaped functions leave the public header
 
 The public `WSKFunctions.h` had grown to **27 declarations**, and the memory note carried the reason

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -124,29 +124,8 @@ NSDate *_Nullable WSKParseISO8601(NSString *string);
  */
 BOOL WSKPathContainsNULByte(NSString *_Nullable path);
 
-/**
- *  Is this byte legal in an HTTP field-name or method? RFC 9112 §5: field-name = 1*tchar.
- *
- *  Shared so the request parser and the response header setter cannot drift. A second
- *  implementation of this rule beside the live one is the trap this codebase keeps falling into.
- */
-BOOL WSKIsHeaderTokenCharacter(unsigned char character);
 
-/**
- *  Does this string consist only of tchar, with at least one character? The whole field-name rule,
- *  in one place.
- */
-BOOL WSKIsHeaderTokenString(NSString *_Nullable string);
 
-/**
- *  Strips one trailing DNS root-label dot. "name.local." and "name.local" are the same host.
- *
- *  Shared because the two sides of the Host allow-list disagreed: the CHECK side stripped it from
- *  the incoming header while the CONFIG side did not strip it from a WSKOption_AllowedHostNames
- *  entry, so an entry written as a fully-qualified name — which is how DNS writes one — matched
- *  nothing at all and every request answered 421.
- */
-NSString *WSKHostNameWithoutRootLabel(NSString *host);
 
 /**
  *  Does a single name satisfy an extension allow-list? A nil list means "no restriction".

--- a/Sources/WebServerKit/Core/WSKPrivate.h
+++ b/Sources/WebServerKit/Core/WSKPrivate.h
@@ -349,4 +349,36 @@ NSString *_Nullable WSKResolvedPathRelativeToDirectory(NSString *path, NSString 
  */
 BOOL WSKResolvedPathHasHiddenComponent(NSString *path, NSString *directory);
 
+#pragma mark - Header-field and host-name internals
+
+// Also formerly public. No caller outside the core target and no plausible host-app use: these are
+// the rules the request parser and the response serializer BOTH have to spell the same way, which
+// is why they are shared at all. WSKResolveWithinDirectory stays public for now despite belonging
+// here, because three public doc comments name it as the resolve-once alternative — it moves with
+// the rest of the resolver cluster so those references never point at a private symbol.
+
+/**
+ *  Is this byte legal in an HTTP field-name or method? RFC 9112 §5: field-name = 1*tchar.
+ *
+ *  Shared so the request parser and the response header setter cannot drift. A second
+ *  implementation of this rule beside the live one is the trap this codebase keeps falling into.
+ */
+BOOL WSKIsHeaderTokenCharacter(unsigned char character);
+
+/**
+ *  Does this string consist only of tchar, with at least one character? The whole field-name rule,
+ *  in one place.
+ */
+BOOL WSKIsHeaderTokenString(NSString *_Nullable string);
+
+/**
+ *  Strips one trailing DNS root-label dot. "name.local." and "name.local" are the same host.
+ *
+ *  Shared because the two sides of the Host allow-list disagreed: the CHECK side stripped it from
+ *  the incoming header while the CONFIG side did not strip it from a WSKOption_AllowedHostNames
+ *  entry, so an entry written as a fully-qualified name — which is how DNS writes one — matched
+ *  nothing at all and every request answered 421.
+ */
+NSString *WSKHostNameWithoutRootLabel(NSString *host);
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Three more off the public surface: `WSKIsHeaderTokenCharacter`, `WSKIsHeaderTokenString`, `WSKHostNameWithoutRootLabel`.

None has a caller outside the core target, and none has a plausible host-app use. They exist because the request parser and the response serializer **both** have to spell the same rule — which is why they were shared at all. Being shared between two files inside one target never required being *public*.

**`WSKFunctions.h` is now 21 declarations, down from 27.**

## ⚠️ One of the four was deliberately held back

`WSKResolveWithinDirectory` was in the approved batch. Moving it would have left **three public doc comments naming a private symbol** — including the `@warning` on `WSKPathIsInsideDirectory` that #67 had *just* rewritten to point at it as the resolve-once alternative.

`WSKPathIsInsideDirectory` is used by both sibling targets, so it stays public until group C. Moving the resolver first would either strand those references or strip the only useful pointer out of a public warning — leaving a public function warned as "not a containment check" with no stated alternative.

So it moves **with the rest of the resolver cluster** in group C. Flagging it because "do the approved thing" and "leave the docs coherent" genuinely conflicted, and the smaller batch keeps both true.

## Verification

- **142 tests, 0 failures** on a clean build
- **0 new warnings**
- **`swift build` clean**
- Trace corpus green
- iOS and tvOS Debug: exit 0, 0 warnings

## Next

Group C — eleven functions the sibling targets genuinely use, needing the SPM target restructure so they can see `WSKPrivate.h`. That's the breaking change, and the last structural item.