### PR TITLE
Public function surface goes 27 → 7; both reasons it couldn't were stale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,50 @@ and the Bonjour/`.local` name only, so without it every request is refused with 
 
 ## Recent Changes
 
+### Cleanup phase 3, group C: the public surface goes 27 → 7, and both reasons it could not were stale
+
+The last structural item. Fourteen audit-shaped functions — the resolvers, the vetting walks, the
+allow-list predicates, the validators, same-file detection — leave the public `WSKFunctions.h` for
+`WSKPrivate.h`. **The public function surface is now 7 declarations, down from 27**, and what remains
+is exactly the general-purpose utilities: URL escaping, MIME type, primary IP, the HTTP date
+format/parse pair, form parsing, the NUL check, and the filesystem-error status mapping.
+
+These were public for one stated reason: the SPM sibling targets could not see `WSKPrivate.h`. The
+manifest gave two justifications for why that could not change. **Both were measured and neither
+reproduced.**
+
+| manifest claim | measured |
+|---|---|
+| `WSKPrivate.h` in the symlink farm makes the module unbuildable by a Swift consumer — "the umbrella would drag in the private header, which imports a dozen others it cannot find" | builds clean, 4.7 s forced rebuild |
+| a sibling reaching `Core/` by a second search path hits clang's "duplicate interface definition" | builds clean, 5.2 s, with a sibling importing `WSKPrivate.h` |
+
+Both may well have been true when written — `#if __has_include` arms and toolchains have moved. The
+point is that neither constrains the layout now, and the change collapsed from "restructure the
+package" to **one extra `headerSearchPath`**. No new header, no modulemap change, no pbxproj change.
+The symlink farm, hand-written modulemap and `SWIFT_PACKAGE` bundle accessor are all untouched.
+
+**⚠️ The oracle had to be built first, and proving it sensitive took two attempts.** `swift build`
+inside this package cannot catch a module that is unbuildable from *outside* it, because every header
+is reachable there — so the check is an **external SwiftPM consumer** that depends on the package by
+path and imports all three modules from Swift. The first sensitivity attempt was worthless twice
+over: a `cd` moved the cleanup out of the repo (leaving a stray symlink behind, caught by
+`git status`), and the build it measured completed in 0.15 s because it was cached. The real check —
+removing a symlink the consumer genuinely needs — produces
+`fatal error: 'WSKWebServer.h' file not found`, which is what makes the green results above worth
+anything.
+
+**Why this matters beyond tidiness.** Every one of the fourteen changed contract during the audit
+programme: `WSKServableFileTypeAtPath` gained two parameters, the resolvers were merged from four
+copies, the allow-list predicate learned a second name. Each of those was a silent source break for
+anyone who had bound to them, published as public API by accident of the build graph.
+
+**Verified together.** 142 tests and 0 failures on a clean build with no warnings, the external SPM
+consumer building and linking against all three modules, `swift build`, the trace corpus, and iOS and
+tvOS Debug all clean.
+
+**The structural cleanup is complete.** What remains is phase 2's low-value tail (the URI-to-path
+derivation, the limits and constants) and consolidating this file, which is past 2,000 lines.
+
 ### Cleanup phase 3, group B: the header-field and host-name rules go private
 
 Three more off the public surface — `WSKIsHeaderTokenCharacter`, `WSKIsHeaderTokenString` and

--- a/Package.swift
+++ b/Package.swift
@@ -18,12 +18,19 @@ let coreSources: [CSetting] = [
     .headerSearchPath("Responses")
 ]
 
