### PR TITLE
A delegate swapped between the check and the callback killed the process; and the audit's last leads are settled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -829,10 +829,16 @@ exercise changes, not on suspicion.
   next request disagrees about — but **the pipelining probe has not been re-run in that mode**. ~7,000 mutated
   requests under ASan+UBSan: zero memory errors. 9,366 injected allocation failures: nothing,
   zero descriptor leaks.
-- **Conformance and real clients** — ⚠️ these figures PREDATE PR #70's status changes (MKCOL 405,
-  the PROPFIND finite-depth refusal, shallow COPY, `Allow` contents) and PR #71's new read surfaces,
-  and should be re-taken before being quoted as current: litmus `basic` 16/16, `http` 4/4, `locks` 3/3, `props`
-  29/30 (sole failure `propfind_invalid2`, settled); 2.3 GB through a real `mount_webdav` mount
+- **Conformance and real clients**, RE-TAKEN against tip after the #70/#71/#75 status changes and
+  unchanged: litmus `basic` 16/16, `http` 4/4, `locks` 3/3, `props`
+  29/30 (sole failure still `propfind_invalid2`, settled). The four changed behaviours were also
+  checked directly: MKCOL new 201 / existing **405**, PROPFIND with no Depth **403**, `Allow`
+  carrying PROPPATCH, and an unknown target **404**. And driven through macOS's own kernel WebDAV
+  client via `mount_webdav`: mkdir, 12 MB write, byte-identical read-back, list, rename,
+  read-after-rename, copy, delete, `mkdir -p` on a nested path — which walks ancestors and so
+  exercises the new 405 — write into it, recursive delete, clean unmount. All passed. (`cp` exits
+  non-zero on extended attributes, which WebDAV has no transport for; the bytes compare identical.)
+  Historic figures, not re-taken: 2.3 GB through a real `mount_webdav` mount
   byte-perfect across 33,269 mixed operations, 3,290 mount-vs-disk listing comparisons agreeing,
   34 hostile filenames including the NFC/NFD pair round-tripping; rclone `sync`/`check` agreeing
   both directions; the macOS client tolerates the dateless-PROPFIND window by falling back to
@@ -962,8 +968,15 @@ the appendix). Still open, roughly in order of weight:
 - **An unmatched request always answers 501**, conflating "unknown target" (404) and "wrong method
   for a known target" (405 + `Allow`). The bare server is affected; the uploader's catch-all GET
   handler already restores 404 for things like `/favicon.ico`.
-- **Ten of the audit's findings were never adversarially verified** (the skeptic fan-out was
-  capped at eight). They are leads, not findings, and must be re-measured before any is acted on.
+- ~~Ten of the audit's findings were never adversarially verified~~ — **done**. Four had already
+  been closed by #75; of the six that remained, **five were refuted** and one was real:
+  `Transfer-Encoding: identity` (the desync it implied is closed by construction, since reuse is
+  restricted to requests with no body framing); the completion-once BOOL races (host-app-only, and
+  two of three stated consequences false); `additionalHeaders` overriding framing headers (the
+  documented contract, with a `@warning` on the method itself); the SSE cached share root (both
+  halves attributed to the wrong method — file-presenter events never call it); and the unchecked
+  `dispatch_source_create` (its arguments are statically pinned, so NULL cannot occur). The
+  survivor was the weak-delegate swap, now fixed.
 
 Carried from earlier passes, never closed:
 - **PROPFIND publishes no `getetag`** — a just-written file has ZERO validators for a
@@ -1166,7 +1179,16 @@ alongside the two that must change — the first change made deliberately under 
    correspondence thirty lines away — it answers NO for `Transfer-Encoding: identity`, which DOES
    carry framing. Any framing, containment or authorization decision must read the primary source
    (here, the raw header names), never a convenience property derived from it elsewhere.
-9. **Messaging nil returns a ZEROED struct, so a struct-returning check on an absent value is
+9. **A check and the action it guards must observe the SAME object.** Every delegate callback
+   tested `-respondsToSelector:` and then hopped to the main queue and re-read the WEAK, MUTABLE
+   delegate — so a host app swapping one live delegate for another implementing a different subset
+   of these @optional methods raised unrecognized-selector, and nothing in `Sources/` catches an
+   NSException. Fourteen sites. Note which oracles are worthless here: setting the delegate to nil
+   and letting it deallocate are BOTH already safe (the weak read yields nil, the message is a
+   no-op), so a test using either passes against the unfixed tree. Re-read into a strong local and
+   re-check inside the block; do not capture strongly at check time, which would deliver into an
+   object the host app has released.
+10. **Messaging nil returns a ZEROED struct, so a struct-returning check on an absent value is
    silently wrong.** `[headers[@"Connection"] rangeOfString:@"close"].location != NSNotFound` was
    TRUE whenever the header was absent, because `{0, 0}.location` is 0. It failed safe, which is
    worse in one specific way: the feature it guarded never turned on, and every functional test

