### PR TITLE
Uploader media serving: inline previews, Range on /download, opt-in caching

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -2913,6 +2913,156 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// The uploader's /download built its response with +responseWithFile:isAttachment:, which passes
+// NSMakeRange(NSUIntegerMax, 0) — no range at all — so a "Range" header was ignored and the whole
+// file came back 200. The base-path handler and DAV's GET have both passed request.byteRange and
+// request.ifRange for several passes; this endpoint never did. For Shape A that means an
+// interrupted download of a multi-hundred-megabyte build cannot resume, and it is also why a
+// <video> cannot seek. Going through the ifRange: variant is what brings the If-Range protection
+// with it, so a resume against a REPLACED file is refused rather than spliced.
+- (void)testUploaderDownloadHonoursRangeRequests {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    XCTAssertTrue([@"0123456789" writeToFile:[dir stringByAppendingPathComponent:@"a.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* partial = SendRawRequest(server.port, @"GET /download?path=%2Fa.txt HTTP/1.1\r\nHost: localhost\r\nRange: bytes=2-5\r\n\r\n");
+    XCTAssertTrue([partial hasPrefix:@"HTTP/1.1 206"], @"a Range request must be answered with 206: %@", [partial substringToIndex:MIN((NSUInteger)40, partial.length)]);
+    XCTAssertTrue([partial containsString:@"Content-Range: bytes 2-5/10"], @"the 206 must describe which bytes it carries: %@", partial);
+    XCTAssertTrue([partial hasSuffix:@"2345"], @"the 206 must carry exactly the requested bytes: %@", partial);
+
+    // An open-ended range is how a resume is actually spelled.
+    NSString* resume = SendRawRequest(server.port, @"GET /download?path=%2Fa.txt HTTP/1.1\r\nHost: localhost\r\nRange: bytes=7-\r\n\r\n");
+    XCTAssertTrue([resume hasPrefix:@"HTTP/1.1 206"], @"an open-ended resume must be 206: %@", [resume substringToIndex:MIN((NSUInteger)40, resume.length)]);
+    XCTAssertTrue([resume hasSuffix:@"789"], @"the resume must carry the tail: %@", resume);
+
+    // Unsatisfiable is 416 with the total, not a silent whole-file 200.
+    NSString* beyond = SendRawRequest(server.port, @"GET /download?path=%2Fa.txt HTTP/1.1\r\nHost: localhost\r\nRange: bytes=999-\r\n\r\n");
+    XCTAssertTrue([beyond hasPrefix:@"HTTP/1.1 416"], @"an unsatisfiable range is 416: %@", [beyond substringToIndex:MIN((NSUInteger)40, beyond.length)]);
+
+    // And what must keep working: no Range header still serves the whole file as an attachment.
+    NSString* whole = SendRawRequest(server.port, @"GET /download?path=%2Fa.txt HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([whole hasPrefix:@"HTTP/1.1 200"], @"an ordinary download is unchanged: %@", [whole substringToIndex:MIN((NSUInteger)40, whole.length)]);
+    XCTAssertTrue([whole containsString:@"attachment"], @"an ordinary download is still an attachment");
+    XCTAssertTrue([whole hasSuffix:@"0123456789"], @"an ordinary download still carries the whole file");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// Rendering a shared file INLINE puts it in the server's own origin, and this UI's one-click
+// buttons delete and move files — so an uploaded .html or .svg served inline is stored XSS against
+// the share itself. That is the whole reason /download forces "attachment", and it is also why a
+// media-rich UI cannot simply drop the flag: <img src="/download?..."> triggers a save dialog
+// rather than rendering.
+//
+// /preview is the narrow, inert-only alternative: an allow-list of types a browser cannot execute,
+// plus nosniff so a .png full of markup cannot be sniffed into active content, plus a CSP that
+// denies everything even if a type ever slips through. SVG is deliberately excluded despite being
+// an image — it carries script, and it is the exact trap an "images are safe" allow-list springs.
+- (void)testUploaderPreviewServesInertMediaInlineAndRefusesActiveContent {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    // Deliberately ASCII rather than real PNG bytes: the type is derived from the EXTENSION, so
+    // the content is irrelevant to what is being tested, and binary would make the reply
+    // undecodable as a string and every assertion below read "(null)".
+    XCTAssertTrue([@"PIXELS" writeToFile:[dir stringByAppendingPathComponent:@"pic.png"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"<script>alert(1)</script>" writeToFile:[dir stringByAppendingPathComponent:@"evil.html"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script></svg>" writeToFile:[dir stringByAppendingPathComponent:@"evil.svg"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([fm createDirectoryAtPath:[dir stringByAppendingPathComponent:@".hidden"] withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"SECRET" writeToFile:[dir stringByAppendingPathComponent:@".hidden/secret.png"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* image = SendRawRequest(server.port, @"GET /preview?path=%2Fpic.png HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([image hasPrefix:@"HTTP/1.1 200"], @"an inert image must render: %@", [image substringToIndex:MIN((NSUInteger)40, image.length)]);
+    XCTAssertTrue([image containsString:@"Content-Disposition: inline"], @"the whole point is inline disposition: %@", image);
+    XCTAssertFalse([image containsString:@"attachment"], @"an inline preview must not also say attachment");
+    XCTAssertTrue([image containsString:@"X-Content-Type-Options: nosniff"], @"inline content must never be sniffable");
+    XCTAssertTrue([image containsString:@"Content-Type: image/png"], @"the type must be stated so nosniff has something to pin: %@", image);
+    XCTAssertTrue([image containsString:@"Content-Security-Policy:"], @"inline content gets a policy that denies everything");
+
+    // Active content is refused outright — including SVG, which is an image and is NOT inert.
+    for (NSString* active in @[ @"%2Fevil.html", @"%2Fevil.svg" ]) {
+        NSString* reply = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /preview?path=%@ HTTP/1.1\r\nHost: localhost\r\n\r\n", active]);
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 403"], @"%@ must not be served inline: %@", active, [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+        XCTAssertFalse([reply containsString:@"alert(1)"], @"%@ must not have its body reflected either", active);
+    }
+
+    // But /download still serves them, as attachments — refusing inline must not remove the file
+    // from the share, only from the inline surface.
+    NSString* downloaded = SendRawRequest(server.port, @"GET /download?path=%2Fevil.svg HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([downloaded hasPrefix:@"HTTP/1.1 200"], @"the file is still downloadable: %@", [downloaded substringToIndex:MIN((NSUInteger)40, downloaded.length)]);
+    XCTAssertTrue([downloaded containsString:@"attachment"], @"…as an attachment");
+
+    // Every refusal /download makes, /preview makes too: it is a second door to the same files.
+    XCTAssertTrue([SendRawRequest(server.port, @"GET /preview?path=%2F.hidden%2Fsecret.png HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 403"], @"a hidden path is refused on the preview surface too");
+    XCTAssertTrue([SendRawRequest(server.port, @"GET /preview?path=%2Fnope.png HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 404"], @"a missing file is still 404");
+
+    // Range works here too, because that is what a <video> needs to seek.
+    NSString* ranged = SendRawRequest(server.port, @"GET /preview?path=%2Fpic.png HTTP/1.1\r\nHost: localhost\r\nRange: bytes=1-3\r\n\r\n");
+    XCTAssertTrue([ranged hasPrefix:@"HTTP/1.1 206"], @"preview must honour Range: %@", [ranged substringToIndex:MIN((NSUInteger)40, ranged.length)]);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// Caching is opt-in, and the default must stay as it was. A share is mutable — files are uploaded,
+// moved and deleted through this very UI — so a max-age the caller did not ask for would hand a
+// browser a window in which it serves content the share no longer holds, with no request to notice
+// it. Left at 0, every response still says no-cache, which does NOT mean "do not store": the
+// browser keeps the body and revalidates with If-None-Match, so a thumbnail grid already costs 304s
+// rather than bodies. What max-age buys is removing the request itself, which is the caller's call.
+- (void)testUploaderFileCacheControlMaxAgeIsOptIn {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    XCTAssertTrue([@"PIXELS" writeToFile:[dir stringByAppendingPathComponent:@"pic.png"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebUploader* server = [[WSKWebUploader alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    XCTAssertEqual(server.fileCacheControlMaxAge, (NSUInteger)0, @"the default must be no caching directive");
+
+    for (NSString* endpoint in @[ @"download", @"preview" ]) {
+        NSString* reply = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /%@?path=%%2Fpic.png HTTP/1.1\r\nHost: localhost\r\n\r\n", endpoint]);
+        XCTAssertTrue([reply containsString:@"Cache-Control: no-cache"], @"/%@ must revalidate by default: %@", endpoint, reply);
+    }
+
+    [server stop];
+
+    server.fileCacheControlMaxAge = 3600;
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    for (NSString* endpoint in @[ @"download", @"preview" ]) {
+        NSString* reply = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /%@?path=%%2Fpic.png HTTP/1.1\r\nHost: localhost\r\n\r\n", endpoint]);
+        XCTAssertTrue([reply containsString:@"max-age=3600"], @"/%@ must honour the configured age: %@", endpoint, reply);
+    }
+
+    // A revalidation still works and still answers 304, so a client that asks anyway is told the
+    // truth rather than handed the body again.
+    // CFHTTPMessage standardizes the field name, so it goes out as "Etag" rather than the "ETag"
+    // the source spells — match case-insensitively rather than pinning CF's choice.
+    NSString* first = SendRawRequest(server.port, @"GET /preview?path=%2Fpic.png HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    NSRange const tagRange = [first rangeOfString:@"etag: " options:NSCaseInsensitiveSearch];
+    XCTAssertNotEqual(tagRange.location, (NSUInteger)NSNotFound, @"a file response carries an entity tag: %@", first);
+
+    if (tagRange.location != NSNotFound) {
+        NSString* tail = [first substringFromIndex:NSMaxRange(tagRange)];
+        NSString* tag = [tail substringToIndex:[tail rangeOfString:@"\r\n"].location];
+        NSString* revalidated = SendRawRequest(server.port, [NSString stringWithFormat:@"GET /preview?path=%%2Fpic.png HTTP/1.1\r\nHost: localhost\r\nIf-None-Match: %@\r\n\r\n", tag]);
+        XCTAssertTrue([revalidated hasPrefix:@"HTTP/1.1 304"], @"an unchanged preview revalidates to 304: %@", [revalidated substringToIndex:MIN((NSUInteger)40, revalidated.length)]);
+    }
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 // RFC 4918 §9.3.1: MKCOL on a URL that already identifies a resource MUST answer 405. This
 // answered 500, because createDirectoryAtPath:withIntermediateDirectories:NO fails with
 // NSFileWriteFileExistsError and the error mapping recognises only the full-volume cases, so

--- a/Sources/WebServerKitUploader/WSKWebUploader.h
+++ b/Sources/WebServerKitUploader/WSKWebUploader.h
@@ -116,6 +116,24 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL serverSentEventsEnabled;
 
 /**
+ *  Sets the "Cache-Control" max-age, in seconds, sent with file bodies served
+ *  from "/download" and "/preview".
+ *
+ *  The default value is 0, which sends "no-cache". That does not mean "do not
+ *  store": a browser still keeps the body and revalidates it with
+ *  "If-None-Match", so an unchanged file costs a 304 rather than a transfer.
+ *  Setting a non-zero age removes the revalidation request itself, which is
+ *  worth doing for a media-rich interface vending many small images.
+ *
+ *  @warning A shared directory is mutable, and files are uploaded, moved and
+ *  deleted through this very interface. For the duration of the age you set, a
+ *  browser may serve content the share no longer holds without making any
+ *  request that would reveal it. Prefer a short age, or address content by a
+ *  URL that changes when the content does.
+ */
+@property (nonatomic) NSUInteger fileCacheControlMaxAge;
+
+/**
  *  Sets the title for the uploader web interface.
  *
  *  The default value is the application name.

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -134,6 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WSKWebUploader (Methods)
 - (nullable WSKResponse *)listDirectory:(WSKRequest *)request;
 - (nullable WSKResponse *)downloadFile:(WSKRequest *)request;
+- (nullable WSKResponse *)previewFile:(WSKRequest *)request;
 - (nullable WSKResponse *)uploadFile:(WSKMultiPartFormRequest *)request;
 - (nullable WSKResponse *)moveItem:(WSKURLEncodedFormRequest *)request;
 - (nullable WSKResponse *)deleteItem:(WSKURLEncodedFormRequest *)request;
@@ -457,6 +458,17 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
                      requestClass:[WSKRequest class]
                      processBlock:^WSKResponse *(WSKRequest *request) {
                          return [server downloadFile:request];
+                     }];
+
+        // Inline media, for an interface that shows pictures rather than listing them. Separate
+        // from /download rather than a flag on it: "always an attachment" and "always inert and
+        // inline" are each defensible in one sentence, where one endpoint with a switch has a
+        // wrong setting to reach.
+        [self addHandlerForMethod:@"GET"
+                             path:@"/preview"
+                     requestClass:[WSKRequest class]
+                     processBlock:^WSKResponse *(WSKRequest *request) {
+                         return [server previewFile:request];
                      }];
 
         // File upload
@@ -1152,7 +1164,39 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
     return [WSKDataResponse responseWithJSONObject:array];
 }
 
+// Types a browser renders but cannot execute. Serving a shared file INLINE puts it in this
+// server's own origin, and this interface's one-click buttons delete and move files — so an
+// uploaded ".html" served inline is stored XSS against the share. /download forces "attachment"
+// for exactly that reason, which is also why it cannot simply be relaxed: <img src="/download?…">
+// gets a save dialog instead of a picture.
+//
+// The list is an allow-list of whole types rather than a deny-list of dangerous ones, because a
+// deny-list is wrong the moment a new type is registered. "image/svg+xml" is excluded DELIBERATELY
+// and is the reason this is not simply "anything beginning image/": SVG carries script and runs it,
+// so an "images are inert" rule admits the one image that is not. PDF is excluded for the same
+// reason — it has its own scripting model.
+static BOOL _MimeTypeIsInertMedia(NSString *mimeType) {
+    NSString *const type = [[mimeType componentsSeparatedByString:@";"].firstObject stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]].lowercaseString;
+
+    if ([type isEqualToString:@"image/svg+xml"]) {
+        return NO;
+    }
+
+    return [type hasPrefix:@"image/"] || [type hasPrefix:@"audio/"] || [type hasPrefix:@"video/"];
+}
+
+- (WSKResponse *)previewFile:(WSKRequest *)request {
+    return [self _fileResponseForRequest:request inline:YES];
+}
+
 - (WSKResponse *)downloadFile:(WSKRequest *)request {
+    return [self _fileResponseForRequest:request inline:NO];
+}
+
+// One body for both surfaces. /preview is a second door to the same files, so every refusal
+// /download makes it has to make too — sharing the walk is what stops the two drifting, which is
+// this codebase's most reliable defect shape.
+- (WSKResponse *)_fileResponseForRequest:(WSKRequest *)request inline:(BOOL)serveInline {
     // Never nil, so error bodies name a path instead of "(null)" — and match -listDirectory:.
     NSString *const requestedPath = [request query][@"path"];
 
@@ -1202,13 +1246,46 @@ static const NSTimeInterval kChangeCoalescingMaxDelay = 1.0;
         return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"Downloading file name \"%@\" is not allowed", fileName];
     }
 
+    // Decided from the same extension mapping the response itself will use, so the type this
+    // refuses on and the type it then declares cannot disagree.
+    NSString *const mimeType = WSKGetMimeTypeForExtension([absolutePath pathExtension], nil);
+
+    if (serveInline && !_MimeTypeIsInertMedia(mimeType)) {
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_Forbidden message:@"\"%@\" cannot be shown inline; use /download instead", [relativePath lastPathComponent]];
+    }
+
     if ([self.delegate respondsToSelector:@selector(webUploader:didDownloadFileAtPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [self.delegate webUploader:self didDownloadFileAtPath:absolutePath];
         });
     }
 
-    return [WSKFileResponse responseWithFile:absolutePath isAttachment:YES];
+    // Range and If-Range are passed through now. This endpoint built its response with
+    // +responseWithFile:isAttachment:, which passes NSMakeRange(NSUIntegerMax, 0) — no range —
+    // so a "Range" header was ignored and the whole file came back 200: an interrupted download
+    // of a large build could not resume, and a <video> could not seek. The base-path handler and
+    // DAV's GET have both passed these for several passes; this was the one file-vending surface
+    // that did not. Going through the ifRange: variant is also what brings the If-Range protection
+    // with it, so a resume against a REPLACED file is refused rather than spliced.
+    WSKFileResponse *const response = [WSKFileResponse responseWithFile:absolutePath byteRange:request.byteRange isAttachment:!serveInline ifRange:request.ifRange];
+
+    if (response == nil) {
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+    }
+
+    if (serveInline) {
+        // "attachment" is what +responseWithFile: sets when asked for one; the inline case sets
+        // none at all, which leaves the browser to guess from the type. Say it explicitly, and
+        // carry the two headers that make guessing harmless: nosniff so a .png full of markup
+        // cannot be sniffed into active content, and a policy that denies every subresource and
+        // script even if a type ever slips past the allow-list above.
+        [response setValue:@"inline" forAdditionalHeader:@"Content-Disposition"];
+        [response setValue:@"nosniff" forAdditionalHeader:@"X-Content-Type-Options"];
+        [response setValue:@"default-src 'none'; sandbox; frame-ancestors 'none'" forAdditionalHeader:@"Content-Security-Policy"];
+    }
+
+    response.cacheControlMaxAge = _fileCacheControlMaxAge;
+    return response;
 }
 
 // Extract the host[:port] authority from an Origin ("scheme://host:port") or a


### PR DESCRIPTION
Groundwork for a media-rich browser interface. Three things — one of which is a plain defect.

## `/download` ignored `Range` entirely

It built its response with `+responseWithFile:isAttachment:`, which passes `NSMakeRange(NSUIntegerMax, 0)` — no range at all. Measured from the network **before** the change:

| request | was | now |
|---|---|---|
| `Range: bytes=2-5` | 200, whole file | **206** + `Content-Range: bytes 2-5/10` |
| `Range: bytes=7-` (a resume) | 200, whole file | **206** |
| `Range: bytes=999-` | 200, whole file | **416** |

The base-path handler and DAV's `GET` have both passed `request.byteRange` and `request.ifRange` for several passes; this was the one file-vending surface that never did. For Shape A that means **an interrupted download of a large build cannot resume**, which this project treats as a main path rather than an edge case. Going through the `ifRange:` variant also brings the If-Range protection with it, so a resume against a *replaced* file is refused rather than spliced.

## `/preview` serves inert media inline

Rendering a shared file inline puts it in this server's **own origin**, and this interface's one-click buttons delete and move files — so an uploaded `.html` served inline is stored XSS against the share. That's exactly why `/download` forces `attachment`, and also why it can't simply be relaxed: `<img src="/download?…">` gets a save dialog rather than a picture.

So inline lives at its own endpoint: an allow-list of types a browser renders but cannot execute, `Content-Disposition: inline`, `nosniff`, and a policy denying every subresource even if a type slips through.

**`image/svg+xml` is excluded deliberately**, and it's why this is an allow-list of whole types rather than `anything beginning image/`: SVG carries script and runs it, so an "images are inert" rule admits the one image that isn't. PDF is out for the same reason. Both are still downloadable — refusing inline removes a file from the *inline surface*, not from the share.

That assertion was **proved sensitive rather than assumed**. With the SVG line removed:

```
error: … %2Fevil.svg must not be served inline: HTTP/1.1 200 OK
error: … %2Fevil.svg must not have its body reflected either
```

Both endpoints share one walk, so every refusal `/download` makes `/preview` makes too — a second door to the same files that vetted them differently is this codebase's most reliable defect shape.

## `fileCacheControlMaxAge` is opt-in

Defaults to 0, keeping today's `no-cache` — which does *not* mean "do not store": a browser keeps the body and revalidates with `If-None-Match`, so a thumbnail grid already costs 304s rather than transfers. A non-zero age removes the **request itself**, which is the win for many small images.

But a share is mutable and files are deleted through this very interface, so for the age you set a browser may serve content the share no longer holds without any request that would reveal it. That trade is the caller's, and the header documentation says so.

## Verification

The Range test fails against the unfixed tree **5/5** on the intended assertions. The other two exercise API that didn't exist, so their oracle was proved by breaking the implementation instead.

Two of my own test bugs found and fixed on the way: binary PNG fixtures made every reply undecodable as a string so assertions read `(null)`, and `CFHTTPMessage` standardizes the field name to `Etag`, not the `ETag` the source spells.

**149 tests, 0 failures**, all eight trace suites green, Release on macOS/iOS/tvOS, clean Debug on all three with zero warnings and an isolated `-derivedDataPath` each, forced-clean `swift build` at 4.94 s.

## Not here

No UI changes — `index.js` still links to `/download`. This is the server-side primitive; the thumbnail grid is a separate piece of work, and it's the one that would benefit from content-addressed URLs so a long `max-age` becomes safe rather than a trade.