-// The .m files in the sibling targets import core headers by bare filename, which SwiftPM
-// does not resolve for a dependency. This points at the symlink directory rather than at
-// Core/Requests/Responses on purpose: reaching the same header by two different paths makes
-// clang treat it as two files and fail with "duplicate interface definition".
+// The .m files in the sibling targets import core headers by bare filename, which SwiftPM does not
+// resolve for a dependency.
+//
+// Core/ is listed as well as the symlink directory so the siblings can reach WSKPrivate.h, which is
+// deliberately NOT in the farm. An older comment here warned that reaching the same header by two
+// paths makes clang treat it as two files and fail with "duplicate interface definition" — that was
+// MEASURED against this toolchain and did not reproduce, with a sibling importing WSKPrivate.h and
+// an external SwiftPM consumer building clean. It may well have been true when written. The check
+// that would catch a regression is an out-of-package consumer, because `swift build` inside this
+// package can reach every header regardless.
 let coreFromSibling: [CSetting] = [
-    .headerSearchPath("../WebServerKit/include/WebServerKit")
+    .headerSearchPath("../WebServerKit/include/WebServerKit"),
+    .headerSearchPath("../WebServerKit/Core")
 ]
 
 let package = Package(

--- a/Sources/WebServerKit/Core/WSKFunctions.h
+++ b/Sources/WebServerKit/Core/WSKFunctions.h
@@ -127,76 +127,11 @@ BOOL WSKPathContainsNULByte(NSString *_Nullable path);
 
 
 
-/**
- *  Does a single name satisfy an extension allow-list? A nil list means "no restriction".
- *
- *  The rule itself, in one place: both servers' -_checkFileExtension: delegate here.
- */
-BOOL WSKNamePassesExtensionAllowList(NSString *name, NSArray<NSString *> *_Nullable allowedExtensions);
 
-/**
- *  Does an ENTRY satisfy the allow-list, judged by BOTH names it presents?
- *
- *  A symlink has two: the name the client used, and the name the bytes actually live under. Those
- *  were judged inconsistently — listings vetted the alias, access vetted the resolved target — so
- *  with a list of ["txt"], "alias.txt -> real.bin" was advertised and then refused 403, while
- *  "alias.bin -> real.txt" was hidden and then served 200.
- *
- *  BOTH must pass. That is the fail-closed reading and the owner's decision: judging the alias
- *  alone would make "alias.txt -> id_rsa" servable, which turns the allow-list into decoration for
- *  reads; judging the target alone contradicts the "symlinks are aliases" semantics a destructive
- *  verb already follows. Pass nil for resolvedName when there is no second name (a regular file, or
- *  a caller with only one to offer), which is exactly the single-name rule.
- */
-BOOL WSKEntryPassesExtensionAllowList(NSString *namedName, NSString *_Nullable resolvedName, NSArray<NSString *> *_Nullable allowedExtensions);
 
-/**
- *  Resolves a client-supplied relative path to an absolute one inside `directory`, FOLLOWING a
- *  final symlink, or nil if it may not be acted on.
- *
- *  Refuses a NUL-bearing path, and refuses a path that resolves to the share root itself unless the
- *  client named the root directly. `outHidden` reports whether the path is hidden by either the
- *  spelling the client used or the one it resolved to; it is only computed when
- *  `allowHiddenItems` is NO.
- *
- *  Both refusals live HERE, at the one point every path-taking verb passes through, so a verb added
- *  later cannot forget them.
- */
-NSString *_Nullable WSKResolvedPathForRelativePath(NSString *relativePath, NSString *directory, BOOL allowHiddenItems, BOOL *_Nullable outHidden);
 
-/**
- *  As above, but resolves the PARENT and appends the raw leaf, so a final symlink is preserved
- *  rather than followed — the entry the client named, which is what a destructive verb acts on.
- *  Naming the root itself is refused: there is no final component to preserve.
- */
-NSString *_Nullable WSKNamedEntryPathForRelativePath(NSString *relativePath, NSString *directory, BOOL allowHiddenItems, BOOL *_Nullable outHidden);
 
-/**
- *  The first subtree member a destructive verb must NOT be allowed to destroy, or nil if the whole
- *  tree is safe to remove.
- *
- *  A recursive DELETE, or an overwrite, must refuse anything a DIRECT request would refuse — or the
- *  same request means two different things depending on how it is spelled. That class has recurred
- *  FOUR times in this project (eighth, tenth, thirteenth and fifteenth passes), most recently
- *  measured at 60/60 destroyed, so the walk lives in one place now rather than once per server.
- *
- *  Two judgement calls are baked in, both load-bearing. Dot-names and their descendants are skipped
- *  whatever `allowHiddenItems` says: a ".DS_Store" sits in every macOS folder and its empty
- *  pathExtension is in no allow-list, so vetting them would make ordinary directories permanently
- *  undeletable. And an extensionless file IS vetted, because a direct DELETE of it is already
- *  refused.
- */
-NSString *_Nullable WSKFirstUnvettableItemAtPath(NSString *absolutePath, BOOL isDirectory, NSArray<NSString *> *_Nullable allowedExtensions);
 
-/**
- *  Do two paths name the same file on disk?
- *
- *  Compares file resource identifiers (inode + volume), so it also catches the case-variant pair
- *  "File.txt"/"file.txt" that is ONE file on a case-insensitive volume. That is the whole of the
- *  protection against a self-move: an unconditional "remove the destination, then move" with
- *  `Overwrite: T` deleted the only copy of the file when the two paths resolved to it.
- */
-BOOL WSKPathsNameTheSameFile(NSString *path1, NSString *path2);
 
 /**
  *  Maps a filesystem NSError onto the server-error status that describes it honestly.
@@ -208,153 +143,16 @@ BOOL WSKPathsNameTheSameFile(NSString *path1, NSString *path2);
  */
 WSKServerErrorHTTPStatusCode WSKServerErrorStatusCodeForError(NSError *_Nullable error);
 
-/**
- *  Removes "//", "/./" and "/../" components from path as well as any trailing slash.
- */
-NSString *WSKNormalizePath(NSString *path);
-
-/**
- *  Returns YES only if `path` resolves to a location strictly inside `directory`
- *  (i.e. neither the directory itself nor outside it). Used to keep destructive
- *  file operations from ever targeting the served root directory, e.g. when a
- *  client-supplied relative path collapses to the empty string.
- *
- *  @warning This is a purely textual comparison and does not resolve symlinks, so it is NOT a
- *  containment check on its own. For a path that came from a client, use
- *  WSKResolveWithinDirectory() — it resolves once and reports containment from that single
- *  observation, which is what the two-observation pattern this warning used to recommend got
- *  wrong.
- */
-BOOL WSKPathIsInsideDirectory(NSString *path, NSString *directory);
-
-
-/**
- *  Resolves `path` ONCE and reports everything a caller needs from that single observation:
- *  returns the fully resolved absolute location if it is inside `directory` (or is `directory`
- *  itself), nil otherwise, and writes the same location expressed relative to the resolved
- *  `directory` into `outRelativePath` when that is non-NULL.
- *
- *  Prefer this to calling the two predicates below in sequence. Each of those performs its own
- *  realpath(3), so a caller that checks containment with one and hiddenness with the other is
- *  acting on two observations of a filesystem that need not agree — and then usually operates on
- *  a *third*, the unresolved path the client sent. A symlink retargeted between those steps was
- *  measured serving content from outside the served root in 24% of requests.
- *
- *  Act on the returned path, not on the caller's own: a resolved path contains no symlinks, so
- *  retargeting one cannot redirect the operation that follows. This narrows the window rather
- *  than closing it — a real directory renamed between resolution and use would still slip
- *  through, and closing that needs an openat(2) component walk or O_NOFOLLOW_ANY, which would
- *  also refuse the benign intermediate symlinks that work today.
- */
-NSString *_Nullable WSKResolveWithinDirectory(NSString *path, NSString *directory, NSString *_Nullable __autoreleasing *_Nullable outRelativePath);
-
-/**
- *  Like WSKResolveWithinDirectory(), but returns the entry the client NAMED rather than what that
- *  entry points at: the parent is resolved, and the final component is appended raw.
- *
- *  Read paths want the target — `GET /latest/app.ipa` should follow the link, and does. Verbs that
- *  REMOVE or RELOCATE an entry want the entry, because that is what `rm`, `mv` and `cp -P` do and
- *  what a user means: `DELETE /latest` used to remove the multi-hundred-megabyte build directory
- *  the link pointed at and leave the dangling link behind, answering 204. No shell tool behaves
- *  that way, and the residue was then invisible to every listing and removable by nothing.
- *
- *  The PARENT is resolved, and the containment and hidden-item verdicts are both derived from that
- *  one observation, exactly as WSKResolveWithinDirectory() does for the full path. That matters:
- *  resolving once for the verdict and again for the path to act on is the two-observations shape
- *  the eighth pass closed and this file names as the form that will recur. It also keeps the
- *  eighth pass's protection intact — `PUT /link/x` where `link` retargets outside is still refused,
- *  because the escape is in the parent and the parent is still resolved.
- *
- *  Unlinking or renaming a symlink never touches its target, so a link pointing outside the share
- *  is safe to remove: the entry itself lives inside. Returns nil when the parent does not resolve
- *  inside `directory`, or when `path` names the directory itself (which has no final component to
- *  keep, and which every destructive verb must refuse anyway).
- */
-NSString *_Nullable WSKResolveNamedEntryWithinDirectory(NSString *path, NSString *directory, NSString *_Nullable __autoreleasing *_Nullable outRelativePath);
-
-/**
- *  The NSFileType an enumeration should CLASSIFY `path` as, which for a symlink is the type of what
- *  it points at — or nil when nothing servable is there.
- *
- *  `-attributesOfItemAtPath:` does not follow links, so a symlink is neither NSFileTypeRegular nor
- *  NSFileTypeDirectory and fell out of all three listings while the same servers happily served
- *  through it. That disagreement is the one this project has now fixed twice in the opposite
- *  direction, and through a real mounted client it is data loss rather than cosmetics: `mv` returns
- *  0 having copied only what the listing reported, then deletes the source, so the entries it never
- *  saw are gone.
- *
- *  A link is only classified when its target resolves INSIDE `directory` — otherwise it would be
- *  advertised and then refused on access, which is the same disagreement with the sign flipped. A
- *  dangling link resolves to nothing and is likewise not classified.
- */
-NSString *_Nullable WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL allowHiddenItems, NSString *_Nullable __autoreleasing *_Nullable outResolvedName);
 
 
 
