### PR TITLE
Request-body refusals answer their own status instead of a blanket 500

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -1323,7 +1323,9 @@ static BOOL gAbortRequestSawVirtualHEAD = NO;
 
     BOOL sawEOF = NO;
     NSString* reply = [[NSString alloc] initWithData:ReadToEOF(fd, &sawEOF) encoding:NSUTF8StringEncoding];
-    XCTAssertTrue(([reply containsString:@"500"] || [reply containsString:@"400"]), @"server did not reject unbounded chunk framing (reply: %@)", reply);
+    // Tightened from "500 or 400": the framing bound is a size limit, so 413 is what it owes, and
+    // that is now what it sends. The loose form was written when every body failure was 500.
+    XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 413"], @"server did not reject unbounded chunk framing with 413 (reply: %@)", reply);
     close(fd);
     [server stop];
 }
@@ -2984,6 +2986,93 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 
     [server stop];
     [fm removeItemAtPath:dir error:NULL];
+}
+
+// Every way a request body could be refused answered 500. The fixed-length and chunked readers
+// report failure as a plain BOOL, and every error they carried was `code:-1` distinguished only by
+// its localized description, so the connection had nothing to key on.
+//
+// 500 is a claim that the SERVER broke. It tells a client to retry something that can never succeed
+// (malformed chunk framing, a corrupt gzip stream) and makes it give up on something that could (a
+// momentarily exhausted budget). Each of these now answers what it owes.
+- (void)testRequestBodyRefusalsAnswerTheirOwnStatus {
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addHandlerForMethod:@"POST"
+                           path:@"/echo"
+                   requestClass:[WSKDataRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"OK"];
+                   }];
+    [server addHandlerForMethod:@"POST"
+                           path:@"/form"
+                   requestClass:[WSKMultiPartFormRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"OK"];
+                   }];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // A chunk-size line that is not a hex number at all. The client's framing is wrong, so 400.
+    NSString* badChunk = SendRawRequest(server.port, @"POST /echo HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/octet-stream\r\nTransfer-Encoding: chunked\r\n\r\nzz\r\nabcd\r\n0\r\n\r\n");
+    XCTAssertTrue([badChunk hasPrefix:@"HTTP/1.1 400"], @"a malformed chunk length is the client's error: %@", [badChunk substringToIndex:MIN((NSUInteger)40, badChunk.length)]);
+
+    // A gzip stream that satisfies its Content-Length but stops part-way through. Also the client's.
+    NSData* full = GZipCompress([NSMutableData dataWithLength:(64 * 1024)]);
+    XCTAssertGreaterThan(full.length, (NSUInteger)20);
+    NSData* prefix = [full subdataWithRange:NSMakeRange(0, 20)];
+    NSMutableData* truncated = [[[NSString stringWithFormat:@"POST /echo HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/octet-stream\r\nContent-Encoding: gzip\r\nContent-Length: %lu\r\n\r\n", (unsigned long)prefix.length] dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+    [truncated appendData:prefix];
+    NSString* truncatedReply = SendRawDataRequest(server.port, truncated);
+    XCTAssertTrue([truncatedReply hasPrefix:@"HTTP/1.1 400"], @"a truncated gzip body is the client's error: %@", [truncatedReply substringToIndex:MIN((NSUInteger)40, truncatedReply.length)]);
+
+    // A body larger than the in-memory cap is a size problem, so 413 — not "the server broke".
+    WSKSetMemoryLimitsForTesting(4 * 1024, 4 * 1024, 1024 * 1024);
+    [self addTeardownBlock:^{
+        WSKSetMemoryLimitsForTesting(0, 0, 0);
+    }];
+
+    NSMutableString* big = [NSMutableString string];
+
+    while (big.length < 32 * 1024) {
+        [big appendString:@"0123456789abcdef"];
+    }
+
+    NSString* oversized = SendRawRequest(server.port, [NSString stringWithFormat:@"POST /echo HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/octet-stream\r\nContent-Length: %lu\r\n\r\n%@", (unsigned long)big.length, big]);
+    XCTAssertTrue([oversized hasPrefix:@"HTTP/1.1 413"], @"an oversized body owes 413: %@", [oversized substringToIndex:MIN((NSUInteger)40, oversized.length)]);
+
+    // A chunk whose DATA is not followed by CRLF. A different branch from the bad size line above,
+    // seventeen lines away in the same loop, and it was the one left answering 500 — which is why
+    // both spellings are asserted rather than trusting that one covers the class.
+    NSString* badTerminator = SendRawRequest(server.port, @"POST /echo HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/octet-stream\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nabcdXX\r\n0\r\n\r\n");
+    XCTAssertTrue([badTerminator hasPrefix:@"HTTP/1.1 400"], @"a chunk not terminated by CRLF is the client's error: %@", [badTerminator substringToIndex:MIN((NSUInteger)40, badTerminator.length)]);
+
+    // A multipart body with no usable boundary fails in -open:, whose error both readers used to
+    // discard before aborting with a hardcoded 500.
+    NSString* noBoundary = SendRawRequest(server.port, @"POST /form HTTP/1.1\r\nHost: localhost\r\nContent-Type: multipart/form-data\r\nContent-Length: 4\r\n\r\nxxxx");
+    XCTAssertTrue([noBoundary hasPrefix:@"HTTP/1.1 400"], @"a multipart body with no boundary is malformed: %@", [noBoundary substringToIndex:MIN((NSUInteger)40, noBoundary.length)]);
+
+    // The multipart parser fails for seven unrelated reasons through one `return NO`. Coding them
+    // all as "malformed" — which the first version of this change did — turns a full disk and an
+    // exhausted budget into 400, the status that says NEVER SEND THIS AGAIN. It is the same
+    // mistake as answering 403 for ENOSPC, which this project fixed once already. A size cap must
+    // read as a size problem.
+    NSMutableString* part = [NSMutableString stringWithString:@"--B\r\nContent-Disposition: form-data; name=\"f\"\r\n\r\n"];
+
+    while (part.length < 32 * 1024) {
+        [part appendString:@"0123456789abcdef"];
+    }
+
+    [part appendString:@"\r\n--B--\r\n"];
+    NSString* oversizedPart = SendRawRequest(server.port, [NSString stringWithFormat:@"POST /form HTTP/1.1\r\nHost: localhost\r\nContent-Type: multipart/form-data; boundary=B\r\nContent-Length: %lu\r\n\r\n%@", (unsigned long)part.length, part]);
+    XCTAssertTrue([oversizedPart hasPrefix:@"HTTP/1.1 413"], @"a multipart body over the size cap owes 413, not a permanent 400: %@", [oversizedPart substringToIndex:MIN((NSUInteger)40, oversizedPart.length)]);
+
+    // And the half that must keep working: a body inside the cap is still served normally. A
+    // status-mapping change is exactly where an over-refusal would hide.
+    NSString* fine = SendRawRequest(server.port, @"POST /echo HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/octet-stream\r\nContent-Length: 5\r\n\r\nhello");
+    XCTAssertTrue([fine hasPrefix:@"HTTP/1.1 200"], @"an ordinary body is unaffected: %@", [fine substringToIndex:MIN((NSUInteger)40, fine.length)]);
+    XCTAssertTrue([fine hasSuffix:@"OK"], @"…and reaches the handler");
+
+    [server stop];
 }
 
 // Connection reuse, and the restriction that makes it safe. A client normally pays a TCP handshake

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -34,6 +34,7 @@
 #import <netinet/in.h>
 #import <sys/socket.h>
 #import <TargetConditionals.h>
+#import <zlib.h>  // Z_DATA_ERROR / Z_NEED_DICT, to tell the client's bad stream from our allocation failure
 #ifdef __WEBSERVERKIT_ENABLE_TESTING__
 #import <stdatomic.h>
 #endif
@@ -117,6 +118,7 @@ NS_ASSUME_NONNULL_END
     BOOL _clientIsHTTP10;          // The client spoke HTTP/1.0 (or older): no chunked framing, no interim 1xx
     BOOL _earlyChecksRun;          // Host allow-list and preflight are decided once, as early as the headers allow
     NSInteger _headerFailureStatus;  // Why the header block was rejected; 500 only if nothing more specific applies
+    NSInteger _bodyFailureStatus;    // Why the body was rejected; same idiom, because the body readers report only a BOOL
     NSTimeInterval _idleTimeout;   // Seconds between idle-timer ticks; 0 when idle timeouts are disabled
 
     // Connection reuse. Deliberately restricted to requests carrying NO body, which is what keeps
@@ -221,6 +223,60 @@ static CFStringRef _ReasonPhraseForStatusCode(NSInteger statusCode) {
         default:
             return NULL;  // CF's phrase is correct for this one.
     }
+}
+
+// What to tell a client whose request body we would not accept.
+//
+// Every failure here used to answer 500, because the fixed-length and chunked readers report
+// failure as a plain BOOL and the errors they carry were all `code:-1`. 500 is a claim that the
+// SERVER broke: it invites a retry of something that can never succeed (malformed chunk framing,
+// a corrupt gzip stream) and makes a client give up on something that could (a momentarily
+// exhausted budget). The codes exist so this can tell the truth.
+//
+// Only the zlib results that mean "the bytes you sent are not a valid stream" are the client's.
+// Z_DATA_ERROR and Z_NEED_DICT are; Z_MEM_ERROR is an allocation failure of OURS, and inflateInit2
+// reports through the same domain — so blanket-mapping this domain to 400 would tell a client its
+// request was malformed because the server ran out of memory.
+//
+// Anything unrecognised falls through to WSKServerErrorStatusCodeForError, which already maps a
+// full volume to 507 and everything else to 500, so the ENOSPC rule has ONE home rather than a
+// second copy here.
+static NSInteger _StatusForBodyError(NSError *error) {
+    if (error == nil) {
+        return kWSKHTTPStatusCode_InternalServerError;
+    }
+
+    if ([error.domain isEqualToString:kZlibErrorDomain]) {
+        if ((error.code == Z_DATA_ERROR) || (error.code == Z_NEED_DICT)) {
+            return kWSKHTTPStatusCode_BadRequest;
+        }
+
+        return kWSKHTTPStatusCode_InternalServerError;
+    }
+
+    if ([error.domain isEqualToString:kWSKErrorDomain]) {
+        WSKRequestBodyErrorCode const code = (WSKRequestBodyErrorCode)error.code;
+
+        if (code == kWSKRequestBodyError_Malformed) {
+            return kWSKHTTPStatusCode_BadRequest;
+        }
+
+        if (code == kWSKRequestBodyError_TooLarge) {
+            return kWSKHTTPStatusCode_RequestEntityTooLarge;
+        }
+
+        if (code == kWSKRequestBodyError_ServerAtCapacity) {
+            return kWSKHTTPStatusCode_ServiceUnavailable;
+        }
+    }
+
+    return WSKServerErrorStatusCodeForError(error);
+}
+
+// Records why the body was refused, for the abort that follows. Mirrors _headerFailureStatus:
+// the readers hand back a BOOL, so the reason has to be left where the abort can find it.
+- (void)_noteBodyFailure:(NSError *)error {
+    _bodyFailureStatus = _StatusForBodyError(error);
 }
 
 - (void)_initializeResponseHeadersWithStatusCode:(NSInteger)statusCode {
@@ -478,6 +534,8 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
     _willKeepAlive = NO;
     _clientIsHTTP10 = NO;
     _headerFailureStatus = kWSKHTTPStatusCode_InternalServerError;
+    _bodyFailureStatus = kWSKHTTPStatusCode_InternalServerError;
+    _chunkReservation = nil;  // Named in the reuse ivar block, so it is cleared here like the rest
     _headerPhaseTicks = 0;  // Or the second request inherits the first's deadline and is killed early.
 
 #ifdef __WEBSERVERKIT_ENABLE_TESTING__
@@ -650,19 +708,29 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
 
     if (![_request performOpen:&error]) {
         WSK_LOG_ERROR(@"Failed opening request body for socket %i: %@", _socket, error);
-        [self abortRequest:_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
+        // The error was populated and thrown away. It carries real information: a multipart body
+        // with no usable boundary is malformed (400), and an open(2) that fails ENOSPC is a full
+        // volume (507) — the same errno the very next call would have mapped correctly.
+        [self _noteBodyFailure:error];
+        [self abortRequest:_request withStatusCode:_bodyFailureStatus];
         return;
     }
 
     if (initialData.length) {
         if (![_request performWriteData:initialData error:&error]) {
             WSK_LOG_ERROR(@"Failed writing request body on socket %i: %@", _socket, error);
+            [self _noteBodyFailure:error];
+            NSError *closeError = nil;
 
-            if (![_request performClose:&error]) {
-                WSK_LOG_ERROR(@"Failed closing request body for socket %i: %@", _socket, error);
+            if (![_request performClose:&closeError]) {
+                // Deliberately does not overwrite the reason: the write failure is why the
+                // request is being refused, and closing a body that already failed to write is
+                // expected to fail too. Reusing one `error` variable here meant the close's
+                // error replaced the write's before anything could read it.
+                WSK_LOG_ERROR(@"Failed closing request body for socket %i: %@", _socket, closeError);
             }
 
-            [self abortRequest:_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
+            [self abortRequest:_request withStatusCode:_bodyFailureStatus];
             return;
         }
 
@@ -679,7 +747,7 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
                                   // chunk framing was malformed, or a size cap rejected it. Don't
                                   // hand the handler a partial body as if it were complete.
                                   [self->_request performClose:NULL];
-                                  [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
+                                  [self abortRequest:self->_request withStatusCode:self->_bodyFailureStatus];
                                   return;
                               }
 
@@ -687,7 +755,8 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
                                   [self _startProcessingRequest];
                               } else {
                                   WSK_LOG_ERROR(@"Failed closing request body for socket %i: %@", self->_socket, localError);
-                                  [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
+                                  [self _noteBodyFailure:localError];
+                                  [self abortRequest:self->_request withStatusCode:self->_bodyFailureStatus];
                               }
                           }];
     } else {
@@ -695,7 +764,8 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
             [self _startProcessingRequest];
         } else {
             WSK_LOG_ERROR(@"Failed closing request body for socket %i: %@", _socket, error);
-            [self abortRequest:_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
+            [self _noteBodyFailure:error];
+            [self abortRequest:_request withStatusCode:_bodyFailureStatus];
         }
     }
 }
@@ -705,7 +775,8 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
 
     if (![_request performOpen:&error]) {
         WSK_LOG_ERROR(@"Failed opening request body for socket %i: %@", _socket, error);
-        [self abortRequest:_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
+        [self _noteBodyFailure:error];
+        [self abortRequest:_request withStatusCode:_bodyFailureStatus];
         return;
     }
 
@@ -720,7 +791,7 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
                     // framing was malformed, or a size cap rejected it. Don't hand the
                     // handler a partial body as if it were complete.
                     [self->_request performClose:NULL];
-                    [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
+                    [self abortRequest:self->_request withStatusCode:self->_bodyFailureStatus];
                     return;
                 }
 
@@ -728,7 +799,8 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
                     [self _startProcessingRequest];
                 } else {
                     WSK_LOG_ERROR(@"Failed closing request body for socket %i: %@", self->_socket, localError);
-                    [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
+                    [self _noteBodyFailure:localError];
+                    [self abortRequest:self->_request withStatusCode:self->_bodyFailureStatus];
                 }
             }];
 }