--- a/Framework/Tests.m
+++ b/Framework/Tests.m
@@ -377,6 +377,33 @@ static BOOL gAbortRequestSawVirtualHEAD = NO;
 @interface Tests : XCTestCase
 @end
 
+// Two delegates for the weak-delegate swap test below. The distinction that matters is that BOTH
+// conform to the protocol and BOTH are alive: WSKFullDelegate implements the optional callback,
+// WSKPartialDelegate does not. Every method in these protocols is @optional, so an object
+// implementing a subset is the designed-for case, not an abuse.
+@interface WSKFullDelegate : NSObject <WSKDelegate>
+@property (nonatomic) BOOL sawStart;
+@end
+
+@implementation WSKFullDelegate
+- (void)webServerDidStart:(WSKWebServer*)server {
+    _sawStart = YES;
+}
+@end
+
+@interface WSKPartialDelegate : NSObject <WSKDelegate>
+@property (nonatomic) BOOL sawConnect;
+@end
+
+@implementation WSKPartialDelegate
+// Deliberately implements a DIFFERENT optional method, so it conforms and is a plausible delegate
+// while not responding to -webServerDidStart:.
+- (void)webServerDidConnect:(WSKWebServer*)server {
+    _sawConnect = YES;
+}
+@end
+
+
 @implementation Tests
 
 - (void)testWebServer {
@@ -2986,6 +3013,79 @@ static NSString* QuotedParam(NSString* header, NSString* name) {
 
     [server stop];
     [fm removeItemAtPath:dir error:NULL];
+}
+
+
+
+// Every delegate callback checks -respondsToSelector: and then hops to the main queue, where it
+// reads the delegate AGAIN. The property is weak AND mutable, so those can be different objects —
+// and an @optional protocol makes partial implementations the designed-for case. A host app that
+// swaps one live delegate for another implementing a different subset therefore raises
+// unrecognized-selector, and nothing in Sources/ catches an NSException: the process dies.
+//
+// ⚠️ Two oracles that look right and are worthless, both measured: setting the delegate to NIL and
+// letting it DEALLOCATE are already safe, because the weak read yields nil and messaging nil is a
+// no-op. The test has to swap in a second LIVE object that conforms and omits the selector.
+//
+// ⚠️ Against the unfixed tree this does not fail — it TERMINATES the runner, which reports
+// "Executed 0 tests, with 0 failures". Read the executed count, as this project has had to four
+// times before.
+//
+// -startWithOptions: dispatch_syncs onto the state queue, so the respondsToSelector: check runs
+// while this thread is blocked and the block lands on a LATER main-queue turn. No concurrency is
+// needed to hit the window: straight-line code suffices.
+- (void)testDelegateSwappedBetweenCheckAndCallbackDoesNotRaise {
+    WSKFullDelegate* full = [[WSKFullDelegate alloc] init];
+    WSKPartialDelegate* partial = [[WSKPartialDelegate alloc] init];
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addHandlerForMethod:@"GET"
+                           path:@"/ok"
+                   requestClass:[WSKRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"ok"];
+                   }];
+    server.delegate = full;
+
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // The check has run against `full` and the block is queued; swap before it lands.
+    server.delegate = partial;
+
+    // Let the queued callback run. Unfixed, this is where the process dies.
+    for (int i = 0; i < 20; i++) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+
+    XCTAssertFalse(full.sawStart, @"the callback must not reach the delegate that was replaced");
+    XCTAssertTrue([server isRunning], @"the server is unaffected");
+
+    // And what must keep working: an UNCHANGED delegate still receives its callback. This is the
+    // half a re-check could silently break.
+    [server stop];
+
+    for (int i = 0; i < 20; i++) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+
+    WSKFullDelegate* stable = [[WSKFullDelegate alloc] init];
+    WSKWebServer* second = [[WSKWebServer alloc] init];
+    [second addHandlerForMethod:@"GET"
+                           path:@"/ok"
+                   requestClass:[WSKRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"ok"];
+                   }];
+    second.delegate = stable;
+    XCTAssertTrue([second startWithOptions:options error:NULL]);
+
+    for (int i = 0; i < 20 && !stable.sawStart; i++) {
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+
+    XCTAssertTrue(stable.sawStart, @"an unchanged delegate must still be called");
+    [second stop];
 }
 
 // An unmatched request always answered 501 Not Implemented — a statement about the METHOD — even

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -542,7 +542,20 @@ static void _DNSServiceCallBack(DNSServiceRef sdRef, DNSServiceFlags flags, uint
         // that queue — and doing so from inside it would deadlock.
         if ([server.delegate respondsToSelector:@selector(webServerDidUpdateNATPortMapping:)]) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                [server.delegate webServerDidUpdateNATPortMapping:server];
+                // Re-read and re-check inside the block. The property is weak AND mutable, so the
+                // object checked above need not be the one messaged here — a host app that swaps
+                // its delegate for another LIVE object implementing a different subset of these
+                // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+                // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+                // weak read yields nil and the message is a no-op.) The strong local also removes a
+                // second weak load between this check and the send. Deliberately NOT a strong
+                // capture at check time: that would keep a delegate the host app has released alive
+                // and deliver into an object mid-teardown.
+                id<WSKDelegate> const delegate = server.delegate;
+
+                if ([delegate respondsToSelector:@selector(webServerDidUpdateNATPortMapping:)]) {
+                    [delegate webServerDidUpdateNATPortMapping:server];
+                }
             });
         }
     }