-/**
- *  Returns the strong entity tag this server issues for a file, derived from `stat(2)` fields.
- *
- *  There is exactly one of these because a validator only works if every path agrees on it: the
- *  tag a client is handed by a GET is the tag it presents back in `If-Match`, so a second
- *  implementation that formatted the same fields differently would make every precondition fail
- *  and every revalidation miss.
- *
- *  Size is part of the tag deliberately — inode and mtime alone do not identify the bytes, since
- *  a rewrite in place that restores the timestamp keeps both. See `WSKFileResponse` for the
- *  measurement behind that.
- */
-NSString *WSKEntityTagForFileInfo(const struct stat *info);
 
-/**
- *  Returns YES if the modification time in `info` may be ISSUED as a `Last-Modified` validator for
- *  the file open on `descriptor`.
- *
- *  A date validator is only strong once the instant it names can no longer be written again. While
- *  mtime still falls inside the filesystem's current timestamp bucket the file can be rewritten
- *  without the timestamp moving, so two representations would go out under one date and nothing
- *  downstream could separate them. The rule therefore has to be applied where the validator is
- *  MINTED, never where a resume redeems it — by redemption time the bucket has always closed, so
- *  the test would report "strong" for precisely the representation that is not.
- *
- *  The bucket is not always one second. APFS records nanoseconds, HFS+ and exFAT a second or
- *  better, but **FAT/msdos stores mtime in TWO-second units and truncates downward**, so on a USB
- *  stick or SD card a timestamp one second old can still take another write. `descriptor` is asked
- *  what it is actually sitting on; anything unrecognised — including `smbfs` and `nfs`, which may
- *  be backed by FAT — is assumed coarse, because failing closed here costs a date-only client one
- *  second of caching and failing open splices two builds together.
- *
- *  Both surfaces that hand out a modification date share this, so they cannot drift: withholding
- *  it in one while the other publishes it is how a client obtained an unsealed date from PROPFIND
- *  after the GET path had been fixed to refuse to issue one.
- */
-BOOL WSKLastModifiedDateIsSealed(int descriptor, const struct stat *info);
 