@@ -1015,6 +1087,7 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
         _socket = socket;
         _connectionQueue = dispatch_queue_create("gcdwebserver.connection", DISPATCH_QUEUE_SERIAL);
         _headerFailureStatus = kWSKHTTPStatusCode_InternalServerError;
+        _bodyFailureStatus = kWSKHTTPStatusCode_InternalServerError;
         WSK_LOG_DEBUG(@"Did open connection on socket %i", _socket);
 
         _keepAliveTimeout = server.connectionKeepAliveTimeout;
@@ -1391,10 +1464,12 @@ typedef NS_ENUM(NSInteger, WSKHeaderBlockState) {
                         }
                     } else {
                         WSK_LOG_ERROR(@"Failed writing request body on socket %i: %@", self->_socket, error);
+                        [self _noteBodyFailure:error];
                         block(NO);
                     }
                 } else {
                     WSK_LOG_ERROR(@"Unexpected extra content reading request body on socket %i", self->_socket);
+                    self->_bodyFailureStatus = kWSKHTTPStatusCode_BadRequest;
                     block(NO);
                     WSK_DNOT_REACHED();
                 }
@@ -1474,6 +1549,7 @@ static inline NSUInteger _ScanHexNumber(const void *bytes, NSUInteger size) {
                     // cap its declared size. Legitimate chunked uploads use many smaller
                     // chunks; this only rejects a pathologically large single chunk.
                     WSK_LOG_ERROR(@"Chunk size %lu exceeds the %lu byte limit reading request body on socket %i", (unsigned long)length, (unsigned long)WSKMaxInMemoryBodyLength(), _socket);
+                    _bodyFailureStatus = kWSKHTTPStatusCode_RequestEntityTooLarge;
                     block(NO);
                     return;
                 }
