### PR TITLE
The audit tail: honest statuses for unmatched requests, a real Accept-Encoding parse, index containment, and the foreground restart's other site

### DIFF
--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -2988,6 +2988,113 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// An unmatched request always answered 501 Not Implemented — a statement about the METHOD — even
+// when the method was one the server implements perfectly well and only the target was unknown. A
+// browser asking for /favicon.ico was told the server does not implement GET. 501 is also
+// heuristically cacheable (RFC 9111 §4.2.2), so an intermediary may remember it for a path that
+// later gains a handler.
+//
+// The distinction the server CAN make is "does any handler claim this method". The one it cannot
+// is "which methods does this path accept", which is what a 405 with Allow would need — a handler
+// is an opaque match block. So 405 is deliberately not attempted, and this test pins the two
+// answers that are honest rather than a third that would be guessed.
+- (void)testUnmatchedRequestDistinguishesUnknownTargetFromUnimplementedMethod {
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addHandlerForMethod:@"GET"
+                           path:@"/ok"
+                   requestClass:[WSKRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"ok"];
+                   }];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // GET is implemented, so an unknown target is 404 — not "this server does not do GET".
+    NSString* unknownTarget = SendRawRequest(server.port, @"GET /nope HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([unknownTarget hasPrefix:@"HTTP/1.1 404"], @"an unknown target under an implemented method is 404: %@", [unknownTarget substringToIndex:MIN((NSUInteger)40, unknownTarget.length)]);
+
+    // A method NO handler claims is genuinely not implemented, and 501 still says so.
+    NSString* unknownMethod = SendRawRequest(server.port, @"PROPFIND /ok HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n");
+    XCTAssertTrue([unknownMethod hasPrefix:@"HTTP/1.1 501"], @"a method no handler claims is still 501: %@", [unknownMethod substringToIndex:MIN((NSUInteger)40, unknownMethod.length)]);
+
+    // A HEAD is rewritten to GET before matching, so it inherits GET's implemented-ness.
+    NSString* head = SendRawRequest(server.port, @"HEAD /nope HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([head hasPrefix:@"HTTP/1.1 404"], @"a mapped HEAD follows GET: %@", [head substringToIndex:MIN((NSUInteger)40, head.length)]);
+
+    // And the handler that does exist is untouched.
+    XCTAssertTrue([SendRawRequest(server.port, @"GET /ok HTTP/1.1\r\nHost: localhost\r\n\r\n") hasPrefix:@"HTTP/1.1 200"], @"the registered handler still serves");
+
+    [server stop];
+}
+
+// "Accept-Encoding" was matched with a case-sensitive SUBSTRING search for "gzip", so a client that
+// wrote "gzip;q=0" — explicitly refusing it — was recorded as accepting, "GZIP" and "*" were
+// recorded as refusing, and any token merely containing the letters counted. The property is
+// public API that a host app is invited to gate compression on, so it has to mean what it says.
+- (void)testAcceptEncodingIsParsedAsTokensWithQualityValues {
+    NSDictionary<NSString*, NSNumber*>* const cases = @{
+        @"gzip" : @YES,
+        @"GZIP" : @YES,             // Tokens are case-insensitive
+        @"x-gzip" : @YES,           // RFC 9110 §8.4.1 synonym
+        @"*" : @YES,                // A wildcard permits it
+        @"deflate, gzip" : @YES,
+        @"gzip;q=0.5" : @YES,
+        @"gzip;q=0" : @NO,          // Explicitly not acceptable
+        @"gzip;q=0.0" : @NO,
+        @"*;q=0" : @NO,
+        @"deflate" : @NO,
+        @"xgzipy" : @NO,            // Not a gzip token at all
+        @"identity" : @NO,
+    };
+
+    for (NSString* header in cases) {
+        WSKRequest* request = [[WSKRequest alloc] initWithMethod:@"GET"
+                                                             url:[NSURL URLWithString:@"http://localhost/"]
+                                                         headers:@{@"Accept-Encoding" : header}
+                                                            path:@"/"
+                                                           query:@{}];
+        XCTAssertNotNil(request, @"header %@ should still build a request", header);
+        XCTAssertEqual(request.acceptsGzipContentEncoding, cases[header].boolValue, @"Accept-Encoding: %@", header);
+    }
+
+    // No header at all is not an acceptance.
+    WSKRequest* bare = [[WSKRequest alloc] initWithMethod:@"GET" url:[NSURL URLWithString:@"http://localhost/"] headers:@{} path:@"/" query:@{}];
+    XCTAssertFalse(bare.acceptsGzipContentEncoding, @"an absent Accept-Encoding is not an acceptance");
+}
+
+// The base-path handler resolves the requested directory and enforces containment on the result,
+// then appended the caller's indexFilename to it and served that WITHOUT resolving again — so a
+// name containing a separator or ".." escaped the served root, since -attributesOfItemAtPath:
+// follows intermediate components and WSKFileResponse's O_NOFOLLOW guards only the final one.
+// Host-app configuration rather than client input, but the header states the guarantee flatly.
+- (void)testIndexFilenameCannotEscapeTheServedDirectory {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* root = MakeTempDirectory();
+    NSString* served = [root stringByAppendingPathComponent:@"served"];
+    XCTAssertTrue([fm createDirectoryAtPath:served withIntermediateDirectories:YES attributes:nil error:NULL]);
+    XCTAssertTrue([@"INSIDE" writeToFile:[served stringByAppendingPathComponent:@"index.html"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([@"SECRET" writeToFile:[root stringByAppendingPathComponent:@"outside.html"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+
+    // An escaping index name must not be served, and the directory listing stands in for it.
+    WSKWebServer* escaping = [[WSKWebServer alloc] init];
+    [escaping addGETHandlerForBasePath:@"/f/" directoryPath:served indexFilename:@"../outside.html" cacheAge:0 allowRangeRequests:NO];
+    XCTAssertTrue([escaping startWithOptions:options error:NULL]);
+    NSString* escaped = SendRawRequest(escaping.port, @"GET /f/ HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertFalse([escaped containsString:@"SECRET"], @"an index filename must not reach outside the served directory: %@", escaped);
+    [escaping stop];
+
+    // And the ordinary case must keep working — this is where an over-refusal would hide.
+    WSKWebServer* ordinary = [[WSKWebServer alloc] init];
+    [ordinary addGETHandlerForBasePath:@"/f/" directoryPath:served indexFilename:@"index.html" cacheAge:0 allowRangeRequests:NO];
+    XCTAssertTrue([ordinary startWithOptions:options error:NULL]);
+    XCTAssertTrue([SendRawRequest(ordinary.port, @"GET /f/ HTTP/1.1\r\nHost: localhost\r\n\r\n") containsString:@"INSIDE"], @"an ordinary index file is still served");
+    [ordinary stop];
+
+    [fm removeItemAtPath:root error:NULL];
+}
+
 // Every way a request body could be refused answered 500. The fixed-length and chunked readers
 // report failure as a plain BOOL, and every error they carried was `code:-1` distinguished only by
 // its localized description, so the connection had nothing to key on.
@@ -3775,7 +3882,11 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
     // HEAD, so the method has been rewritten to GET before matching; no handler claims
     // "/nope", so this takes the 501 branch that builds its own request.
     NSString* reply = SendRawRequest(server.port, @"HEAD /nope HTTP/1.1\r\nHost: localhost\r\n\r\n");
-    XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 501"], @"expected 501 for an unclaimed path: %@", reply);
+    // 404 rather than the 501 this once asserted: a GET handler is registered above, and the HEAD
+    // was rewritten to GET before matching, so the METHOD is implemented and only the target is
+    // missing. The branch under test — the one that builds its own request — is the same either
+    // way; the status is incidental to what this test is actually about.
+    XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 404"], @"expected 404 for an unclaimed path on a server that does implement GET: %@", reply);
 
     XCTAssertNotNil(gAbortRequestPeer, @"the aborted request carried no peer address");
     XCTAssertTrue([gAbortRequestPeer hasPrefix:@"127.0.0.1"], @"peer address is wrong: %@", gAbortRequestPeer);
@@ -3952,8 +4063,14 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 
     // The catch-all matches GET only, exactly as the base path handler it replaces did, so no
     // other method's status is affected by it.
-    NSString* posted = SendRawRequest(server.port, [NSString stringWithFormat:@"POST /nope.txt HTTP/1.1\r\nHost: %@\r\nContent-Length: 0\r\n\r\n", host]);
-    XCTAssertFalse([posted hasPrefix:@"HTTP/1.1 404"], @"the catch-all must not claim non-GET methods: %@", [posted substringToIndex:MIN((NSUInteger)40, posted.length)]);
+    //
+    // This used to assert "not 404", which worked only while an unmatched request answered 501.
+    // Now that an unmatched request answers 404 when the method exists elsewhere — and the
+    // uploader does register POST handlers — that proxy cannot tell "the catch-all declined" from
+    // "the catch-all claimed it". Assert the property directly instead: a POST to a path the
+    // catch-all WOULD serve for a GET must not come back with that path's contents.
+    NSString* postedToRealAsset = SendRawRequest(server.port, [NSString stringWithFormat:@"POST /css/index.css HTTP/1.1\r\nHost: %@\r\nContent-Length: 0\r\n\r\n", host]);
+    XCTAssertFalse([postedToRealAsset hasPrefix:@"HTTP/1.1 200"], @"the catch-all must not serve a non-GET method: %@", [postedToRealAsset substringToIndex:MIN((NSUInteger)40, postedToRealAsset.length)]);
 
     // And it must sit behind every real handler, not in front of them.
     NSString* page = SendRawRequest(server.port, [NSString stringWithFormat:@"GET / HTTP/1.1\r\nHost: %@\r\n\r\n", host]);

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -99,6 +99,7 @@ NS_ASSUME_NONNULL_END
     NSDictionary<NSString *, NSString *> *_authenticationDigestAccounts;
     NSSet<NSString *> *_allowedHostNames;
     BOOL _shouldAutomaticallyMapHEADToGET;
+    NSSet<NSString *> *_registeredMethods;  // Methods SOME handler claims; decides 404 vs 501 for an unmatched request
 
     CFHTTPMessageRef _requestMessage;
     WSKRequest *_request;
@@ -1042,7 +1043,24 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
                             self->_request.localAddressData = self.localAddressData;
                             self->_request.remoteAddressData = self.remoteAddressData;
                             self->_request.virtualHEAD = self->_virtualHEAD;
-                            [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_NotImplemented];
+                            // 501 says "this server does not implement that method". It was the
+                            // answer for an unknown TARGET too, so a browser asking for
+                            // /favicon.ico was told the server does not implement GET — and 501 is
+                            // heuristically cacheable, so an intermediary may remember it for a
+                            // path that later gains a handler. If some handler claims the method,
+                            // the method is implemented and what is missing is the target: 404.
+                            //
+                            // 405 with Allow, which is what a KNOWN target with the wrong method
+                            // owes, is deliberately not attempted: a handler is an opaque match
+                            // block, so the server cannot ask which methods a path accepts without
+                            // changing the registration model. Guessing it would be worse.
+                            NSInteger unmatchedStatus = kWSKHTTPStatusCode_NotImplemented;
+
+                            if ([self->_registeredMethods containsObject:requestMethod]) {
+                                unmatchedStatus = kWSKHTTPStatusCode_NotFound;
+                            }
+
+                            [self abortRequest:self->_request withStatusCode:unmatchedStatus];
                         } else {
                             // The base request rejected these headers too — a framing conflict
                             // such as "Content-Length" together with a chunked "Transfer-Encoding"
@@ -1082,6 +1100,7 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
         _authenticationDigestAccounts = server.authenticationDigestAccounts;
         _allowedHostNames = server.allowedHostNames;
         _shouldAutomaticallyMapHEADToGET = server.shouldAutomaticallyMapHEADToGET;
+        _registeredMethods = server.registeredMethods;
         _localAddressData = localAddress;
         _remoteAddressData = remoteAddress;
         _socket = socket;

--- a/Sources/WebServerKit/Core/WSKPrivate.h
+++ b/Sources/WebServerKit/Core/WSKPrivate.h
@@ -300,6 +300,7 @@ extern NSString *WSKStringFromSockAddr(const struct sockaddr *addr, BOOL include
 @property (nonatomic, readonly) dispatch_queue_priority_t dispatchQueuePriority;
 @property (nonatomic, readonly) NSTimeInterval connectionIdleTimeout;
 @property (nonatomic, readonly) NSTimeInterval connectionKeepAliveTimeout;
+@property (nonatomic, readonly) NSSet<NSString *> *registeredMethods;
 - (void)willStartConnection:(WSKConnection *)connection;
 - (void)didEndConnection:(WSKConnection *)connection;
 @end

--- a/Sources/WebServerKit/Core/WSKRequest.m
+++ b/Sources/WebServerKit/Core/WSKRequest.m
@@ -355,6 +355,50 @@ static BOOL _ParseTransferEncoding(NSString *header, BOOL *outRejected) {
     return NO;
 }
 
+// Does "Accept-Encoding" actually permit gzip? (RFC 9110 §12.5.3.)
+//
+// This was a case-sensitive substring search for "gzip", which said YES to "gzip;q=0" — a client
+// explicitly refusing it — and to any token merely containing the letters, while saying NO to
+// "GZIP" and to "*". A token-exact parse costs the same and cannot be wrong in the direction that
+// sends a body a client cannot read. "x-gzip" is accepted as the synonym RFC 9110 §8.4.1 defines,
+// which is the spelling the request-decoding side twenty lines below already honours.
+static BOOL _AcceptEncodingAllowsGzip(NSString *header) {
+    if (header.length == 0) {
+        return NO;
+    }
+
+    BOOL allowed = NO;
+
+    for (NSString *element in [header componentsSeparatedByString:@","]) {
+        NSArray<NSString *> *const parts = [element componentsSeparatedByString:@";"];
+        NSString *const token = [[parts.firstObject stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] lowercaseString];
+
+        if (!([token isEqualToString:@"gzip"] || [token isEqualToString:@"x-gzip"] || [token isEqualToString:@"*"])) {
+            continue;
+        }
+
+        // "q=0" means not acceptable. Any other quality, or none at all, means it is.
+        BOOL refused = NO;
+
+        for (NSUInteger i = 1; i < parts.count; i++) {
+            NSString *const parameter = [[parts[i] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] lowercaseString];
+
+            if ([parameter hasPrefix:@"q="]) {
+                refused = ([[parameter substringFromIndex:2] doubleValue] <= 0.0);
+            }
+        }
+
+        // An explicit "gzip" beats a wildcard, so a later exact refusal must be able to win.
+        if ([token isEqualToString:@"*"]) {
+            allowed = allowed || !refused;
+        } else {
+            return !refused;
+        }
+    }
+
+    return allowed;
+}
+
 // Parse a "Content-Encoding" list (RFC 9110 §8.4). Returns NO when the coding cannot be undone,
 // in which case the caller MUST refuse the request.
 //
@@ -514,9 +558,7 @@ static BOOL _ParseContentEncoding(NSString *header, BOOL *outGZip) {
             }
         }
 
-        if ([_headers[@"Accept-Encoding"] rangeOfString:@"gzip"].location != NSNotFound) {
-            _acceptsGzipContentEncoding = YES;
-        }
+        _acceptsGzipContentEncoding = _AcceptEncodingAllowsGzip(_headers[@"Accept-Encoding"]);
 
         _decoders = [[NSMutableArray alloc] init];
         _attributes = [[NSMutableDictionary alloc] init];

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -192,6 +192,7 @@ static void _ExecuteMainThreadRunLoopSources(void) {
     dispatch_queue_t _stateQueue;
     dispatch_group_t _sourceGroup;
     NSMutableArray<WSKHandler *> *_handlers;
+    NSMutableSet<NSString *> *_registeredMethods;  // Which methods ANY handler claims; see -_noteRegisteredMethod:
     NSInteger _activeConnections;        // Accessed through _syncQueue only
     NSInteger _reservedConnections;      // Accepted sockets not yet counted in _activeConnections; through _syncQueue only
     BOOL _connected;                     // Accessed on main thread only
@@ -243,6 +244,7 @@ static void _ExecuteMainThreadRunLoopSources(void) {
         _stateQueue = dispatch_queue_create("gcdwebserver.state", DISPATCH_QUEUE_SERIAL);
         _sourceGroup = dispatch_group_create();
         _handlers = [[NSMutableArray alloc] init];
+        _registeredMethods = [[NSMutableSet alloc] init];
 #if TARGET_OS_IPHONE
         _backgroundTask = UIBackgroundTaskInvalid;
 #endif
@@ -436,6 +438,25 @@ static void _ExecuteMainThreadRunLoopSources(void) {
         result = type && CFStringGetLength(type) ? CFBridgingRelease(CFStringCreateCopy(kCFAllocatorDefault, type)) : nil;
     });
     return result;
+}
+
+// Records that SOME handler claims this method, which is what separates "this server does not do
+// that" from "not here". A request matching no handler answered 501 Not Implemented for both, so a
+// browser asking for /favicon.ico was told the server does not implement GET. 501 is also
+// heuristically cacheable (RFC 9111 4.2.2), so an intermediary may remember it for a path that
+// later gains a handler.
+//
+// Deliberately NOT a path-to-methods map, which is what a 405 with Allow would need: a handler is
+// an opaque match block, so the server cannot ask which methods a given path accepts without
+// changing the registration model. 405 stays unimplemented rather than guessed at.
+- (void)_noteRegisteredMethod:(NSString *)method {
+    if (method.length) {
+        [_registeredMethods addObject:method];
+    }
+}
+
+- (NSSet<NSString *> *)registeredMethods {
+    return [_registeredMethods copy];
 }
 
 - (void)addHandlerWithMatchBlock:(WSKMatchBlock)matchBlock processBlock:(WSKProcessBlock)processBlock {
@@ -1110,7 +1131,22 @@ static inline NSString *_EncodeBase64(NSString *string) {
 
     dispatch_sync(_stateQueue, ^{
         if (!self->_source4) {
-            [self _start:NULL];  // TODO: There's probably nothing we can do on failure
+            NSError *error = nil;
+
+            if (![self _start:&error]) {
+                // Previously "[self _start:NULL]" under a TODO saying nothing could be done. The
+                // sibling -_reconnectInForeground: was given this logging and this one was not —
+                // and THIS is the default path, since WSKOption_AutomaticallySuspendInBackground
+                // defaults to YES. So the fix landed on the opt-in configuration and left the
+                // ordinary one silent: exactly the "closed at one of the sites the rule applies
+                // to" shape, in the change that was meant to close it.
+                //
+                // Deliberately not a -webServerDidStop: call: -_stop already posts one, and adding
+                // a second here delivered two callbacks for one stop last time. -isRunning and
+                // -serverURL report stopped honestly, so nothing believes the server resumed; what
+                // was missing is any way to find out WHY.
+                WSK_LOG_ERROR(@"Failed restarting %@ on returning to the foreground: %@", [self class], error);
+            }
         }
     });
 }
@@ -1426,6 +1462,8 @@ static inline NSString *_EncodeBase64(NSString *string) {
 }
 
 - (void)addDefaultHandlerForMethod:(NSString *)method requestClass:(Class)aClass asyncProcessBlock:(WSKAsyncProcessBlock)block {
+    [self _noteRegisteredMethod:method];
+
     [self
         addHandlerWithMatchBlock:^WSKRequest *(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery) {
             if (![requestMethod isEqualToString:method]) {
@@ -1447,6 +1485,8 @@ static inline NSString *_EncodeBase64(NSString *string) {
 }
 
 - (void)addHandlerForMethod:(NSString *)method path:(NSString *)path requestClass:(Class)aClass asyncProcessBlock:(WSKAsyncProcessBlock)block {
+    [self _noteRegisteredMethod:method];
+
     if ([path hasPrefix:@"/"] && [aClass isSubclassOfClass:[WSKRequest class]]) {
         [self
             addHandlerWithMatchBlock:^WSKRequest *(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery) {
@@ -1476,6 +1516,8 @@ static inline NSString *_EncodeBase64(NSString *string) {
 }
 
 - (void)addHandlerForMethod:(NSString *)method pathRegex:(NSString *)regex requestClass:(Class)aClass asyncProcessBlock:(WSKAsyncProcessBlock)block {
+    [self _noteRegisteredMethod:method];
+
     NSRegularExpression *expression = [NSRegularExpression regularExpressionWithPattern:regex options:NSRegularExpressionCaseInsensitive error:NULL];
 
     if (expression && [aClass isSubclassOfClass:[WSKRequest class]]) {
@@ -1623,6 +1665,10 @@ static NSString *_EscapeHTMLString(NSString *string) {
 }
 
 - (void)addGETHandlerForBasePath:(NSString *)basePath directoryPath:(NSString *)directoryPath indexFilename:(NSString *)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests allowHiddenItems:(BOOL)allowHiddenItems {
+    // Registers its own match block rather than going through -addHandlerForMethod:, so the method
+    // has to be recorded here too.
+    [self _noteRegisteredMethod:@"GET"];
+
     // The leading and trailing slashes used to be an undocumented precondition enforced by
     // WSK_DNOT_REACHED(): abort with no diagnostic in Debug, and in Release register
     // NOTHING and return, so every request 404'd with the host app given no clue why.
@@ -1730,11 +1776,25 @@ static NSString *_EscapeHTMLString(NSString *string) {
                 if (fileType) {
                     if ([fileType isEqualToString:NSFileTypeDirectory]) {
                         if (indexFilename) {
-                            NSString *indexPath = [filePath stringByAppendingPathComponent:indexFilename];
-                            NSString *indexType = [[[NSFileManager defaultManager] attributesOfItemAtPath:indexPath error:NULL] fileType];
+                            // Resolved and contained like every other path this handler acts on.
+                            // It used to be appended to an already-resolved directory and served
+                            // unchecked — so an indexFilename containing a separator or ".."
+                            // escaped the served root, since -attributesOfItemAtPath: follows
+                            // intermediate components and WSKFileResponse's O_NOFOLLOW guards only
+                            // the final one. Host-app configuration rather than client input, and
+                            // every in-tree caller passes nil, but the header states the
+                            // containment guarantee unconditionally.
+                            NSString *indexRelativePath = nil;
+                            NSString *const indexPath = WSKResolveWithinDirectory([filePath stringByAppendingPathComponent:indexFilename], directoryPath, &indexRelativePath);
 
-                            if ([indexType isEqualToString:NSFileTypeRegular]) {
-                                return [WSKFileResponse responseWithFile:indexPath];
+                            if (indexPath) {
+                                NSString *const indexType = [[[NSFileManager defaultManager] attributesOfItemAtPath:indexPath error:NULL] fileType];
+
+                                if ([indexType isEqualToString:NSFileTypeRegular]) {
+                                    return [WSKFileResponse responseWithFile:indexPath];
+                                }
+                            } else {
+                                WSK_LOG_WARNING(@"Refusing index file \"%@\" under \"%@\": it does not resolve inside the served directory", indexFilename, relativePath);
                             }
                         }
 


### PR DESCRIPTION
The four remaining confirmed findings from the outside audit, closed together — each is small and none shares code with the others.

## Unmatched requests: 404 vs 501

An unmatched request always answered **501 Not Implemented** — a statement about the *method* — even when the method was one this server implements and only the target was unknown. A browser asking for `/favicon.ico` was told the server does not implement GET. 501 is also heuristically cacheable (RFC 9111 §4.2.2), so an intermediary may remember it for a path that later gains a handler.

The server now records which methods **any** handler claims: unmatched answers **404** when the method is among them, **501** when it isn't.

**405 with `Allow` is deliberately not attempted.** A handler is an opaque match block, so the server cannot ask which methods a path accepts without changing the registration model. Guessing would be worse than omitting it — recorded as still open rather than half-done.

## `Accept-Encoding` was a substring search

It said YES to `gzip;q=0` — a client *explicitly refusing* it — and to `xgzipy`; NO to `GZIP` and `*`.

And, found by writing the test rather than by predicting it: **it said YES when the header was absent.** `[nil rangeOfString:]` returns a zeroed `NSRange` whose `location` is 0, which is not `NSNotFound`. That's the **fourth** appearance of the messaging-nil-returns-a-zeroed-struct shape in this codebase, and the second caught by a test instead of by reading.

Now a token parse with q-values, accepting `x-gzip` as the RFC 9110 §8.4.1 synonym — the spelling the request-*decoding* side twenty lines below already honoured. No consumer inside the library, so nothing served changes today; it's public API a host app is invited to gate compression on, and it has to mean what it says.

## `indexFilename` escaped the served root

Appended to a resolved directory and served **without resolving again** — `-attributesOfItemAtPath:` follows intermediate components and `WSKFileResponse`'s `O_NOFOLLOW` guards only the final one. Measured before the fix: `indexFilename:@"../outside.html"` served a file outside the directory with **200 OK**.

Host-app configuration rather than client input, and every in-tree caller passes nil — but the header states the containment guarantee flatly.

**⚠️ My first version broke the ordinary case.** `WSKResolveWithinDirectory` takes an *absolute* path and I passed a relative one, so no index file resolved at all and every configured index silently became a directory listing. Caught by the half of the test that asserts what must keep working — the half that exists precisely because a guard justified by one failure mode has to be checked against everything it then refuses.

## `-_willEnterForeground:` — the other site

Still called `[self _start:NULL]` under the original TODO saying nothing could be done on failure. Its sibling `-_reconnectInForeground:` got error logging from an earlier batch — and **this one is the default path**, since `AutomaticallySuspendInBackground` defaults to YES. So that fix landed on the opt-in configuration and left the ordinary one silent: the "closed at one of the sites the rule applies to" shape, inside the change meant to close it.

Still no `-webServerDidStop:` here — `-_stop` already posts one, and adding a second delivered two callbacks for one stop last time.

## Two existing tests updated, not worked around

- `testAbortedRequestCarriesItsAddressesAndHEADFlag` asserted 501 for an unclaimed path. It registers a GET handler, so the honest answer is now 404; the branch under test is identical either way.
- `testUploaderAnswersNotFoundRatherThanNotImplemented` asserted `!= 404` as a **proxy** for "the GET-only catch-all declined this POST" — valid only while unmatched meant 501. It now asserts the property directly: a POST to a path the catch-all *would* serve for a GET must not come back with that path's contents.

## Verification

The three new tests fail **9/9** against the unfixed tree on the intended assertions — including a `200 OK` carrying content from outside the served directory.

**158 tests, 0 failures**, all eight trace suites green, Release on macOS/iOS/tvOS, clean Debug on all three with zero warnings and isolated `-derivedDataPath` each, forced-clean `swift build`.

## Still open

405-with-`Allow` as described above, and the ten audit findings that were never adversarially verified — leads, not findings, to be re-measured before any is acted on.