-/**
- *  Returns the first item at or under `absolutePath` that could not be removed, expressed relative
- *  to `absolutePath` (or `absolutePath`'s own last component if it is the blocker), or nil when the
- *  whole tree can go.
- *
- *  `-[NSFileManager removeItemAtPath:]` walks a tree deleting as it goes and stops at the first
- *  member it cannot unlink — leaving everything it already removed removed, and reporting only a
- *  failure. So a collection holding one locked file (`chflags uchg`, which is exactly what Finder's
- *  "Locked" checkbox sets) or one unwritable subdirectory answered 500, or 403 through an overwrite,
- *  with most of its contents destroyed. Measured: 21 files in, 9 left, status 500, and on the
- *  MOVE/COPY surface the source was left in place too — a failed operation AND a gutted destination.
- *
- *  Asking first turns that into an untouched tree and a refusal that names the offending item, which
- *  is what this library's "refuse clearly rather than half-succeed" priority requires. RFC 4918
- *  §9.6.1's 207 Multi-Status is the conformant alternative and is strictly worse here: it reports
- *  the damage rather than preventing it.
- *
- *  This cannot be folded into the extension-allow-list walk, tempting as that is: that walk returns
- *  immediately when no allow-list is configured, which is the default and where all of this is
- *  reachable. Removability has to be checked unconditionally.
- *
- *  Inherently advisory: flags and modes can change between this walk and the removal. Nothing in
- *  this library changes either, so that window needs a local process, and closing it would need a
- *  transactional filesystem.
- */
-NSString *_Nullable WSKFirstUnremovableItemAtPath(NSString *absolutePath);
+
+
+
+
+
 
 #ifdef __cplusplus
 }