@@ -1491,11 +1567,13 @@ static inline NSUInteger _ScanHexNumber(const void *bytes, NSUInteger size) {
                         [chunkData replaceBytesInRange:NSMakeRange(0, range.location + range.length + length + 2) withBytes:NULL length:0];
                     } else {
                         WSK_LOG_ERROR(@"Failed writing request body on socket %i: %@", _socket, error);
+                        [self _noteBodyFailure:error];
                         block(NO);
                         return;
                     }
                 } else {
                     WSK_LOG_ERROR(@"Missing terminating CRLF sequence for chunk reading request body on socket %i", _socket);
+                    _bodyFailureStatus = kWSKHTTPStatusCode_BadRequest;
                     block(NO);
                     return;
                 }
@@ -1512,6 +1590,7 @@ static inline NSUInteger _ScanHexNumber(const void *bytes, NSUInteger size) {
             }
         } else {
             WSK_LOG_ERROR(@"Invalid chunk length reading request body on socket %i", _socket);
+            _bodyFailureStatus = kWSKHTTPStatusCode_BadRequest;
             block(NO);
             return;
         }
@@ -1526,6 +1605,7 @@ static inline NSUInteger _ScanHexNumber(const void *bytes, NSUInteger size) {
     // plus framing slack: a legitimate in-flight chunk needs at most that much buffered.
     if (chunkData.length > WSKMaxInMemoryBodyLength() + kHeadersMaxLength) {
         WSK_LOG_ERROR(@"Chunked transfer framing exceeds the buffer limit reading request body on socket %i", _socket);
+        _bodyFailureStatus = kWSKHTTPStatusCode_RequestEntityTooLarge;
         block(NO);
         return;
     }
@@ -1535,6 +1615,7 @@ static inline NSUInteger _ScanHexNumber(const void *bytes, NSUInteger size) {
     // process-wide ceiling too, and give bytes back as the parser drains them.
     if (![_chunkReservation reserveBytes:chunkData.length]) {
         WSK_LOG_ERROR(@"Refusing chunked body on socket %i: the server is already holding its %lu byte in-memory limit across all connections", _socket, (unsigned long)kWSKMaxTotalInMemoryLength);
+        _bodyFailureStatus = kWSKHTTPStatusCode_ServiceUnavailable;
         block(NO);
         return;
     }

--- a/Sources/WebServerKit/Core/WSKPrivate.h
+++ b/Sources/WebServerKit/Core/WSKPrivate.h
@@ -208,6 +208,28 @@ NS_ASSUME_NONNULL_BEGIN
 #define kWSKServerName @"WebServerKit"
 #define kWSKErrorDomain @"WSKErrorDomain"
 
+// Was #defined identically in WSKRequest.m and WSKResponse.m; the connection now needs it too, to
+// tell a zlib failure (the client's data) from one of ours.
+#define kZlibErrorDomain @"ZlibErrorDomain"
+
+/**
+ *  Why a request body could not be accepted.
+ *
+ *  Every error in this domain used to be `code:-1`, distinguished only by its localized
+ *  description — so the connection layer had nothing to key on and answered 500 for all of them.
+ *  A client told 500 has been told the SERVER broke, which invites a retry of something that can
+ *  never succeed (malformed framing), or gives up on something that could (a full disk, a
+ *  momentarily exhausted budget). These codes exist so the status can tell the truth; the
+ *  description stays for the log.
+ */
+typedef NS_ENUM(NSInteger, WSKRequestBodyErrorCode) {
+    kWSKRequestBodyError_Unspecified = -1,     // What every one of these errors used to be
+    kWSKRequestBodyError_Malformed = 1,        // The client's framing or encoding is wrong -> 400
+    kWSKRequestBodyError_TooLarge,             // A per-request size cap was exceeded -> 413
+    kWSKRequestBodyError_ServerAtCapacity,     // The process-wide in-memory ceiling is full -> 503
+    kWSKRequestBodyError_Internal,             // Ours, not the client's -> 500
+};
+
 static inline BOOL WSKIsValidByteRange(NSRange range) {
     return ((range.location != NSUIntegerMax) || (range.length > 0));
 }

--- a/Sources/WebServerKit/Core/WSKRequest.m
+++ b/Sources/WebServerKit/Core/WSKRequest.m
@@ -35,7 +35,6 @@
 
 NSString *const WSKRequestAttribute_RegexCaptures = @"WSKRequestAttribute_RegexCaptures";
 
-#define kZlibErrorDomain @"ZlibErrorDomain"
 #define kGZipInitialBufferSize (256 * 1024)
 
 @interface WSKBodyDecoder : NSObject <WSKBodyWriter>
@@ -110,7 +109,7 @@ NSString *const WSKRequestAttribute_RegexCaptures = @"WSKRequestAttribute_RegexC
             WSK_LOG_ERROR(@"Trailing data after the end of the gzip request body");
 
             if (error) {
-                *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Trailing data after end of gzip request body"}];
+                *error = [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_Malformed userInfo:@{NSLocalizedDescriptionKey: @"Trailing data after end of gzip request body"}];
             }
 
             return NO;
@@ -135,7 +134,7 @@ NSString *const WSKRequestAttribute_RegexCaptures = @"WSKRequestAttribute_RegexC
         WSK_LOG_ERROR(@"Refusing to inflate: the server is already holding its %lu byte in-memory limit across all connections", (unsigned long)kWSKMaxTotalInMemoryLength);
 
         if (error) {
-            *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Server is at its total in-memory capacity"}];
+            *error = [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_ServerAtCapacity userInfo:@{NSLocalizedDescriptionKey: @"Server is at its total in-memory capacity"}];
         }
 
         return NO;
@@ -167,7 +166,7 @@ NSString *const WSKRequestAttribute_RegexCaptures = @"WSKRequestAttribute_RegexC
             WSK_LOG_ERROR(@"Decompressed request body exceeds the %lu byte limit", (unsigned long)WSKMaxDecompressedBodyLength());
 
             if (error) {
-                *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Decompressed request body exceeds maximum size"}];
+                *error = [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_TooLarge userInfo:@{NSLocalizedDescriptionKey: @"Decompressed request body exceeds maximum size"}];
             }
 
             return NO;
@@ -194,7 +193,7 @@ NSString *const WSKRequestAttribute_RegexCaptures = @"WSKRequestAttribute_RegexC
                     WSK_LOG_ERROR(@"Trailing data after the end of the gzip request body");
 
                     if (error) {
-                        *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Trailing data after end of gzip request body"}];
+                        *error = [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_Malformed userInfo:@{NSLocalizedDescriptionKey: @"Trailing data after end of gzip request body"}];
                     }
 
                     return NO;
@@ -222,7 +221,7 @@ NSString *const WSKRequestAttribute_RegexCaptures = @"WSKRequestAttribute_RegexC
             WSK_LOG_ERROR(@"Refusing to inflate further: the server is already holding its %lu byte in-memory limit across all connections", (unsigned long)kWSKMaxTotalInMemoryLength);
 
             if (error) {
-                *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Server is at its total in-memory capacity"}];
+                *error = [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_ServerAtCapacity userInfo:@{NSLocalizedDescriptionKey: @"Server is at its total in-memory capacity"}];
             }
 
             return NO;
@@ -258,7 +257,7 @@ NSString *const WSKRequestAttribute_RegexCaptures = @"WSKRequestAttribute_RegexC
         [super close:NULL];
 
         if (error) {
-            *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Truncated gzip request body"}];
+            *error = [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_Malformed userInfo:@{NSLocalizedDescriptionKey: @"Truncated gzip request body"}];
         }
 
         return NO;

--- a/Sources/WebServerKit/Core/WSKResponse.m
+++ b/Sources/WebServerKit/Core/WSKResponse.m
@@ -33,7 +33,6 @@
 
 #import "WSKPrivate.h"
 
-#define kZlibErrorDomain @"ZlibErrorDomain"
 #define kGZipInitialBufferSize (256 * 1024)
 
 @interface WSKBodyEncoder : NSObject <WSKBodyReader>

--- a/Sources/WebServerKit/Requests/WSKDataRequest.m
+++ b/Sources/WebServerKit/Requests/WSKDataRequest.m
@@ -56,7 +56,7 @@
 
     if (_data == nil) {
         if (error) {
-            *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed allocating memory"}];
+            *error = [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_Internal userInfo:@{NSLocalizedDescriptionKey: @"Failed allocating memory"}];
         }
 
         return NO;
@@ -72,7 +72,7 @@
         WSK_LOG_ERROR(@"Request body exceeds the %lu byte in-memory limit", (unsigned long)WSKMaxInMemoryBodyLength());
 
         if (error) {
-            *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Request body exceeds maximum in-memory size"}];
+            *error = [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_TooLarge userInfo:@{NSLocalizedDescriptionKey: @"Request body exceeds maximum in-memory size"}];
         }
 
         return NO;
@@ -84,7 +84,7 @@
         WSK_LOG_ERROR(@"Refusing request body: the server is already holding its %lu byte in-memory limit across all connections", (unsigned long)kWSKMaxTotalInMemoryLength);
 
         if (error) {
-            *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Server is at its total in-memory capacity"}];
+            *error = [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_ServerAtCapacity userInfo:@{NSLocalizedDescriptionKey: @"Server is at its total in-memory capacity"}];
         }
 
         return NO;

--- a/Sources/WebServerKit/Requests/WSKMultiPartFormRequest.m
+++ b/Sources/WebServerKit/Requests/WSKMultiPartFormRequest.m
@@ -88,6 +88,14 @@ typedef enum {
 } ParserState;
 
 @interface WSKMIMEStreamParser : NSObject
+// Why the last -appendBytes:length: or -close returned NO.
+//
+// The parser fails for seven unrelated reasons and used to report all of them as a bare NO, so the
+// request could only guess — and guessing "the client's data is malformed" turns a full temp
+// directory and a momentarily exhausted budget into 400, which tells a client never to try again.
+// That is the same mistake as answering 403 for ENOSPC, which this project fixed once already.
+@property (nonatomic, readonly) WSKRequestBodyErrorCode failureCode;
+@property (nonatomic, readonly, nullable) NSError *failureError;  // Set instead when an errno is the truth (a full disk)
 @end
 
 static NSData *_newlineData = nil;
@@ -167,6 +175,21 @@ static NSData *_dashNewlineData = nil;
     NSUInteger _depth;  // Nesting level; 0 for the top-level parser, +1 per multipart/mixed
     WSKMIMEStreamBudget *_budget;              // Shared with every sub-parser
     WSKMemoryReservation *_workingReservation;  // This parser's own working buffer
+    WSKRequestBodyErrorCode _failureCode;
+    NSError *_failureError;
+}
+
+// A sub-parser's failure is the whole body's failure, so the reason has to travel up with it.
+- (WSKRequestBodyErrorCode)failureCode {
+    if (_subParser && (_subParser.failureCode != kWSKRequestBodyError_Malformed)) {
+        return _subParser.failureCode;
+    }
+
+    return _failureCode ? _failureCode : kWSKRequestBodyError_Malformed;
+}
+
+- (NSError *)failureError {
+    return _failureError ? _failureError : _subParser.failureError;
 }
 
 + (void)initialize {
@@ -256,6 +279,7 @@ static NSData *_dashNewlineData = nil;
             // budget still reads zero. Real part headers are a few hundred bytes.
             if (range.location > kMultiPartMaxHeadersLength) {
                 WSK_LOG_ERROR(@"Headers of a part of 'multipart/form-data' exceed the %i byte limit", (int)kMultiPartMaxHeadersLength);
+                _failureCode = kWSKRequestBodyError_TooLarge;
                 return NO;
             }
 
@@ -321,6 +345,10 @@ static NSData *_dashNewlineData = nil;
                         // A full or unwritable temporary directory is an environment condition
                         // rather than an unreachable state.
                         WSK_LOG_ERROR(@"Failed creating temporary file for part of 'multipart/form-data': %s (%i)", strerror(errno), errno);
+                        // The environment, not the client. Carrying the errno is what lets a full
+                        // volume reach WSKServerErrorStatusCodeForError's 507 rather than being
+                        // reported as malformed input the client must never send again.
+                        _failureError = WSKMakePosixError(errno);
                         success = NO;
                     }
                 }
@@ -366,6 +394,7 @@ static NSData *_dashNewlineData = nil;
                         _subParser = nil;
                     } else if (_budget->partCount >= kMultiPartMaxParts) {
                         WSK_LOG_ERROR(@"'multipart/form-data' body exceeds the %i part limit", (int)kMultiPartMaxParts);
+                        _failureCode = kWSKRequestBodyError_TooLarge;
                         success = NO;
 
                         if (_tmpPath) {  // Drop the part already staged on disk rather than orphaning it
@@ -388,6 +417,7 @@ static NSData *_dashNewlineData = nil;
                             // environment condition, not an unreachable state, so fail the parse
                             // rather than abort in debug.
                             WSK_LOG_ERROR(@"Failed writing part of 'multipart/form-data' to disk");
+                            _failureError = WSKMakePosixError(errno ? errno : ENOSPC);
                             success = NO;
                             unlink([_tmpPath fileSystemRepresentation]);  // Remove the orphaned temp file; -dealloc can't (we clear _tmpPath below).
                         }
@@ -399,9 +429,11 @@ static NSData *_dashNewlineData = nil;
                         // individually-legal parts would otherwise grow without limit. File parts
                         // are drained to disk and so are governed by the part count instead.
                         WSK_LOG_ERROR(@"Multipart form arguments retained in memory exceed the %lu byte limit", (unsigned long)WSKMaxInMemoryBodyLength());
+                        _failureCode = kWSKRequestBodyError_TooLarge;
                         success = NO;
                     } else if (![_budget.reservation reserveBytes:(_budget->argumentBytes + dataLength)]) {
                         WSK_LOG_ERROR(@"Refusing multipart argument: the server is already holding its %lu byte in-memory limit across all connections", (unsigned long)kWSKMaxTotalInMemoryLength);
+                        _failureCode = kWSKRequestBodyError_ServerAtCapacity;
                         success = NO;
                     } else {
                         _budget->partCount += 1;
@@ -442,6 +474,7 @@ static NSData *_dashNewlineData = nil;
                     } else {
                         // As above: a short write means the temporary directory filled up.
                         WSK_LOG_ERROR(@"Failed streaming part of 'multipart/form-data' to disk: %s (%i)", strerror(errno), errno);
+                        _failureError = WSKMakePosixError(errno);
                         success = NO;
                     }
                 }