@@ -1021,7 +1034,20 @@ static inline NSString *_EncodeBase64(NSString *string) {
 
     if ([_delegate respondsToSelector:@selector(webServerDidStart:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self->_delegate webServerDidStart:self];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKDelegate> const delegate = self->_delegate;
+
+            if ([delegate respondsToSelector:@selector(webServerDidStart:)]) {
+                [delegate webServerDidStart:self];
+            }
         });
     }
 
@@ -1102,7 +1128,20 @@ static inline NSString *_EncodeBase64(NSString *string) {
 
     if ([_delegate respondsToSelector:@selector(webServerDidStop:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self->_delegate webServerDidStop:self];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKDelegate> const delegate = self->_delegate;
+
+            if ([delegate respondsToSelector:@selector(webServerDidStop:)]) {
+                [delegate webServerDidStop:self];
+            }
         });
     }
 }

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -679,7 +679,20 @@ static WSKResponse *_MethodNotAllowed(NSString *format, ...) {
 
     if ([self.delegate respondsToSelector:@selector(davServer:didDownloadFileAtPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate davServer:self didDownloadFileAtPath:absolutePath];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKWebDAVServerDelegate> const delegate = self.delegate;
+
+            if ([delegate respondsToSelector:@selector(davServer:didDownloadFileAtPath:)]) {
+                [delegate davServer:self didDownloadFileAtPath:absolutePath];
+            }
         });
     }
 
@@ -780,7 +793,20 @@ static WSKResponse *_MethodNotAllowed(NSString *format, ...) {
 
     if ([self.delegate respondsToSelector:@selector(davServer:didUploadFileAtPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate davServer:self didUploadFileAtPath:absolutePath];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKWebDAVServerDelegate> const delegate = self.delegate;
+
+            if ([delegate respondsToSelector:@selector(davServer:didUploadFileAtPath:)]) {
+                [delegate davServer:self didUploadFileAtPath:absolutePath];
+            }
         });
     }
 
@@ -865,7 +891,20 @@ static WSKResponse *_MethodNotAllowed(NSString *format, ...) {
 
     if ([self.delegate respondsToSelector:@selector(davServer:didDeleteItemAtPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate davServer:self didDeleteItemAtPath:absolutePath];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKWebDAVServerDelegate> const delegate = self.delegate;
+
+            if ([delegate respondsToSelector:@selector(davServer:didDeleteItemAtPath:)]) {
+                [delegate davServer:self didDeleteItemAtPath:absolutePath];
+            }
         });
     }
 
@@ -957,7 +996,20 @@ static WSKResponse *_MethodNotAllowed(NSString *format, ...) {
 
     if ([self.delegate respondsToSelector:@selector(davServer:didCreateDirectoryAtPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate davServer:self didCreateDirectoryAtPath:absolutePath];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKWebDAVServerDelegate> const delegate = self.delegate;
+
+            if ([delegate respondsToSelector:@selector(davServer:didCreateDirectoryAtPath:)]) {
+                [delegate davServer:self didCreateDirectoryAtPath:absolutePath];
+            }
         });
     }
 