--- a/Sources/WebServerKit/Core/WSKPrivate.h
+++ b/Sources/WebServerKit/Core/WSKPrivate.h
@@ -381,4 +381,233 @@ BOOL WSKIsHeaderTokenString(NSString *_Nullable string);
  */
 NSString *WSKHostNameWithoutRootLabel(NSString *host);
 
+#pragma mark - Path, validator and vetting internals
+
+// The audit-shaped half of what used to be WSKFunctions.h. These carry contracts that changed
+// repeatedly through the audit programme — WSKServableFileTypeAtPath gained two parameters, the
+// resolvers were merged from four copies, the allow-list predicate learned a second name — and
+// every one of those was a source break for anyone who had bound to them. They were only public
+// because the sibling targets could not see this header; they can now.
+//
+// Both reasons the manifest gave for that not being possible were MEASURED and did not reproduce:
+// a Swift consumer builds with WSKPrivate.h in the symlink farm, and a sibling reaching Core/ by a
+// second search path does not hit "duplicate interface definition". Both may have been true when
+// written; neither constrains the layout now.
+
+/**
+ *  Does a single name satisfy an extension allow-list? A nil list means "no restriction".
+ *
+ *  The rule itself, in one place: both servers' -_checkFileExtension: delegate here.
+ */
+BOOL WSKNamePassesExtensionAllowList(NSString *name, NSArray<NSString *> *_Nullable allowedExtensions);
+
+/**
+ *  Does an ENTRY satisfy the allow-list, judged by BOTH names it presents?
+ *
+ *  A symlink has two: the name the client used, and the name the bytes actually live under. Those
+ *  were judged inconsistently — listings vetted the alias, access vetted the resolved target — so
+ *  with a list of ["txt"], "alias.txt -> real.bin" was advertised and then refused 403, while
+ *  "alias.bin -> real.txt" was hidden and then served 200.
+ *
+ *  BOTH must pass. That is the fail-closed reading and the owner's decision: judging the alias
+ *  alone would make "alias.txt -> id_rsa" servable, which turns the allow-list into decoration for
+ *  reads; judging the target alone contradicts the "symlinks are aliases" semantics a destructive
+ *  verb already follows. Pass nil for resolvedName when there is no second name (a regular file, or
+ *  a caller with only one to offer), which is exactly the single-name rule.
+ */
+BOOL WSKEntryPassesExtensionAllowList(NSString *namedName, NSString *_Nullable resolvedName, NSArray<NSString *> *_Nullable allowedExtensions);
+
+/**
+ *  Resolves a client-supplied relative path to an absolute one inside `directory`, FOLLOWING a
+ *  final symlink, or nil if it may not be acted on.
+ *
+ *  Refuses a NUL-bearing path, and refuses a path that resolves to the share root itself unless the
+ *  client named the root directly. `outHidden` reports whether the path is hidden by either the
+ *  spelling the client used or the one it resolved to; it is only computed when
+ *  `allowHiddenItems` is NO.
+ *
+ *  Both refusals live HERE, at the one point every path-taking verb passes through, so a verb added
+ *  later cannot forget them.
+ */
+NSString *_Nullable WSKResolvedPathForRelativePath(NSString *relativePath, NSString *directory, BOOL allowHiddenItems, BOOL *_Nullable outHidden);
+
+/**
+ *  As above, but resolves the PARENT and appends the raw leaf, so a final symlink is preserved
+ *  rather than followed — the entry the client named, which is what a destructive verb acts on.
+ *  Naming the root itself is refused: there is no final component to preserve.
+ */
+NSString *_Nullable WSKNamedEntryPathForRelativePath(NSString *relativePath, NSString *directory, BOOL allowHiddenItems, BOOL *_Nullable outHidden);
+
+/**
+ *  The first subtree member a destructive verb must NOT be allowed to destroy, or nil if the whole
+ *  tree is safe to remove.
+ *
+ *  A recursive DELETE, or an overwrite, must refuse anything a DIRECT request would refuse — or the
+ *  same request means two different things depending on how it is spelled. That class has recurred
+ *  FOUR times in this project (eighth, tenth, thirteenth and fifteenth passes), most recently
+ *  measured at 60/60 destroyed, so the walk lives in one place now rather than once per server.
+ *
+ *  Two judgement calls are baked in, both load-bearing. Dot-names and their descendants are skipped
+ *  whatever `allowHiddenItems` says: a ".DS_Store" sits in every macOS folder and its empty
+ *  pathExtension is in no allow-list, so vetting them would make ordinary directories permanently
+ *  undeletable. And an extensionless file IS vetted, because a direct DELETE of it is already
+ *  refused.
+ */
+NSString *_Nullable WSKFirstUnvettableItemAtPath(NSString *absolutePath, BOOL isDirectory, NSArray<NSString *> *_Nullable allowedExtensions);
+
+/**
+ *  Do two paths name the same file on disk?
+ *
+ *  Compares file resource identifiers (inode + volume), so it also catches the case-variant pair
+ *  "File.txt"/"file.txt" that is ONE file on a case-insensitive volume. That is the whole of the
+ *  protection against a self-move: an unconditional "remove the destination, then move" with
+ *  `Overwrite: T` deleted the only copy of the file when the two paths resolved to it.
+ */
+BOOL WSKPathsNameTheSameFile(NSString *path1, NSString *path2);
+
+/**
+ *  Removes "//", "/./" and "/../" components from path as well as any trailing slash.
+ */
+NSString *WSKNormalizePath(NSString *path);
+
+/**
+ *  Returns YES only if `path` resolves to a location strictly inside `directory`
+ *  (i.e. neither the directory itself nor outside it). Used to keep destructive
+ *  file operations from ever targeting the served root directory, e.g. when a
+ *  client-supplied relative path collapses to the empty string.
+ *
+ *  @warning This is a purely textual comparison and does not resolve symlinks, so it is NOT a
+ *  containment check on its own. For a path that came from a client, use
+ *  WSKResolveWithinDirectory() — it resolves once and reports containment from that single
+ *  observation, which is what the two-observation pattern this warning used to recommend got
+ *  wrong.
+ */
+BOOL WSKPathIsInsideDirectory(NSString *path, NSString *directory);
+
+/**
+ *  Resolves `path` ONCE and reports everything a caller needs from that single observation:
+ *  returns the fully resolved absolute location if it is inside `directory` (or is `directory`
+ *  itself), nil otherwise, and writes the same location expressed relative to the resolved
+ *  `directory` into `outRelativePath` when that is non-NULL.
+ *
+ *  Prefer this to calling the two predicates below in sequence. Each of those performs its own
+ *  realpath(3), so a caller that checks containment with one and hiddenness with the other is
+ *  acting on two observations of a filesystem that need not agree — and then usually operates on
+ *  a *third*, the unresolved path the client sent. A symlink retargeted between those steps was
+ *  measured serving content from outside the served root in 24% of requests.
+ *
+ *  Act on the returned path, not on the caller's own: a resolved path contains no symlinks, so
+ *  retargeting one cannot redirect the operation that follows. This narrows the window rather
+ *  than closing it — a real directory renamed between resolution and use would still slip
+ *  through, and closing that needs an openat(2) component walk or O_NOFOLLOW_ANY, which would
+ *  also refuse the benign intermediate symlinks that work today.
+ */
+NSString *_Nullable WSKResolveWithinDirectory(NSString *path, NSString *directory, NSString *_Nullable __autoreleasing *_Nullable outRelativePath);
+
+/**
+ *  Like WSKResolveWithinDirectory(), but returns the entry the client NAMED rather than what that
+ *  entry points at: the parent is resolved, and the final component is appended raw.
+ *
+ *  Read paths want the target — `GET /latest/app.ipa` should follow the link, and does. Verbs that
+ *  REMOVE or RELOCATE an entry want the entry, because that is what `rm`, `mv` and `cp -P` do and
+ *  what a user means: `DELETE /latest` used to remove the multi-hundred-megabyte build directory
+ *  the link pointed at and leave the dangling link behind, answering 204. No shell tool behaves
+ *  that way, and the residue was then invisible to every listing and removable by nothing.
+ *
+ *  The PARENT is resolved, and the containment and hidden-item verdicts are both derived from that
+ *  one observation, exactly as WSKResolveWithinDirectory() does for the full path. That matters:
+ *  resolving once for the verdict and again for the path to act on is the two-observations shape
+ *  the eighth pass closed and this file names as the form that will recur. It also keeps the
+ *  eighth pass's protection intact — `PUT /link/x` where `link` retargets outside is still refused,
+ *  because the escape is in the parent and the parent is still resolved.
+ *
+ *  Unlinking or renaming a symlink never touches its target, so a link pointing outside the share
+ *  is safe to remove: the entry itself lives inside. Returns nil when the parent does not resolve
+ *  inside `directory`, or when `path` names the directory itself (which has no final component to
+ *  keep, and which every destructive verb must refuse anyway).
+ */
+NSString *_Nullable WSKResolveNamedEntryWithinDirectory(NSString *path, NSString *directory, NSString *_Nullable __autoreleasing *_Nullable outRelativePath);
+
+/**
+ *  The NSFileType an enumeration should CLASSIFY `path` as, which for a symlink is the type of what
+ *  it points at — or nil when nothing servable is there.
+ *
+ *  `-attributesOfItemAtPath:` does not follow links, so a symlink is neither NSFileTypeRegular nor
+ *  NSFileTypeDirectory and fell out of all three listings while the same servers happily served
+ *  through it. That disagreement is the one this project has now fixed twice in the opposite
+ *  direction, and through a real mounted client it is data loss rather than cosmetics: `mv` returns
+ *  0 having copied only what the listing reported, then deletes the source, so the entries it never
+ *  saw are gone.
+ *
+ *  A link is only classified when its target resolves INSIDE `directory` — otherwise it would be
+ *  advertised and then refused on access, which is the same disagreement with the sign flipped. A
+ *  dangling link resolves to nothing and is likewise not classified.
+ */
+NSString *_Nullable WSKServableFileTypeAtPath(NSString *path, NSString *directory, BOOL allowHiddenItems, NSString *_Nullable __autoreleasing *_Nullable outResolvedName);
+
+/**
+ *  Returns the strong entity tag this server issues for a file, derived from `stat(2)` fields.
+ *
+ *  There is exactly one of these because a validator only works if every path agrees on it: the
+ *  tag a client is handed by a GET is the tag it presents back in `If-Match`, so a second
+ *  implementation that formatted the same fields differently would make every precondition fail
+ *  and every revalidation miss.
+ *
+ *  Size is part of the tag deliberately — inode and mtime alone do not identify the bytes, since
+ *  a rewrite in place that restores the timestamp keeps both. See `WSKFileResponse` for the
+ *  measurement behind that.
+ */
+NSString *WSKEntityTagForFileInfo(const struct stat *info);
+
+/**
+ *  Returns YES if the modification time in `info` may be ISSUED as a `Last-Modified` validator for
+ *  the file open on `descriptor`.
+ *
+ *  A date validator is only strong once the instant it names can no longer be written again. While
+ *  mtime still falls inside the filesystem's current timestamp bucket the file can be rewritten
+ *  without the timestamp moving, so two representations would go out under one date and nothing
+ *  downstream could separate them. The rule therefore has to be applied where the validator is
+ *  MINTED, never where a resume redeems it — by redemption time the bucket has always closed, so
+ *  the test would report "strong" for precisely the representation that is not.
+ *
+ *  The bucket is not always one second. APFS records nanoseconds, HFS+ and exFAT a second or
+ *  better, but **FAT/msdos stores mtime in TWO-second units and truncates downward**, so on a USB
+ *  stick or SD card a timestamp one second old can still take another write. `descriptor` is asked
+ *  what it is actually sitting on; anything unrecognised — including `smbfs` and `nfs`, which may
+ *  be backed by FAT — is assumed coarse, because failing closed here costs a date-only client one
+ *  second of caching and failing open splices two builds together.
+ *
+ *  Both surfaces that hand out a modification date share this, so they cannot drift: withholding
+ *  it in one while the other publishes it is how a client obtained an unsealed date from PROPFIND
+ *  after the GET path had been fixed to refuse to issue one.
+ */
+BOOL WSKLastModifiedDateIsSealed(int descriptor, const struct stat *info);
+
+/**
+ *  Returns the first item at or under `absolutePath` that could not be removed, expressed relative
+ *  to `absolutePath` (or `absolutePath`'s own last component if it is the blocker), or nil when the
+ *  whole tree can go.
+ *
+ *  `-[NSFileManager removeItemAtPath:]` walks a tree deleting as it goes and stops at the first
+ *  member it cannot unlink — leaving everything it already removed removed, and reporting only a
+ *  failure. So a collection holding one locked file (`chflags uchg`, which is exactly what Finder's
+ *  "Locked" checkbox sets) or one unwritable subdirectory answered 500, or 403 through an overwrite,
+ *  with most of its contents destroyed. Measured: 21 files in, 9 left, status 500, and on the
+ *  MOVE/COPY surface the source was left in place too — a failed operation AND a gutted destination.
+ *
+ *  Asking first turns that into an untouched tree and a refusal that names the offending item, which
+ *  is what this library's "refuse clearly rather than half-succeed" priority requires. RFC 4918
+ *  §9.6.1's 207 Multi-Status is the conformant alternative and is strictly worse here: it reports
+ *  the damage rather than preventing it.
+ *
+ *  This cannot be folded into the extension-allow-list walk, tempting as that is: that walk returns
+ *  immediately when no allow-list is configured, which is the default and where all of this is
+ *  reachable. Removability has to be checked unconditionally.
+ *
+ *  Inherently advisory: flags and modes can change between this walk and the removal. Nothing in
+ *  this library changes either, so that window needs a local process, and closing it would need a
+ *  transactional filesystem.
+ */
+NSString *_Nullable WSKFirstUnremovableItemAtPath(NSString *absolutePath);
+
 NS_ASSUME_NONNULL_END

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -32,6 +32,7 @@
 // WebDAV specifications: http://webdav.org/specs/rfc4918.html
 
 // Requires "HEADER_SEARCH_PATHS = $(SDKROOT)/usr/include/libxml2" in Xcode build settings