@@ -462,11 +495,13 @@ static NSData *_dashNewlineData = nil;
     // buffer without bound).
     if (_data.length + length > WSKMaxInMemoryBodyLength()) {
         WSK_LOG_ERROR(@"Multipart form data buffered in memory exceeds the %lu byte limit", (unsigned long)WSKMaxInMemoryBodyLength());
+        _failureCode = kWSKRequestBodyError_TooLarge;
         return NO;
     }
 
     if (![_workingReservation reserveBytes:(_data.length + length)]) {
         WSK_LOG_ERROR(@"Refusing multipart data: the server is already holding its %lu byte in-memory limit across all connections", (unsigned long)kWSKMaxTotalInMemoryLength);
+        _failureCode = kWSKRequestBodyError_ServerAtCapacity;
         return NO;
     }
 
@@ -506,6 +541,28 @@ static NSData *_dashNewlineData = nil;
     return self;
 }
 
+// Builds the error from the parser's own verdict rather than assuming the client's data was
+// malformed. Seven unrelated conditions come out of -appendBytes: as a bare NO — two per-request
+// size caps, two process-wide reservations, a part-count cap, a header cap, and a temp file that
+// could not be written. Reporting the last three as 400 tells a client never to retry something a
+// little free disk space or a moment's wait would fix.
+- (NSError *)_errorForParserFailure:(NSString *)description {
+    if (_parser == nil) {
+        // No parser to ask: either the boundary parameter was missing or unusable, or the body
+        // ended mid-part. Both are the client's data. Stated explicitly because messaging a nil
+        // parser would return a ZEROED code that matches no case and silently degrade to 500.
+        return [NSError errorWithDomain:kWSKErrorDomain code:kWSKRequestBodyError_Malformed userInfo:@{NSLocalizedDescriptionKey: description}];
+    }
+
+    NSError *const underlying = _parser.failureError;
+
+    if (underlying) {
+        return underlying;  // An errno is the truth; WSKServerErrorStatusCodeForError maps a full volume to 507.
+    }
+
+    return [NSError errorWithDomain:kWSKErrorDomain code:_parser.failureCode userInfo:@{NSLocalizedDescriptionKey: description}];
+}
+
 - (BOOL)open:(NSError **)error {
     NSString *const boundary = WSKExtractHeaderValueParameter(self.contentType, @"boundary");
 
@@ -513,7 +570,7 @@ static NSData *_dashNewlineData = nil;
 
     if (_parser == nil) {
         if (error) {
-            *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed starting to parse multipart form data"}];
+            *error = [self _errorForParserFailure:@"Failed starting to parse multipart form data"];
         }
 
         return NO;
@@ -525,7 +582,7 @@ static NSData *_dashNewlineData = nil;
 - (BOOL)writeData:(NSData *)data error:(NSError **)error {
     if (![_parser appendBytes:data.bytes length:data.length]) {
         if (error) {
-            *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed continuing to parse multipart form data"}];
+            *error = [self _errorForParserFailure:@"Failed continuing to parse multipart form data"];
         }
 
         return NO;
@@ -535,17 +592,23 @@ static NSData *_dashNewlineData = nil;
 }
 
 - (BOOL)close:(NSError **)error {
-    BOOL atEnd = [_parser isAtEnd];
-
-    _parser = nil;
+    BOOL const atEnd = [_parser isAtEnd];
 
     if (!atEnd) {
+        // Built BEFORE _parser is released: it is the only thing that knows why. Releasing first
+        // left the helper messaging nil and reporting every truncated body as generically
+        // malformed, losing a disk-full or capacity reason recorded during the parse.
+        NSError *const failure = [self _errorForParserFailure:@"Failed finishing to parse multipart form data"];
+        _parser = nil;
+
         if (error) {
-            *error = [NSError errorWithDomain:kWSKErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed finishing to parse multipart form data"}];
+            *error = failure;
         }
 
         return NO;
     }
+
+    _parser = nil;
 
     return YES;
 }


### PR DESCRIPTION
The last substantial finding from the outside audit. Every way a request body could be refused answered **500** — the fixed-length and chunked readers report failure as a plain `BOOL`, and every `NSError` they carried was `code:-1` distinguished only by its localized description, so the connection layer had nothing to key on.

500 is a claim that the *server* broke. It invites a retry of something that can never succeed (malformed framing, a corrupt gzip stream) and makes a client give up on something that could (a full disk, a momentarily exhausted budget).

Measured before — all 500:

| refusal | was | now |
|---|---|---|
| malformed chunk size line | 500 | **400** |
| chunk data not followed by CRLF | 500 | **400** |
| truncated gzip stream | 500 | **400** |
| multipart with no usable boundary | 500 | **400** |
| body over the per-request cap | 500 | **413** |
| chunk framing over the bound | 500 | **413** |
| multipart over a size cap | 500 | **413** |
| process-wide budget exhausted | 500 | **503** |
| full volume while spooling | 500 | **507** |

The mechanism is deliberately **not** a new one: `_bodyFailureStatus` mirrors the `_headerFailureStatus` idiom already in this file. And `_StatusForBodyError` falls through to the existing `WSKServerErrorStatusCodeForError`, so the ENOSPC→507 rule keeps **one home** rather than gaining a second copy.

## ⚠️ The first version made things worse

A completeness sweep caught it. The multipart parser fails for **seven unrelated reasons** through a single `return NO` — two per-request size caps, two process-wide reservations, a part-count cap, a header cap, and a temp file that couldn't be written. Coding them all as "malformed" turned **a full disk and an exhausted budget into 400** — the status that says *never send this again*.

That is precisely the mistake batch B fixed when ENOSPC answered 403, reintroduced at a different verb. The parser now reports *why* it failed, and the disk cases carry their `errno` so a full volume reaches 507.

This is the project's ~1-new-defect-per-5 rate showing up exactly where the fix touched — which is where it always shows up.

## Three more sites, all the same shape

- **"Chunk data not followed by CRLF"** was the one malformed-framing branch left answering 500 — *seventeen lines* from the sibling that was fixed. The test asserts **both** spellings rather than trusting one covers the class.
- **Both readers discarded `performOpen:`'s error** and aborted with a hardcoded 500, so a multipart body with no boundary could never reach the mapping, and an `open(2)` failing ENOSPC answered 500 while the identical errno one call later answered 507.
- **`close:` released the parser *before* building the error**, so the helper messaged nil and reported every truncated body as generically malformed — the same nil-returns-zero shape as the keep-alive `Connection` header bug two PRs ago.

## zlib is no longer blanket-mapped

Only `Z_DATA_ERROR` and `Z_NEED_DICT` mean "the bytes you sent are not a valid stream". `Z_MEM_ERROR` is an allocation failure of **ours**, and `inflateInit2` reports through the same domain — so the blanket rule would have told a client its request was malformed because the server ran out of memory.

`kZlibErrorDomain` was `#define`d identically in two files and needed in a third, so it moved to `WSKPrivate.h` rather than becoming a third copy.

## One existing test tightened, not widened

`testChunkedTransferRejectsUnterminatedSizeLine` asserted `500 || 400` — a deliberately loose bound written when every body failure was 500. A size bound owes a size status, so it now requires **413**.

## Verification

The new test fails **3/3** against the unfixed tree on the intended assertions, and the multipart assertion was proved sensitive by removing the cause-threading and watching it fail.

**155 tests, 0 failures**, all eight trace suites green, Release on macOS/iOS/tvOS, clean Debug on all three with zero warnings and isolated `-derivedDataPath` each, forced-clean `swift build`.

## Deliberately not here

The 503 carries no `Retry-After` (RFC 9110 §15.6.4 says SHOULD; `abortRequest:` has no mechanism to add one), and a client that disconnects mid-body still gets a manufactured 500 rather than a bare close — **not observable from a client that has already gone**, so it can't be tested and was left alone.