@@ -1232,13 +1284,39 @@ static WSKResponse *_MethodNotAllowed(NSString *format, ...) {
     if (isMove) {
         if ([self.delegate respondsToSelector:@selector(davServer:didMoveItemFromPath:toPath:)]) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                [self.delegate davServer:self didMoveItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
+                // Re-read and re-check inside the block. The property is weak AND mutable, so the
+                // object checked above need not be the one messaged here — a host app that swaps
+                // its delegate for another LIVE object implementing a different subset of these
+                // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+                // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+                // weak read yields nil and the message is a no-op.) The strong local also removes a
+                // second weak load between this check and the send. Deliberately NOT a strong
+                // capture at check time: that would keep a delegate the host app has released alive
+                // and deliver into an object mid-teardown.
+                id<WSKWebDAVServerDelegate> const delegate = self.delegate;
+
+                if ([delegate respondsToSelector:@selector(davServer:didMoveItemFromPath:toPath:)]) {
+                    [delegate davServer:self didMoveItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
+                }
             });
         }
     } else {
         if ([self.delegate respondsToSelector:@selector(davServer:didCopyItemFromPath:toPath:)]) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                [self.delegate davServer:self didCopyItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
+                // Re-read and re-check inside the block. The property is weak AND mutable, so the
+                // object checked above need not be the one messaged here — a host app that swaps
+                // its delegate for another LIVE object implementing a different subset of these
+                // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+                // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+                // weak read yields nil and the message is a no-op.) The strong local also removes a
+                // second weak load between this check and the send. Deliberately NOT a strong
+                // capture at check time: that would keep a delegate the host app has released alive
+                // and deliver into an object mid-teardown.
+                id<WSKWebDAVServerDelegate> const delegate = self.delegate;
+
+                if ([delegate respondsToSelector:@selector(davServer:didCopyItemFromPath:toPath:)]) {
+                    [delegate davServer:self didCopyItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
+                }
             });
         }
     }

--- a/Sources/WebServerKitUploader/WSKWebUploader.m
+++ b/Sources/WebServerKitUploader/WSKWebUploader.m
@@ -1256,7 +1256,20 @@ static BOOL _MimeTypeIsInertMedia(NSString *mimeType) {
 
     if ([self.delegate respondsToSelector:@selector(webUploader:didDownloadFileAtPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate webUploader:self didDownloadFileAtPath:absolutePath];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKWebUploaderDelegate> const delegate = self.delegate;
+
+            if ([delegate respondsToSelector:@selector(webUploader:didDownloadFileAtPath:)]) {
+                [delegate webUploader:self didDownloadFileAtPath:absolutePath];
+            }
         });
     }
 
@@ -1441,7 +1454,20 @@ static NSString *_OriginAuthority(NSString *value) {
 
     if ([self.delegate respondsToSelector:@selector(webUploader:didUploadFileAtPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate webUploader:self didUploadFileAtPath:absolutePath];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKWebUploaderDelegate> const delegate = self.delegate;
+
+            if ([delegate respondsToSelector:@selector(webUploader:didUploadFileAtPath:)]) {
+                [delegate webUploader:self didUploadFileAtPath:absolutePath];
+            }
         });
     }
 
@@ -1558,7 +1584,20 @@ static NSString *_OriginAuthority(NSString *value) {
 
     if ([self.delegate respondsToSelector:@selector(webUploader:didMoveItemFromPath:toPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate webUploader:self didMoveItemFromPath:oldAbsolutePath toPath:newAbsolutePath];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKWebUploaderDelegate> const delegate = self.delegate;
+
+            if ([delegate respondsToSelector:@selector(webUploader:didMoveItemFromPath:toPath:)]) {
+                [delegate webUploader:self didMoveItemFromPath:oldAbsolutePath toPath:newAbsolutePath];
+            }
         });
     }
 
@@ -1665,7 +1704,20 @@ static NSString *_OriginAuthority(NSString *value) {
 
     if ([self.delegate respondsToSelector:@selector(webUploader:didDeleteItemAtPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate webUploader:self didDeleteItemAtPath:absolutePath];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKWebUploaderDelegate> const delegate = self.delegate;
+
+            if ([delegate respondsToSelector:@selector(webUploader:didDeleteItemAtPath:)]) {
+                [delegate webUploader:self didDeleteItemAtPath:absolutePath];
+            }
         });
     }
 
