### PR TITLE
Connection reuse for bodyless requests, off by default

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -199,6 +199,79 @@ static NSString* SendRawRequest(NSUInteger port, NSString* request) {
     return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 
+// Sends several requests over ONE connection, returning each reply separately. Unlike
+// SendRawRequest it cannot read to EOF between requests — on a reused connection there is no EOF
+// until the last one — so each reply is delimited by its own framing: the header block is read,
+// then exactly Content-Length bytes. A reply that never completes ends the run rather than
+// hanging, and the count of replies returned is what the caller asserts on.
+static NSArray<NSString*>* SendRawRequestsOnOneConnection(NSUInteger port, NSArray<NSString*>* requests) {
+    int fd = ConnectToLocalhostPort(port);
+    if (fd < 0) {
+        return @[];
+    }
+
+    struct timeval tv = {2, 0};
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    NSMutableArray<NSString*>* replies = [NSMutableArray array];
+    NSMutableData* buffered = [NSMutableData data];
+
+    for (NSString* request in requests) {
+        const char* bytes = [request UTF8String];
+        if (send(fd, bytes, strlen(bytes), 0) < 0) {
+            break;
+        }
+
+        // Read until this reply's header block plus its declared body are both in hand.
+        NSData* terminator = [@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+        NSRange headerEnd = NSMakeRange(NSNotFound, 0);
+        NSInteger expected = -1;
+        BOOL stalled = NO;
+
+        while (!stalled) {
+            if (headerEnd.location == NSNotFound) {
+                headerEnd = [buffered rangeOfData:terminator options:0 range:NSMakeRange(0, buffered.length)];
+
+                if (headerEnd.location != NSNotFound) {
+                    NSString* head = [[NSString alloc] initWithData:[buffered subdataWithRange:NSMakeRange(0, NSMaxRange(headerEnd))] encoding:NSUTF8StringEncoding];
+                    NSRange lengthRange = [head rangeOfString:@"Content-Length: " options:NSCaseInsensitiveSearch];
+                    expected = 0;
+
+                    if (lengthRange.location != NSNotFound) {
+                        expected = [[head substringFromIndex:NSMaxRange(lengthRange)] integerValue];
+                    }
+                }
+            }
+
+            if ((headerEnd.location != NSNotFound) && ((NSInteger)(buffered.length - NSMaxRange(headerEnd)) >= expected)) {
+                break;
+            }
+
+            char chunk[4096];
+            ssize_t got = recv(fd, chunk, sizeof(chunk), 0);
+
+            if (got <= 0) {
+                stalled = YES;
+            } else {
+                [buffered appendBytes:chunk length:(NSUInteger)got];
+            }
+        }
+
+        if (headerEnd.location == NSNotFound) {
+            break;  // No complete reply arrived; the caller sees a short array.
+        }
+
+        NSUInteger const total = NSMaxRange(headerEnd) + (NSUInteger)MAX((NSInteger)0, expected);
+        NSUInteger const take = MIN(total, buffered.length);
+        NSString* reply = [[NSString alloc] initWithData:[buffered subdataWithRange:NSMakeRange(0, take)] encoding:NSUTF8StringEncoding];
+        [replies addObject:(reply ? reply : @"")];
+        [buffered replaceBytesInRange:NSMakeRange(0, take) withBytes:NULL length:0];
+    }
+
+    close(fd);
+    return replies;
+}
+
 // As SendRawDataRequest, but split into two writes with a pause, so the tail arrives in a
 // separate socket read. Used to prove a verdict does not depend on how the client segmented.
 static NSString* SendRawDataRequestSplit(NSUInteger port, NSData* request, NSUInteger splitAt) {
@@ -2908,6 +2981,304 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     XCTAssertTrue([fm createDirectoryAtPath:[dir stringByAppendingPathComponent:@"Coll"] withIntermediateDirectories:YES attributes:nil error:NULL]);
     NSString* deleted = SendRawRequest(server.port, @"DELETE /Coll HTTP/1.1\r\nHost: localhost\r\nDepth: Infinity\r\n\r\n");
     XCTAssertTrue([deleted hasPrefix:@"HTTP/1.1 204"], @"Depth: Infinity should be accepted: %@", [deleted substringToIndex:MIN((NSUInteger)40, deleted.length)]);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// Connection reuse, and the restriction that makes it safe. A client normally pays a TCP handshake
+// per request because every response carried "Connection: Close" and the connection served exactly
+// one request — fine for a few large downloads, wasteful for an interface fetching many small
+// images.
+//
+// Reuse is allowed ONLY for requests carrying no body framing at all. Request smuggling is a
+// disagreement about where one request's body ends and the next begins, so a connection on which no
+// body is ever read cannot be desynchronized — the property is structural rather than a matter of
+// parsing carefully. This test pins both halves: that eligible requests really do share one
+// connection, and that every ineligible shape still closes.
+- (void)testConnectionKeepAliveCarriesBodylessRequestsAndClosesOnEverythingElse {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    XCTAssertTrue([@"ALPHA" writeToFile:[dir stringByAppendingPathComponent:@"a.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"BETA" writeToFile:[dir stringByAppendingPathComponent:@"b.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/f/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    // Hoisted: a dictionary literal's commas split XCTAssertTrue's macro arguments. Fourth time
+    // this project has hit that.
+    NSDictionary* keepAliveOptions = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_ConnectionKeepAliveTimeout : @5.0};
+    XCTAssertTrue([server startWithOptions:keepAliveOptions error:NULL]);
+
+    NSString* const getA = @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    NSString* const getB = @"GET /f/b.txt HTTP/1.1\r\nHost: localhost\r\n\r\n";
+
+    NSArray<NSString*>* replies = SendRawRequestsOnOneConnection(server.port, @[ getA, getB, getA ]);
+    XCTAssertEqual(replies.count, (NSUInteger)3, @"three bodyless GETs must all be answered on one connection");
+
+    if (replies.count == 3) {
+        XCTAssertTrue([replies[0] containsString:@"ALPHA"], @"first reply: %@", replies[0]);
+        XCTAssertTrue([replies[1] containsString:@"BETA"], @"second reply — proves the connection was reused: %@", replies[1]);
+        XCTAssertTrue([replies[2] containsString:@"ALPHA"], @"third reply: %@", replies[2]);
+        XCTAssertTrue([replies[0] rangeOfString:@"Connection: keep-alive" options:NSCaseInsensitiveSearch].location != NSNotFound, @"the reply must announce reuse: %@", replies[0]);
+
+        // State must not leak across requests on one connection — a class this connection could not
+        // previously have, since it never served a second request. Serving b.txt after a.txt with
+        // the first request's body or validators would show up here.
+        XCTAssertFalse([replies[1] containsString:@"ALPHA"], @"the second reply must not carry the first's body");
+    }
+
+    // A HEAD followed by a GET: _virtualHEAD is per-request state, and inheriting it would suppress
+    // the following GET's body entirely.
+    NSArray<NSString*>* mixed = SendRawRequestsOnOneConnection(server.port, @[ @"HEAD /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\n", getB ]);
+    XCTAssertEqual(mixed.count, (NSUInteger)2, @"a HEAD may be followed by a GET on the same connection");
+
+    if (mixed.count == 2) {
+        XCTAssertFalse([mixed[0] containsString:@"ALPHA"], @"a HEAD carries no body");
+        XCTAssertTrue([mixed[1] containsString:@"BETA"], @"the GET after a HEAD must still get its body — _virtualHEAD must not leak: %@", mixed[1]);
+    }
+
+    // A request that was REFUSED ends the connection: a refusal can happen before the body is read,
+    // so bytes may be left in flight that would otherwise be parsed as the next request line.
+    NSArray<NSString*>* refused = SendRawRequestsOnOneConnection(server.port, @[ @"GET /f/nope.txt HTTP/1.1\r\nHost: localhost\r\n\r\n", getA ]);
+    XCTAssertTrue(refused.count >= 1, @"the refusal itself is answered");
+    XCTAssertTrue([refused.firstObject hasPrefix:@"HTTP/1.1 404"], @"…as a 404: %@", refused.firstObject);
+    XCTAssertTrue([refused.firstObject rangeOfString:@"keep-alive" options:NSCaseInsensitiveSearch].location == NSNotFound, @"a refusal must not offer to keep the connection: %@", refused.firstObject);
+
+    // A request WITH a body is answered and the connection closes, whatever the body is. This is
+    // the restriction the whole design rests on.
+    NSArray<NSString*>* withBody = SendRawRequestsOnOneConnection(server.port, @[ @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n", getB ]);
+    XCTAssertTrue(withBody.count >= 1, @"the request carrying framing is still answered");
+    XCTAssertTrue([withBody.firstObject rangeOfString:@"keep-alive" options:NSCaseInsensitiveSearch].location == NSNotFound, @"a request declaring Content-Length must not be reused: %@", withBody.firstObject);
+
+    // "Transfer-Encoding: identity" sets no content type, so -[WSKRequest hasBody] answers NO for
+    // it — keying reuse on that instead of on the raw header names would have made exactly the
+    // shape a TE.CL desync is built from eligible. It must not be.
+    NSArray<NSString*>* identity = SendRawRequestsOnOneConnection(server.port, @[ @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: identity\r\n\r\n", getB ]);
+    XCTAssertTrue(identity.count >= 1);
+    XCTAssertTrue([identity.firstObject rangeOfString:@"keep-alive" options:NSCaseInsensitiveSearch].location == NSNotFound, @"a Transfer-Encoding of any kind must not be reused: %@", identity.firstObject);
+
+    // A client that asks to close is obeyed.
+    NSArray<NSString*>* asked = SendRawRequestsOnOneConnection(server.port, @[ @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n", getB ]);
+    XCTAssertTrue(asked.count >= 1);
+    XCTAssertTrue([asked.firstObject rangeOfString:@"keep-alive" options:NSCaseInsensitiveSearch].location == NSNotFound, @"Connection: close must be honoured: %@", asked.firstObject);
+
+    // HTTP/1.0 has no persistent connections by default and may be framed by connection close.
+    NSArray<NSString*>* old = SendRawRequestsOnOneConnection(server.port, @[ @"GET /f/a.txt HTTP/1.0\r\nHost: localhost\r\n\r\n", getB ]);
+    XCTAssertTrue(old.count >= 1);
+    XCTAssertTrue([old.firstObject rangeOfString:@"keep-alive" options:NSCaseInsensitiveSearch].location == NSNotFound, @"an HTTP/1.0 client must not be given a persistent connection: %@", old.firstObject);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// The option defaults to off, so every existing deployment keeps serving exactly one request per
+// connection until it opts in. Worth pinning: the whole feature is new machinery in the most
+// security-critical file in the library, and "the default did not change" is the property that
+// makes landing it safe.
+- (void)testConnectionKeepAliveIsOffByDefault {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    XCTAssertTrue([@"ALPHA" writeToFile:[dir stringByAppendingPathComponent:@"a.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/f/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    NSDictionary* defaultOptions = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:defaultOptions error:NULL]);
+
+    NSString* single = SendRawRequest(server.port, @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([single containsString:@"ALPHA"], @"the response is unchanged: %@", single);
+    XCTAssertTrue([single rangeOfString:@"Connection: Close" options:NSCaseInsensitiveSearch].location != NSNotFound, @"the default is still one request per connection: %@", single);
+
+    NSArray<NSString*>* replies = SendRawRequestsOnOneConnection(server.port, @[ @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\n", @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\n" ]);
+    XCTAssertEqual(replies.count, (NSUInteger)1, @"a second request on the same connection must go unanswered by default");
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// A connection held open for reuse is holding one of kWSKMaxConnections slots, so it has to be
+// given back. This is the half of keep-alive that matters most for a server measured in weeks: a
+// reused connection that is never reclaimed is a slot leak, and 128 of them are a permanent denial
+// of service with no error anywhere.
+//
+// The reclaim rides on the existing idle timer, which means the effective hold is rounded up to the
+// next tick — the test uses a short idle timeout so it measures in seconds rather than in the
+// 30-second default. What it pins is that the connection IS closed while idle, and that the
+// slowloris deadline for a request in progress was not weakened to achieve it.
+- (void)testConnectionKeepAliveReclaimsAnIdleConnection {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    XCTAssertTrue([@"ALPHA" writeToFile:[dir stringByAppendingPathComponent:@"a.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/f/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_ConnectionKeepAliveTimeout : @1.0, WSKOption_ConnectionIdleTimeout : @1.0};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    int fd = ConnectToLocalhostPort(server.port);
+    XCTAssertTrue(fd >= 0);
+
+    const char* request = "GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    XCTAssertTrue(send(fd, request, strlen(request), 0) > 0);
+
+    // Drain the reply, then go quiet and let the reaper find it.
+    struct timeval tv = {5, 0};
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    // Drain the WHOLE reply — header block plus exactly Content-Length bytes. A single recv
+    // returns only what has arrived, so stopping there leaves the body in the socket and the
+    // "did the server close?" read below picks THAT up instead of EOF.
+    char buffer[8192];
+    NSMutableData* reply = [NSMutableData data];
+    NSData* const terminator = [@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+    NSRange headerEnd = NSMakeRange(NSNotFound, 0);
+    NSInteger expected = 0;
+
+    while (true) {
+        headerEnd = [reply rangeOfData:terminator options:0 range:NSMakeRange(0, reply.length)];
+
+        if (headerEnd.location != NSNotFound) {
+            NSString* head = [[NSString alloc] initWithData:[reply subdataWithRange:NSMakeRange(0, NSMaxRange(headerEnd))] encoding:NSUTF8StringEncoding];
+            NSRange lengthRange = [head rangeOfString:@"Content-Length: " options:NSCaseInsensitiveSearch];
+            expected = (lengthRange.location == NSNotFound) ? 0 : [[head substringFromIndex:NSMaxRange(lengthRange)] integerValue];
+
+            if ((NSInteger)(reply.length - NSMaxRange(headerEnd)) >= expected) {
+                break;
+            }
+        }
+
+        ssize_t chunk = recv(fd, buffer, sizeof(buffer), 0);
+
+        if (chunk <= 0) {
+            break;
+        }
+
+        [reply appendBytes:buffer length:(NSUInteger)chunk];
+    }
+
+    XCTAssertTrue(reply.length > 0, @"the first request is answered");
+    XCTAssertTrue([[[NSString alloc] initWithData:reply encoding:NSUTF8StringEncoding] rangeOfString:@"keep-alive" options:NSCaseInsensitiveSearch].location != NSNotFound, @"…and the connection is offered for reuse");
+
+    // Now read again without sending anything. A reclaimed connection gives EOF; one that is never
+    // reclaimed sits here until the receive timeout above, which is what the assertion catches.
+    NSDate* const started = [NSDate date];
+    ssize_t const after = recv(fd, buffer, sizeof(buffer), 0);
+    NSTimeInterval const waited = -[started timeIntervalSinceNow];
+    close(fd);
+
+    XCTAssertEqual(after, (ssize_t)0, @"an idle kept-alive connection must be closed by the server, not held forever");
+    XCTAssertLessThan(waited, 4.5, @"…and reclaimed promptly rather than at the receive timeout (waited %.1fs)", waited);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// The companion to the reclaim test above, and the one that actually discriminates. That test
+// passes even with the keep-alive idle branch removed, because the pre-existing header-phase
+// deadline (kMaxHeaderPhaseTicks idle ticks, a slowloris defence) closes the connection anyway —
+// so it pins "nothing leaks" but says nothing about the configured timeout being honoured.
+//
+// This one sets a keep-alive longer than that deadline and shows the connection survives past it.
+// Without the branch, an idle reused connection is cut after two idle ticks no matter what
+// WSKOption_ConnectionKeepAliveTimeout says, and the option's documented meaning would be a lie.
+- (void)testConnectionKeepAliveHoldsForTheConfiguredTimeNotTheSlowlorisDeadline {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    XCTAssertTrue([@"ALPHA" writeToFile:[dir stringByAppendingPathComponent:@"a.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/f/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    // Idle ticks of 1s, so the header-phase deadline would cut an idle connection at ~2s; a
+    // keep-alive of 8s must override that.
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_ConnectionKeepAliveTimeout : @8.0, WSKOption_ConnectionIdleTimeout : @1.0};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    int fd = ConnectToLocalhostPort(server.port);
+    XCTAssertTrue(fd >= 0);
+    struct timeval tv = {5, 0};
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    NSString* (^exchange)(void) = ^NSString* {
+        const char* request = "GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\n";
+
+        if (send(fd, request, strlen(request), 0) <= 0) {
+            return nil;
+        }
+
+        NSMutableData* reply = [NSMutableData data];
+        NSData* const terminator = [@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+        char buffer[8192];
+
+        while (true) {
+            NSRange headerEnd = [reply rangeOfData:terminator options:0 range:NSMakeRange(0, reply.length)];
+
+            if (headerEnd.location != NSNotFound) {
+                NSString* head = [[NSString alloc] initWithData:[reply subdataWithRange:NSMakeRange(0, NSMaxRange(headerEnd))] encoding:NSUTF8StringEncoding];
+                NSRange lengthRange = [head rangeOfString:@"Content-Length: " options:NSCaseInsensitiveSearch];
+                NSInteger expected = (lengthRange.location == NSNotFound) ? 0 : [[head substringFromIndex:NSMaxRange(lengthRange)] integerValue];
+
+                if ((NSInteger)(reply.length - NSMaxRange(headerEnd)) >= expected) {
+                    break;
+                }
+            }
+
+            ssize_t chunk = recv(fd, buffer, sizeof(buffer), 0);
+
+            if (chunk <= 0) {
+                break;
+            }
+
+            [reply appendBytes:buffer length:(NSUInteger)chunk];
+        }
+
+        return [[NSString alloc] initWithData:reply encoding:NSUTF8StringEncoding];
+    };
+
+    XCTAssertTrue([exchange() containsString:@"ALPHA"], @"the first request is answered");
+
+    // Go quiet for longer than the header-phase deadline would tolerate, then use the connection.
+    [NSThread sleepForTimeInterval:3.0];
+
+    NSString* second = exchange();
+    XCTAssertTrue([second containsString:@"ALPHA"], @"the connection must survive an idle period shorter than the configured keep-alive: %@", second);
+
+    close(fd);
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// A pipelining client writes its next request before reading the previous reply, so the second
+// request's bytes arrive in the SAME socket read as the first's header block. Those bytes are
+// carried over rather than dropped — and the header reader has to notice it already holds a
+// complete block instead of issuing a read for bytes the client has no reason to send, which would
+// hang until the idle timeout. That hazard is the reason this is a refactor and not a one-line loop.
+- (void)testConnectionKeepAliveAnswersPipelinedRequestsInOrder {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    XCTAssertTrue([@"ALPHA" writeToFile:[dir stringByAppendingPathComponent:@"a.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"BETA" writeToFile:[dir stringByAppendingPathComponent:@"b.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/f/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    // Hoisted: a dictionary literal's commas split XCTAssertTrue's macro arguments. Fourth time
+    // this project has hit that.
+    NSDictionary* keepAliveOptions = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_ConnectionKeepAliveTimeout : @5.0};
+    XCTAssertTrue([server startWithOptions:keepAliveOptions error:NULL]);
+
+    // Both requests in a single write, so the second lands in the first's read.
+    NSArray<NSString*>* replies = SendRawRequestsOnOneConnection(server.port, @[ @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\nGET /f/b.txt HTTP/1.1\r\nHost: localhost\r\n\r\n" ]);
+    XCTAssertTrue(replies.count >= 1, @"the first pipelined request is answered");
+    XCTAssertTrue([replies.firstObject containsString:@"ALPHA"], @"…and in order: %@", replies.firstObject);
+
+    // Then drain the second reply, which must have been produced from the carried-over bytes
+    // without waiting for anything further from the client.
+    NSArray<NSString*>* both = SendRawRequestsOnOneConnection(server.port, @[ @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\nGET /f/b.txt HTTP/1.1\r\nHost: localhost\r\n\r\n", @"" ]);
+    XCTAssertEqual(both.count, (NSUInteger)2, @"a pipelined pair must produce two replies");
+
+    if (both.count == 2) {
+        XCTAssertTrue([both[0] containsString:@"ALPHA"], @"first: %@", both[0]);
+        XCTAssertTrue([both[1] containsString:@"BETA"], @"second, from carried-over bytes: %@", both[1]);
+    }
 
     [server stop];
     [fm removeItemAtPath:dir error:NULL];

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -45,6 +45,7 @@
 #define kHeadersMaxLength (64 * 1024)  // Upper bound on total request header bytes, to cap memory for a client that never sends the terminating blank line.
 #define kMaxHeaderPhaseTicks 2  // Idle-timer ticks a connection may spend receiving its request line + headers before being closed (defeats a slowloris dribbling bytes just under the zero-progress check).
 #define kMinReceiveBytesPerSecond 32  // Throughput a connection must sustain while its request body is still arriving; see -_checkIdleTimeout.
+#define kMaxRequestsPerConnection 100  // Requests one reused connection may carry before it must be re-established; bounds how long a single client can hold one of the kWSKMaxConnections slots.
 
 typedef void (^ReadDataCompletionBlock)(BOOL success);
 typedef void (^ReadHeadersCompletionBlock)(NSData *extraData);
@@ -117,6 +118,19 @@ NS_ASSUME_NONNULL_END
     BOOL _earlyChecksRun;          // Host allow-list and preflight are decided once, as early as the headers allow
     NSInteger _headerFailureStatus;  // Why the header block was rejected; 500 only if nothing more specific applies
     NSTimeInterval _idleTimeout;   // Seconds between idle-timer ticks; 0 when idle timeouts are disabled
+
+    // Connection reuse. Deliberately restricted to requests carrying NO body, which is what keeps
+    // request smuggling structurally impossible rather than a matter of parsing carefully: a
+    // desync is a disagreement about where a body ends, and no body is ever read on a reused
+    // connection. Everything else — a body, a refusal, HTTP/1.0, an indeterminate response length
+    // — answers and closes exactly as it always has.
+    NSTimeInterval _keepAliveTimeout;   // 0 disables reuse entirely, which is the default
+    BOOL _requestIsBodyless;            // No Content-Length and no Transfer-Encoding, from the raw header names
+    BOOL _willKeepAlive;                // Decided before the headers go out, honoured after the body does
+    BOOL _awaitingNextRequest;          // Between requests: the idle rules differ from the header phase
+    NSUInteger _requestsServed;         // Bounds how long one client can hold a connection slot
+    NSUInteger _readBytesWhenIdleBegan;  // Read count when the last response finished; the next request can only arrive as reads
+    NSMutableData *_carryOverData;      // Bytes of the NEXT request that arrived in this request's last read
     WSKMemoryReservation *_chunkReservation;  // This connection's chunked framing buffer
 
 #ifdef __WEBSERVERKIT_ENABLE_TESTING__
@@ -359,6 +373,141 @@ static BOOL _IsIPAddressLiteral(NSString *host) {
     return [self preflightRequest:_request];
 }
 
+// A request is eligible for connection reuse only if it carries NO body framing at all. Read from
+// the RAW header names rather than from -[WSKRequest hasBody], which keys on _contentType and is
+// only equivalent to "has a body" because -initWithMethod: maintains that correspondence thirty
+// lines away. Basing a framing decision on a second spelling of the rule is how this codebase's
+// defects usually start — and the difference is not theoretical: "Transfer-Encoding: identity" sets
+// no content type, so -hasBody answers NO for a request that DOES carry transfer-coding framing,
+// which is exactly the shape a TE.CL desync is built from.
+//
+// Matched case-insensitively over every key, rather than by subscripting the two standard
+// spellings, because CFHTTPMessageCopyAllHeaderFields only standardizes the names it recognises.
+// CFHTTPMessageCopyAllHeaderFields only standardizes the names it recognises, so a lookup that
+// matters is done over the keys rather than by subscripting one spelling.
+static NSString *_HeaderValueForName(NSDictionary *headers, NSString *name) {
+    for (NSString *key in headers) {
+        if ([key caseInsensitiveCompare:name] == NSOrderedSame) {
+            return headers[key];
+        }
+    }
+
+    return nil;
+}
+
+static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
+    for (NSString *name in headers) {
+        if (([name caseInsensitiveCompare:@"Content-Length"] == NSOrderedSame) ||
+            ([name caseInsensitiveCompare:@"Transfer-Encoding"] == NSOrderedSame)) {
+            return NO;
+        }
+    }
+
+    return YES;
+}
+
+// Every condition that must hold for this connection to carry another request. Evaluated once, with
+// the response in hand, immediately before the header block that announces the decision goes out.
+- (BOOL)_shouldKeepConnectionAlive {
+    if (_keepAliveTimeout <= 0.0) {
+        return NO;  // Disabled, which is the default: one request per connection, as before.
+    }
+
+    // No body was read, so no body bytes can be left unconsumed and there is nothing for this
+    // server and an intermediary to disagree about. This is the whole basis of the guarantee.
+    if (!_requestIsBodyless) {
+        return NO;
+    }
+
+    // HTTP/1.0 has no persistent connections by default, and this server does not implement the
+    // "Connection: keep-alive" extension it would need. It is also the client for which the
+    // response may be framed by connection close.
+    if (_clientIsHTTP10) {
+        return NO;
+    }
+
+    // Note the nil guard: messaging nil returns a ZEROED struct, so a missing Connection header
+    // gives {0, 0} and `location != NSNotFound` is true — which made this refuse every request that
+    // did not send the header, i.e. all of them. It failed safe, so nothing was unsafe; the feature
+    // was simply never on.
+    NSString *const connectionHeader = _HeaderValueForName(_request.headers, @"Connection");
+
+    if (connectionHeader && ([connectionHeader rangeOfString:@"close" options:NSCaseInsensitiveSearch].location != NSNotFound)) {
+        return NO;  // The client asked us not to.
+    }
+
+    // The response must state its own length, or the client cannot tell where it ends without
+    // waiting for the close that reuse is avoiding. A chunked response frames itself; anything
+    // else needs Content-Length.
+    if (![self _shouldChunkResponse] && (_response.contentLength == NSUIntegerMax)) {
+        return NO;
+    }
+
+    // A bound on how long one client can hold a slot. With kWSKMaxConnections at 128 and a browser
+    // opening six per origin, unbounded reuse would let a handful of tabs occupy the server
+    // indefinitely — the cap that binds in practice is the connection pool, not this.
+    if (_requestsServed >= kMaxRequestsPerConnection) {
+        return NO;
+    }
+
+    return YES;
+}
+
+// Everything the next request must not inherit. Kept adjacent to the ivar block it mirrors,
+// because a field added there and forgotten here is a cross-request state leak — a defect class
+// this connection could not previously have, since it never served a second request.
+- (void)_resetForNextRequest {
+    if (_requestMessage) {
+        CFRelease(_requestMessage);
+        _requestMessage = NULL;
+    }
+
+    if (_responseMessage) {
+        CFRelease(_responseMessage);
+        _responseMessage = NULL;
+    }
+
+    _request = nil;
+    _response = nil;
+    _handler = nil;
+    _statusCode = 0;
+    _virtualHEAD = NO;
+    _requestReceived = NO;
+    _earlyChecksRun = NO;
+    _requestIsBodyless = NO;
+    _willKeepAlive = NO;
+    _clientIsHTTP10 = NO;
+    _headerFailureStatus = kWSKHTTPStatusCode_InternalServerError;
+    _headerPhaseTicks = 0;  // Or the second request inherits the first's deadline and is killed early.
+
+#ifdef __WEBSERVERKIT_ENABLE_TESTING__
+    _requestPath = nil;
+    _responsePath = nil;
+    _requestFD = 0;
+    _responseFD = 0;
+#endif
+}
+
+// The end of a response. Either the connection carries another request or it is simply released,
+// which is what closes it — the same unwind as before this existed.
+- (void)_finishConnectionOrReadNextRequest {
+    if (!_willKeepAlive) {
+        return;
+    }
+
+    [self close];  // Flush this request's log line and any recording while its state is still live.
+    _opened = NO;  // -dealloc must not close it a second time.
+    _requestsServed += 1;
+    [self _resetForNextRequest];
+    // Snapshot the READ count, not read+written. The response that just went out moved bytes, so
+    // comparing the combined total would make the very first idle tick conclude the next request
+    // had started arriving — dropping straight back into the header-phase deadline and closing the
+    // connection after two ticks regardless of the configured keep-alive.
+    _readBytesWhenIdleBegan = _totalBytesRead;
+    _awaitingNextRequest = YES;
+    [self _readRequestHeaders];
+}
+
 - (void)_startProcessingRequest {
     WSK_DCHECK(_responseMessage == NULL);
     _requestReceived = YES;  // Nothing further is read from the socket for this request
@@ -459,12 +608,33 @@ static BOOL _IsIPAddressLiteral(NSString *host) {
         [_response.additionalHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
             CFHTTPMessageSetHeaderFieldValue(self->_responseMessage, (__bridge CFStringRef)key, (__bridge CFStringRef)obj);
         }];
+
+        // Decided here rather than in -_initializeResponseHeadersWithStatusCode:, which sets
+        // "Close" unconditionally. That default is what makes every abort, every refusal and every
+        // path that does not reach this point close the connection by construction rather than by
+        // remembering to.
+        _willKeepAlive = [self _shouldKeepConnectionAlive];
+
+        if (_willKeepAlive) {
+            CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Connection"), CFSTR("keep-alive"));
+            CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Keep-Alive"), (__bridge CFStringRef)[NSString stringWithFormat:@"timeout=%i, max=%i", (int)_keepAliveTimeout, (int)(kMaxRequestsPerConnection - _requestsServed)]);
+        }
+
         [self writeHeadersWithCompletionBlock:^(BOOL success) {
             if (success) {
                 if (hasBody) {
                     [self writeBodyWithCompletionBlock:^(BOOL successInner) {
                         [self->_response performClose];  // TODO: There's nothing we can do on failure as headers have already been sent
+
+                        // Only a body that went out whole leaves the stream at a known
+                        // position; after a partial write the client cannot tell where the
+                        // next response begins, so the connection has to end.
+                        if (successInner) {
+                            [self _finishConnectionOrReadNextRequest];
+                        }
                     }];
+                } else {
+                    [self _finishConnectionOrReadNextRequest];
                 }
             } else if (hasBody) {
                 [self->_response performClose];
@@ -573,6 +743,35 @@ static BOOL _IsIPAddressLiteral(NSString *host) {
     NSUInteger transferredBytes = _totalBytesRead + _totalBytesWritten;
     BOOL waitingOnSocket = (_pendingIOCount > 0);
 
+    // A reused connection with no request in flight is idle BY DESIGN — that is what it is for —
+    // so the slowloris deadline below must not apply to it. It gets its own, longer allowance
+    // instead: the configured keep-alive timeout, after which the slot is reclaimed. The moment
+    // the first byte of the next request lands this reverts to the ordinary header-phase rules,
+    // so a client cannot buy slowloris immunity by keeping a connection alive first.
+    if (_awaitingNextRequest) {
+        if (_totalBytesRead > _readBytesWhenIdleBegan) {
+            // The next request has started arriving. Hand the ordinary header-phase deadline a
+            // FRESH budget: _headerPhaseTicks counts idle waiting above and header dribbling
+            // below, so carrying it across would charge this request for time the connection was
+            // legitimately idle and cut short a slow but genuine one.
+            _awaitingNextRequest = NO;
+            _headerPhaseTicks = 0;
+        } else {
+            _headerPhaseTicks += 1;
+
+            if ((_idleTimeout > 0.0) && ((NSTimeInterval)_headerPhaseTicks * _idleTimeout > _keepAliveTimeout)) {
+                WSK_LOG_DEBUG(@"Closing idle keep-alive connection on socket %i", _socket);
+                dispatch_source_cancel(_idleTimer);
+                shutdown(_socket, SHUT_RDWR);
+                return;
+            }
+
+            _idleCheckWasBusy = waitingOnSocket;
+            _idleCheckedBytes = transferredBytes;
+            return;
+        }
+    }
+
     // Absolute deadline for the request-line + headers phase (before any handler is
     // matched, i.e. while _request is still nil — assigned on this same queue). Headers
     // are small and bounded, so no legitimate client needs more than this; a deadline
@@ -624,6 +823,15 @@ static BOOL _IsIPAddressLiteral(NSString *host) {
 - (void)_readRequestHeaders {
     _requestMessage = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, true);
     NSMutableData *const headersData = [[NSMutableData alloc] initWithCapacity:kHeadersReadCapacity];
+
+    // On a reused connection the next request's first bytes usually arrived in the previous
+    // request's final read. They are the ONLY thing carried across, and they can only ever be a
+    // request line: reuse requires that the previous request had no body, so there are no
+    // unconsumed body bytes that could be mistaken for one.
+    if (_carryOverData.length > 0) {
+        [headersData appendData:_carryOverData];
+        _carryOverData = nil;
+    }
     [self readHeaders:headersData
         withCompletionBlock:^(NSData *extraData) {
             if (extraData) {
@@ -640,6 +848,7 @@ static BOOL _IsIPAddressLiteral(NSString *host) {
                 }
 
                 NSDictionary *const requestHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(self->_requestMessage));  // Header names are case-insensitive but CFHTTPMessageCopyAllHeaderFields() will standardize the common ones
+                self->_requestIsBodyless = _HeadersCarryNoBodyFraming(requestHeaders);
                 NSURL *requestURL = CFBridgingRelease(CFHTTPMessageCopyRequestURL(self->_requestMessage));
 
                 if (requestURL) {
@@ -733,6 +942,14 @@ static BOOL _IsIPAddressLiteral(NSString *host) {
                                 [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_BadRequest];
                             }
                         } else {
+                            // No body to read, so anything past the header block belongs to the
+                            // NEXT request. Held only when this connection may actually carry one;
+                            // otherwise it is dropped exactly as it always was, which is what made
+                            // "leftover bytes are never read" true.
+                            if ((self->_keepAliveTimeout > 0.0) && self->_requestIsBodyless && (extraData.length > 0)) {
+                                self->_carryOverData = [extraData mutableCopy];
+                            }
+
                             [self _startProcessingRequest];
                         }
                     } else {
@@ -800,6 +1017,7 @@ static BOOL _IsIPAddressLiteral(NSString *host) {
         _headerFailureStatus = kWSKHTTPStatusCode_InternalServerError;
         WSK_LOG_DEBUG(@"Did open connection on socket %i", _socket);
 
+        _keepAliveTimeout = server.connectionKeepAliveTimeout;
         NSTimeInterval idleTimeout = server.connectionIdleTimeout;
         _idleTimeout = idleTimeout;
 
@@ -1054,55 +1272,101 @@ static BOOL _ValidateRequestHeaderBlock(const void *rawBytes, NSUInteger length)
     return !expectingRequestLine;
 }
 
+typedef NS_ENUM(NSInteger, WSKHeaderBlockState) {
+    kWSKHeaderBlockIncomplete = 0,  // More bytes needed
+    kWSKHeaderBlockComplete,        // Parsed; anything past the terminator is returned as extra data
+    kWSKHeaderBlockFailed,          // Malformed or oversized; _headerFailureStatus says which
+};
+
+// Decide on what is already buffered, WITHOUT calling the completion block — the caller owns that,
+// so it is called exactly once on every path. (Folding the two together made the block's invocation
+// correlate with a return value the analyzer cannot relate, which it reported as both "never
+// called" and "called twice" in the same function.)
+//
+// Split out of -readHeaders: because a reused connection starts with the next request's bytes
+// ALREADY in the buffer, left there by the previous request's final read. Going straight to
+// dispatch_read in that state waits for bytes the client has no reason to send: it has a complete
+// request outstanding and is waiting for us. That is a hang until the idle timeout, and it is the
+// specific hazard that makes this a refactor rather than a one-line loop.
+- (WSKHeaderBlockState)_settleHeadersFromBuffer:(NSMutableData *)headersData extraData:(NSData *_Nullable *_Nonnull)outExtraData {
+    NSRange range = [headersData rangeOfData:_CRLFCRLFData options:0 range:NSMakeRange(0, headersData.length)];
+
+    if (range.location == NSNotFound) {
+        if (headersData.length > kHeadersMaxLength) {
+            WSK_LOG_ERROR(@"Request headers exceeded %i bytes on socket %i", (int)kHeadersMaxLength, _socket);
+            _headerFailureStatus = kWSKHTTPStatusCode_RequestHeaderFieldsTooLarge;
+            return kWSKHeaderBlockFailed;
+        }
+
+        return kWSKHeaderBlockIncomplete;
+    }
+
+    NSUInteger const length = range.location + range.length;
+
+    // kHeadersMaxLength was only ever enforced on the branch above, i.e. while still waiting for
+    // the terminator. A client that sent an oversized header block in one burst had it found,
+    // parsed and served — the cap was skipped entirely. Bound the block itself, not the buffer,
+    // which legitimately runs past it once body bytes arrive in the same read.
+    if (length > kHeadersMaxLength) {
+        WSK_LOG_ERROR(@"Request headers exceeded %i bytes on socket %i", (int)kHeadersMaxLength, _socket);
+        _headerFailureStatus = kWSKHTTPStatusCode_RequestHeaderFieldsTooLarge;
+        return kWSKHeaderBlockFailed;
+    }
+
+    if (!_ValidateRequestHeaderBlock(headersData.bytes, length)) {
+        WSK_LOG_ERROR(@"Rejecting malformed request line or header syntax on socket %i", _socket);
+        _headerFailureStatus = kWSKHTTPStatusCode_BadRequest;
+        return kWSKHeaderBlockFailed;
+    }
+
+    if (!CFHTTPMessageAppendBytes(_requestMessage, headersData.bytes, length)) {
+        WSK_LOG_ERROR(@"Failed appending request headers data from socket %i", _socket);
+        _headerFailureStatus = kWSKHTTPStatusCode_BadRequest;
+        return kWSKHeaderBlockFailed;
+    }
+
+    if (!CFHTTPMessageIsHeaderComplete(_requestMessage)) {
+        WSK_LOG_ERROR(@"Failed parsing request headers from socket %i", _socket);
+        _headerFailureStatus = kWSKHTTPStatusCode_BadRequest;
+        return kWSKHeaderBlockFailed;
+    }
+
+    *outExtraData = [headersData subdataWithRange:NSMakeRange(length, headersData.length - length)];
+    return kWSKHeaderBlockComplete;
+}
+
 - (void)readHeaders:(NSMutableData *)headersData withCompletionBlock:(ReadHeadersCompletionBlock)block {
     WSK_DCHECK(_requestMessage);
+    NSData *bufferedExtraData = nil;
+    WSKHeaderBlockState const buffered = [self _settleHeadersFromBuffer:headersData extraData:&bufferedExtraData];
+
+    if (buffered == kWSKHeaderBlockComplete) {
+        block(bufferedExtraData);
+        return;
+    }
+
+    if (buffered == kWSKHeaderBlockFailed) {
+        block(nil);
+        return;
+    }
+
     [self readData:headersData
              withLength:NSUIntegerMax
         completionBlock:^(BOOL success) {
-            if (success) {
-                NSRange range = [headersData rangeOfData:_CRLFCRLFData options:0 range:NSMakeRange(0, headersData.length)];
-
-                if (range.location == NSNotFound) {
-                    if (headersData.length > kHeadersMaxLength) {
-                        WSK_LOG_ERROR(@"Request headers exceeded %i bytes on socket %i", (int)kHeadersMaxLength, self->_socket);
-                        self->_headerFailureStatus = kWSKHTTPStatusCode_RequestHeaderFieldsTooLarge;
-                        block(nil);
-                    } else {
-                        [self readHeaders:headersData withCompletionBlock:block];
-                    }
-                } else {
-                    NSUInteger length = range.location + range.length;
-
-                    // kHeadersMaxLength was only ever enforced on the branch above, i.e.
-                    // while still waiting for the terminator. A client that sent an
-                    // oversized header block in one burst had it found, parsed and served
-                    // — the cap was skipped entirely. Bound the block itself, not the
-                    // buffer, which legitimately runs past it once body bytes arrive in the
-                    // same read.
-                    if (length > kHeadersMaxLength) {
-                        WSK_LOG_ERROR(@"Request headers exceeded %i bytes on socket %i", (int)kHeadersMaxLength, self->_socket);
-                        self->_headerFailureStatus = kWSKHTTPStatusCode_RequestHeaderFieldsTooLarge;
-                        block(nil);
-                    } else if (!_ValidateRequestHeaderBlock(headersData.bytes, length)) {
-                        WSK_LOG_ERROR(@"Rejecting malformed request line or header syntax on socket %i", self->_socket);
-                        self->_headerFailureStatus = kWSKHTTPStatusCode_BadRequest;
-                        block(nil);
-                    } else if (CFHTTPMessageAppendBytes(self->_requestMessage, headersData.bytes, length)) {
-                        if (CFHTTPMessageIsHeaderComplete(self->_requestMessage)) {
-                            block([headersData subdataWithRange:NSMakeRange(length, headersData.length - length)]);
-                        } else {
-                            WSK_LOG_ERROR(@"Failed parsing request headers from socket %i", self->_socket);
-                            self->_headerFailureStatus = kWSKHTTPStatusCode_BadRequest;
-                            block(nil);
-                        }
-                    } else {
-                        WSK_LOG_ERROR(@"Failed appending request headers data from socket %i", self->_socket);
-                        self->_headerFailureStatus = kWSKHTTPStatusCode_BadRequest;
-                        block(nil);
-                    }
-                }
-            } else {
+            if (!success) {
                 block(nil);
+                return;
+            }
+
+            NSData *extraData = nil;
+            WSKHeaderBlockState const state = [self _settleHeadersFromBuffer:headersData extraData:&extraData];
+
+            if (state == kWSKHeaderBlockComplete) {
+                block(extraData);
+            } else if (state == kWSKHeaderBlockFailed) {
+                block(nil);
+            } else {
+                [self readHeaders:headersData withCompletionBlock:block];
             }
         }];
 }

--- a/Sources/WebServerKit/Core/WSKPrivate.h
+++ b/Sources/WebServerKit/Core/WSKPrivate.h
@@ -277,6 +277,7 @@ extern NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL include
 @property (nonatomic, readonly) BOOL shouldAutomaticallyMapHEADToGET;
 @property (nonatomic, readonly) dispatch_queue_priority_t dispatchQueuePriority;
 @property (nonatomic, readonly) NSTimeInterval connectionIdleTimeout;
+@property (nonatomic, readonly) NSTimeInterval connectionKeepAliveTimeout;
 - (void)willStartConnection:(WSKConnection *)connection;
 - (void)didEndConnection:(WSKConnection *)connection;
 @end

--- a/Sources/WebServerKit/Core/WSKWebServer.h
+++ b/Sources/WebServerKit/Core/WSKWebServer.h
@@ -249,6 +249,29 @@ extern NSString *const WSKOption_DispatchQueuePriority;
  */
 extern NSString *const WSKOption_ConnectionIdleTimeout;
 
+/**
+ *  Allows a connection to carry more than one request, so a client does not pay
+ *  a TCP handshake per request (NSNumber / double, in seconds). The value is how
+ *  long an otherwise idle connection is held open waiting for the next request.
+ *
+ *  Reuse is deliberately restricted to requests that carry NO BODY — no
+ *  "Content-Length" and no "Transfer-Encoding" header at all. Request smuggling
+ *  is a disagreement about where one request's body ends and the next begins, so
+ *  a connection on which no body is ever read cannot be desynchronized: the
+ *  property is structural rather than a matter of parsing carefully. Anything
+ *  with a body is answered and the connection is closed, exactly as before, as is
+ *  any request that was refused, any HTTP/1.0 client, and any response whose
+ *  length the server cannot state up front.
+ *
+ *  This matters most for an interface that fetches many small resources — icons,
+ *  thumbnails, stylesheets — where the handshake dominates the transfer.
+ *
+ *  Set to 0.0 to serve exactly one request per connection.
+ *
+ *  The default value is 0.0.
+ */
+extern NSString *const WSKOption_ConnectionKeepAliveTimeout;
+
 #if TARGET_OS_IPHONE
 
 /**

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -71,6 +71,7 @@ NSString *const WSKOption_AutomaticallyMapHEADToGET = @"AutomaticallyMapHEADToGE
 NSString *const WSKOption_ConnectedStateCoalescingInterval = @"ConnectedStateCoalescingInterval";
 NSString *const WSKOption_DispatchQueuePriority = @"DispatchQueuePriority";
 NSString *const WSKOption_ConnectionIdleTimeout = @"ConnectionIdleTimeout";
+NSString *const WSKOption_ConnectionKeepAliveTimeout = @"ConnectionKeepAliveTimeout";
 #if TARGET_OS_IPHONE
 NSString *const WSKOption_AutomaticallySuspendInBackground = @"AutomaticallySuspendInBackground";
 #endif
@@ -580,6 +581,7 @@ static NSString *_ValidateOptions(NSDictionary<NSString *, id> *options) {
         WSKOption_ConnectedStateCoalescingInterval: [NSNumber class],
         WSKOption_DispatchQueuePriority: [NSNumber class],
         WSKOption_ConnectionIdleTimeout: [NSNumber class],
+        WSKOption_ConnectionKeepAliveTimeout: [NSNumber class],
 #if TARGET_OS_IPHONE
         WSKOption_AutomaticallySuspendInBackground: [NSNumber class],
 #endif
@@ -859,6 +861,7 @@ static inline NSString *_EncodeBase64(NSString *string) {
     _disconnectDelay = [(NSNumber *)_GetOption(_options, WSKOption_ConnectedStateCoalescingInterval, @1.0) doubleValue];
     _dispatchQueuePriority = [(NSNumber *)_GetOption(_options, WSKOption_DispatchQueuePriority, @(DISPATCH_QUEUE_PRIORITY_DEFAULT)) longValue];
     _connectionIdleTimeout = [(NSNumber *)_GetOption(_options, WSKOption_ConnectionIdleTimeout, @30.0) doubleValue];
+    _connectionKeepAliveTimeout = [(NSNumber *)_GetOption(_options, WSKOption_ConnectionKeepAliveTimeout, @0.0) doubleValue];
 
     _source4 = [self _createDispatchSourceWithListeningSocket:listeningSocket4 isIPv6:NO];
     _source6 = [self _createDispatchSourceWithListeningSocket:listeningSocket6 isIPv6:YES];


### PR DESCRIPTION
A client has paid a TCP handshake per request since the beginning — every response carried `Connection: Close` and the connection served exactly one request. Fine for a few large downloads, wasteful for an interface fetching many small images.

`WSKOption_ConnectionKeepAliveTimeout` enables reuse and **defaults to 0** — one request per connection, exactly as today. This is new machinery in the most security-critical file in the library, and this project's measured rate is roughly one new defect per five closed. Flipping the default later is one line.

## The restriction is the design

Reuse is allowed only for requests carrying **no body framing at all**. Request smuggling is a disagreement about where one request's body ends and the next begins, so a connection on which no body is ever read cannot be desynchronized. The property stays **structural** — which is how CLAUDE.md justifies it today ("one request per connection, `Connection: Close`, leftover bytes never read") — rather than becoming a matter of parsing carefully.

Everything else answers and closes as before: a body of any kind, a refusal, HTTP/1.0, a client asking to close, a response whose length we can't state, a partial body write, and anything past `kMaxRequestsPerConnection`.

Eligibility reads the **raw header names**, not `-[WSKRequest hasBody]`, and that's load-bearing. `hasBody` keys on `_contentType` and is only equivalent to "has a body" because `-initWithMethod:` maintains the correspondence thirty lines away — and it is *not* equivalent for `Transfer-Encoding: identity`, which sets no content type, so `hasBody` answers **NO for a request that does carry transfer-coding framing**. That's exactly the shape a TE.CL desync is built from, and it would have been eligible. The test pins it.

## Three defects of my own, two found only by tests that discriminate

- **The `Connection: close` check refused everything.** It messaged `_request.headers[@"Connection"]`, and messaging nil returns a **zeroed struct** — so a missing header gave `{0, 0}` and `location != NSNotFound` was true. Reuse was refused for every request that didn't send the header, i.e. all of them. It failed *safe*, so nothing was unsafe; the feature simply never turned on, and the functional tests passed while it did nothing.
- **The idle branch never engaged.** It compared read+written bytes, so the response that had just gone out counted as "the next request has started arriving" — dropping straight back into the header-phase deadline. Found because the first reclaim test **passed with the whole branch removed**: it was measuring the pre-existing slowloris defence. The second test sets a keep-alive longer than that deadline and fails on both trees until fixed.
- **`_headerPhaseTicks` bled between phases**, charging a request for time the connection was legitimately idle and shortening its slowloris budget.

## Structure

`-readHeaders:` is split so the buffered block is settled *without* calling the completion, and the caller invokes it exactly once. Two reasons: a reused connection starts with the next request's bytes **already buffered**, and issuing a read there waits for bytes the client has no reason to send — a hang until the idle timeout. And folding the two together made the block's invocation correlate with a return value the analyzer can't relate, which it reported as both "never called" and "called twice" in one function.

`-_resetForNextRequest` clears every per-request field and sits next to the ivar block it mirrors — a field added there and forgotten here is a **cross-request state leak**, a defect class this connection could not previously have. The test drives a `HEAD` followed by a `GET` for that reason: an inherited `_virtualHEAD` would silently suppress the following response's body.

## Measured

Against the real implementation, not the earlier ceiling estimate:

```
one per connection:      0.515 ms/request   (400/400 served)
reused connection:       0.377 ms/request   (397/400 served)
  saved on loopback   :  0.137 ms/request (26.7%)
```

Loopback is where the handshake costs almost nothing; on a link with RTT *R* it adds ~*R* per request, which is the term that actually matters and which loopback cannot show. The 397/400 is the `kMaxRequestsPerConnection` cap re-establishing the connection and the harness skipping a request each time — the cap working, visible in the numbers.

## Verified

**154 tests, 0 failures**, all eight trace suites green, Release on macOS/iOS/tvOS, clean Debug on all three with zero warnings and an isolated `-derivedDataPath` each, forced-clean `swift build`.

The full suite was also run with the feature **off** before any test for it existed, to establish that the `-readHeaders:` refactor is behaviour-preserving on its own.