+#import "WSKPrivate.h"
 #import "WSKWebDAVServer.h"
 
 #import <sys/xattr.h>

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -49,6 +49,7 @@ FOUNDATION_EXPORT NSBundle *WebServerKitUploader_SWIFTPM_MODULE_BUNDLE(void);
 #import "WSKMultiPartFormRequest.h"
 #import "WSKStreamedResponse.h"
 #import "WSKURLEncodedFormRequest.h"
+#import "WSKPrivate.h"
 #import "WSKWebUploader.h"
 #import "WSKWebUploaderSSEChannel.h"
 


### PR DESCRIPTION
The last structural item. Fourteen audit-shaped functions — the resolvers, the vetting walks, the allow-list predicates, the validators, same-file detection — move from the public `WSKFunctions.h` to `WSKPrivate.h`.

**Public function surface: 27 → 7.** What remains is exactly the general-purpose utilities: URL escaping, MIME type, primary IP, the HTTP date format/parse pair, form parsing, the NUL check, and the filesystem-error status mapping.

## Both reasons this "couldn't" be done were stale

These were public for one stated reason: the SPM sibling targets couldn't see `WSKPrivate.h`. The manifest gave two justifications for why that couldn't change. **Neither reproduced.**

| manifest claim | measured |
|---|---|
| `WSKPrivate.h` in the symlink farm makes the module unbuildable by a Swift consumer — *"the umbrella would drag in the private header, which imports a dozen others it cannot find"* | **builds clean**, 4.7 s forced rebuild |
| a sibling reaching `Core/` by a second search path hits clang's *"duplicate interface definition"* | **builds clean**, 5.2 s, with a sibling importing `WSKPrivate.h` |