@@ -1739,7 +1791,20 @@ static NSString *_OriginAuthority(NSString *value) {
 
     if ([self.delegate respondsToSelector:@selector(webUploader:didCreateDirectoryAtPath:)]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.delegate webUploader:self didCreateDirectoryAtPath:absolutePath];
+            // Re-read and re-check inside the block. The property is weak AND mutable, so the
+            // object checked above need not be the one messaged here — a host app that swaps
+            // its delegate for another LIVE object implementing a different subset of these
+            // optional methods raises unrecognized-selector, and nothing in Sources/ catches an
+            // NSException. (Setting it to nil, or letting it deallocate, was always safe: the
+            // weak read yields nil and the message is a no-op.) The strong local also removes a
+            // second weak load between this check and the send. Deliberately NOT a strong
+            // capture at check time: that would keep a delegate the host app has released alive
+            // and deliver into an object mid-teardown.
+            id<WSKWebUploaderDelegate> const delegate = self.delegate;
+
+            if ([delegate respondsToSelector:@selector(webUploader:didCreateDirectoryAtPath:)]) {
+                [delegate webUploader:self didCreateDirectoryAtPath:absolutePath];
+            }
         });
     }
 


### PR DESCRIPTION
Two things: the final real finding from the outside audit, and closure of everything it left unverified.

## Fourteen callbacks checked one object and messaged another

Each delegate callback does `-respondsToSelector:`, hops to the main queue, and re-reads the delegate **there**. The property is weak *and* mutable, and every method in all three protocols is `@optional` — so an object implementing a subset is the designed-for case, not an abuse. A host app that swaps one live delegate for another implementing a different subset raises unrecognized-selector, and nothing in `Sources/` catches an `NSException`. **The process dies.**

No concurrency needed for three of the sites: `-startWithOptions:` and `-stop` `dispatch_sync` onto the state queue, so the check runs while the calling thread is blocked and the block lands on a *later* main-queue turn. Straight-line code hits it:

```objc
server.delegate = a;
[server startWithOptions:… error:NULL];   // check runs against `a`, block queued
server.delegate = b;                       // b conforms, omits the selector
// … back to the runloop → boom
```

## ⚠️ Two oracles that look right and prove nothing

Setting the delegate to **nil** and letting it **deallocate** are *both already safe* — the weak read yields nil and messaging nil is a no-op. A test using either passes against the unfixed tree. It has to swap in a second **live** object that conforms and omits the selector.

And against the unfixed tree the test doesn't fail — it **terminates the runner**:

```
Executed 0 tests, with 0 failures
*** Terminating app due to uncaught exception 'NSInvalidArgumentException',
    reason: '-[WSKPartialDelegate webServerDidStart:]: unrecognized selector sent to instance'
```

Reading the failure count alone would have said it passed. Fifth time this project has recorded that trap.

## The fix, and two things it deliberately isn't

Re-read into a strong local and re-check inside each block.

- **Not** a strong capture at check time — that keeps alive a delegate the host app has released and delivers into an object mid-teardown, a behaviour change in the risky direction.
- **Not** removing the `dispatch_async` — the comment at the NAT site records that the hop exists so a delegate may call back into `-serverURL`/`-publicServerURL` without deadlocking on the state queue.

The outer check stays, so the common no-delegate case still enqueues nothing.

## The ten unverified leads are settled

Four were already closed by #75. Of the six remaining, **five were refuted** with high confidence and are now recorded as not-defects so a later pass doesn't re-find them:

| lead | why not |
|---|---|
| `Transfer-Encoding: identity` | real deviation, but the desync is closed by construction — reuse requires no body framing |
| completion-once BOOL races | host-app-only, and two of three stated consequences false |
| `additionalHeaders` override | the documented contract, with a `@warning` on the method itself |
| SSE cached share root | both halves attributed to the wrong method — file-presenter events never call it |
| unchecked `dispatch_source_create` | arguments statically pinned; NULL cannot occur |

## Conformance re-taken

After #70/#71/#75 moved six status codes — **unchanged**: litmus `basic` 16/16, `http` 4/4, `locks` 3/3, `props` 29/30 with the sole failure still `propfind_invalid2`.

Changed behaviours checked directly (MKCOL existing **405**, PROPFIND no-Depth **403**, `Allow` carrying PROPPATCH, unknown target **404**) and driven through macOS's own kernel WebDAV client via `mount_webdav` — including `mkdir -p` on a nested path, which walks ancestors and so exercises the new 405. All passed, clean unmount.

**159 tests, 0 failures**, all eight trace suites green, Release on macOS/iOS/tvOS, clean Debug on all three with zero warnings.