Both may well have been true when written — `#if __has_include` arms and toolchains move. The point is neither constrains the layout now, and the change collapsed from "restructure the package" to **one extra `headerSearchPath`**.

No new header, no modulemap change, no pbxproj change. The symlink farm, hand-written modulemap and `SWIFT_PACKAGE` bundle accessor are untouched.

## ⚠️ The oracle came first, and proving it sensitive took two attempts

`swift build` **inside** this package cannot catch a module that's unbuildable from *outside* it — every header is reachable there. So the check is an **external SwiftPM consumer** that depends on the package by path and imports all three modules from Swift.

The first sensitivity attempt was worthless twice over: a `cd` moved the cleanup out of the repo (leaving a stray symlink, caught by `git status`), and the build it measured completed in 0.15 s because it was cached. The real check — removing a symlink the consumer genuinely needs — gives:

```
fatal error: 'WSKWebServer.h' file not found
```

That's what makes the green results below worth anything.

## Why this matters beyond tidiness

Every one of the fourteen **changed contract during the audit programme**: `WSKServableFileTypeAtPath` gained two parameters, the resolvers were merged from four copies, the allow-list predicate learned a second name. Each was a silent source break for anyone who had bound to them — published as public API by accident of the build graph, not by intent.

## Verification

- **142 tests, 0 failures** on a clean build
- **0 warnings**
- **External SPM consumer** builds and links against all three modules
- `swift build`, trace corpus, iOS and tvOS Debug: all clean

## The structural cleanup is complete

What remains is phase 2's low-value tail (URI-to-path derivation, limits and constants) and consolidating `CLAUDE.md`, now past 2,000 lines.