### PR TITLE
Fix four connection-reuse defects, the worst a mid-body truncation of pipelined responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,6 +501,35 @@ the same rule spelled two ways in two places.
   built from, and gating on `hasBody` would have made it the one eligible shape.
   Measured 0.515 → 0.377 ms/request (26.7%) on loopback, where the handshake is nearly free; on
   a real link it is about one RTT per request.
+- **A request served from `_carryOverData` is NOT idle, and the reaper must be told so at the point
+  the carry-over is consumed.** "Has the next request started arriving?" was a read-count
+  comparison, which a pipelined request can never satisfy — its bytes were counted against the
+  request BEFORE it, so no read happens and the count never rises. The connection therefore stayed
+  marked idle while its response streamed, and the keep-alive deadline cut the body off mid-transfer
+  under a `Content-Length` it then never reached: measured **15,867,384 of 16,777,216 bytes** at the
+  default idle timeout, and 3,622,183 of 8,388,608 in the regression test. A complete, well-formed,
+  WRONG response — the same shape as the in-place-rewrite splice, and the reason
+  `testPipelinedRequestIsNotReclaimedWhileItsResponseIsStillStreaming` carries a SEQUENTIAL control
+  that must pass on both trees: without it the test cannot tell this apart from the ordinary
+  response-phase idle rule.
+- **Bytes past the header block are TRIMMED to `Content-Length`, never refused.** Requiring
+  `extraData.length <= contentLength` honoured a guess about segmentation — TCP may deliver a body
+  and whatever follows it in one read — and answered 400. It was **reachable in the DEFAULT
+  configuration** (no keep-alive needed, one write is enough) and predates connection reuse
+  entirely; the split-invariance oracle found it, not reading. The remainder is DROPPED, never
+  interpreted: a request carrying body framing is not eligible for reuse, so the connection closes
+  after it and nothing is framed by a length the next request could disagree about.
+- **`-open` and `-close` are once per CONNECTION**, which is what their headers say and what a host
+  app pairing them relies on. Reuse briefly called `-close` per REQUEST, giving one open and N
+  closes. The per-request work — the access-log line and the trace recording — lives in
+  `-_flushRequestRecordAndLog` instead, called as each response completes, with `-close` flushing
+  only the request that has not been flushed yet. That guard is why `_requestLogged` is deliberately
+  NOT cleared in `-_resetForNextRequest` (which runs whether or not another request ever comes) but
+  where the next header block actually arrives.
+- **A persistent connection ending because the client went away is its designed end, not a
+  failure** — no `ERROR` log line, and no response. It used to write a 500 into a socket that was
+  already gone, putting a fabricated server error in the access log for every well-behaved
+  keep-alive client. Genuine read ERRORS still log as errors; only the EOF case changed.
 
 ### Limits and budgets
 
@@ -802,9 +831,12 @@ exercise changes, not on suspicion.
   descriptors, the budget driven to its ceiling and abandoned 150 times with `SO_LINGER {1,0}`
   and still 0 at rest. An RSS creep of ~15 B/request was chased and proved allocator behaviour
   (`leaks(1)` zero; live bytes fell between samples; a legitimate-traffic control showed the
-  same slope). **PR #72's connection reuse (`_keepAliveTimeout`, `_carryOverData`,
-  `kMaxRequestsPerConnection`) has NOT been soaked and should be, with keep-alive ENABLED, before
-  the next release.** Re-run when the connection or response layer changes (PR #48 did; the full re-run
+  same slope). PR #72's connection reuse HAS since been soaked with keep-alive ENABLED — 6.01 h,
+  85,210,679 requests, 14.4 TB, descriptors at baseline and `reservedInMemoryByteCount` 0 at rest.
+  **But that soak did not PIPELINE** (its client read one response per write), so it never touched
+  `_carryOverData`, which is the path the narrow audit then found three defects in. **A pipelining
+  soak is the outstanding debt, and it should run against the fixed tree before the next release.**
+  Re-run when the connection or response layer changes (PR #48 did; the full re-run
   has since exercised it).
 - **Torn writes do not happen** — 240 concurrent 128 KiB + 90 concurrent 4 MiB PUTs, zero mixed
   files (the body always lands in a temp file first). **Atomic replacement under load is safe**
@@ -826,7 +858,18 @@ exercise changes, not on suspicion.
   one request per connection, `Connection: Close`, leftover bytes dropped) — verified LIVE by
   pipelining. With `WSKOption_ConnectionKeepAliveTimeout` set, that premise is preserved by
   restricting reuse to requests carrying NO body framing, so nothing can be framed by a length the
-  next request disagrees about — but **the pipelining probe has not been re-run in that mode**. ~7,000 mutated
+  next request disagrees about. That mode HAS now been probed: the split-invariance oracle replayed
+  ten pipelined byte-streams — bodyless runs, a body between two GETs, a bad chunk, `Connection:
+  close` mid-stream, an HTTP/1.0 request mid-stream — at every single-byte split offset and
+  byte-at-a-time, 1,355 segmentations, run against BOTH trees with the same oracle: **14 status
+  disagreements before, 4 and 6 in two runs after**. Read the BASELINES, not the counts — the
+  counts are RST timing and move in both directions between runs (one shape went 1→0, another
+  0→4), while the baselines changed exactly where they should: `200,400,close` → `200,200,close`
+  and `400,close` → `200,close`, with "GET then bad chunk then GET" correctly still baselining at
+  `400`. A genuinely malformed body is still refused; only the spurious refusal went. What remains
+  is the RST-lost-response shape (`200,200,close` becoming `200,error`: the reply was produced, the
+  client never got to read it), not a difference in what the server DECIDED. That is evidence
+  against desync, not proof of its absence. ~7,000 mutated
   requests under ASan+UBSan: zero memory errors. 9,366 injected allocation failures: nothing,
   zero descriptor leaks.
 - **Conformance and real clients**, RE-TAKEN against tip after the #70/#71/#75 status changes and
@@ -943,31 +986,21 @@ and the two `Allow` gaps, which the draft had merged into one bullet):
 - A symlinked share receives no `NSFilePresenter` events at all.
 
 From the outside audit (an independent agent, 23 findings, 5 solid after adversarial review — see
-the appendix). Still open, roughly in order of weight:
-- **Request-body failures all collapse into 500.** The body-read protocol reports failure as a
-  plain BOOL, so malformed chunking, gzip corruption, a multipart rejection, a decompression-limit
-  hit, aggregate-memory exhaustion and a disk-write failure are indistinguishable at the
-  connection layer — where 400, 413, 503 and 507 are each owed. This file already admits ONE
-  instance of it (the budget-exhaustion 500 under "Limits and budgets"); the audit's contribution
-  is that the class is much wider. Needs a typed failure reason threaded through the body-read
-  path, which is why it was not taken with the rest.
-- **`-_willEnterForeground:` still calls `[self _start:NULL]` under a TODO saying nothing can be
-  done on failure.** Its sibling `-_reconnectInForeground:` got the error handling; this is the
-  DEFAULT path (`suspendInBackground` defaults to YES), so the fix landed on the opt-in
-  configuration. The signature shape, again. Note the consequence claim is NOT that the app
-  believes it resumed — `-isRunning` and `-serverURL` report honestly; what is lost is the
-  diagnostic and the `NSError`.
-- **`indexFilename` is appended to a resolved directory without re-resolving containment**, so a
-  value containing a separator or `..` escapes the served root (`O_NOFOLLOW` guards only the
-  final component). Host-app reachable only — no client input reaches it, and every in-tree
-  caller passes nil — but it is a hole in a guarantee the public header states unconditionally.
-- **`acceptsGzipContentEncoding` is parsed by case-sensitive substring** (`gzip;q=0` reads as
-  YES, `GZIP` and `*` as NO) **and is read by nothing in the library** — a public-API honesty bug
-  rather than a live serving defect, and the token-exact spelling it should use is 120 lines above
-  it in the same file.
-- **An unmatched request always answers 501**, conflating "unknown target" (404) and "wrong method
-  for a known target" (405 + `Allow`). The bare server is affected; the uploader's catch-all GET
-  handler already restores 404 for things like `/favicon.ico`.
+the appendix). **All five are now CLOSED** — by #74 (typed body-failure statuses) and #75 (the
+audit tail). They are struck here rather than deleted because this list asserted them as open for
+six days after the code stopped agreeing, which is this file's own signature failure and worth
+leaving visible:
+- ~~Request-body failures all collapse into 500~~ — `_StatusForBodyError` maps a typed
+  `WSKRequestBodyErrorCode` to 400/413/503/500 (#74). Verified at tip.
+- ~~`-_willEnterForeground:` calls `[self _start:NULL]`~~ — it passes `&error` and logs (#75).
+- ~~`indexFilename` escapes the served root~~ — it goes through `WSKResolveWithinDirectory` and is
+  refused with a warning when it lands outside (#75).
+- ~~`acceptsGzipContentEncoding` parsed by case-sensitive substring~~ — `_AcceptEncodingAllowsGzip`
+  now parses tokens and q-values (#75).
+- ~~An unmatched request always answers 501~~ — it consults `_registeredMethods` and answers 404
+  when some handler implements the method (#75). **405 with `Allow` remains deliberately
+  unattempted**: a handler is an opaque match block, so the server cannot ask which methods a path
+  accepts without changing the registration model.
 - ~~Ten of the audit's findings were never adversarially verified~~ — **done**. Four had already
   been closed by #75; of the six that remained, **five were refuted** and one was real:
   `Transfer-Encoding: identity` (the desync it implied is closed by construction, since reuse is
@@ -977,6 +1010,23 @@ the appendix). Still open, roughly in order of weight:
   halves attributed to the wrong method — file-presenter events never call it); and the unchecked
   `dispatch_source_create` (its arguments are statically pinned, so NULL cannot occur). The
   survivor was the weak-delegate swap, now fixed.
+
+From the narrow audit of #72's 1,024 new lines (two lenses and the split-invariance oracle
+converged on the same area; four defects fixed, one left open):
+- **No lingering close, so a client can lose the last response to a RST.** When the server closes
+  with unread bytes still in its receive buffer — which is exactly what pipelining past a
+  non-reusable request produces — Darwin sends RST rather than FIN, and the client's unread receive
+  buffer is discarded with it. Measured as `200,error` where `200,200,error` was owed, in a minority
+  of segmentations. RFC 9112 §9.6's remedy is `shutdown(SHUT_WR)` then drain-before-close. NOT taken
+  in that batch: it holds a connection slot open longer on a server with a 128-slot cap, so it needs
+  its own bounded design rather than being tacked onto a fix for something else. **Pre-existing and
+  unchanged by the fixes** — 48 differing segmentations before, 47 after, on the same shape.
+- **The split-invariance oracle needed refining before its verdict meant anything.** It compared
+  the connection's manner of ending as if it were a status, so it reported 228 disagreements of
+  which every single one was FIN-vs-RST, at the same rate on both trees. It now compares statuses
+  and counts endings separately. Its `HEAD then GET -> desync` baseline is likewise the oracle's own
+  bug — its client consumes `Content-Length` bytes after a HEAD response, which has none. A RED
+  signal from an unvalidated oracle is worth exactly as much as a green one.
 
 Carried from earlier passes, never closed:
 - **PROPFIND publishes no `getetag`** — a just-written file has ZERO validators for a

--- a/Framework/TestsSupport.h
+++ b/Framework/TestsSupport.h
@@ -17,6 +17,7 @@
 extern NSData* SSEData(NSString* string);
 extern int ConnectToLocalhostPort(NSUInteger port);
 extern NSData* ReadToEOF(int fd, BOOL* sawEOF);
+extern NSUInteger DrainToEOFAtPace(int fd, NSUInteger chunkSize, useconds_t pauseMicroseconds);
 extern NSData* GZipDecompress(NSData* input);
 extern NSData* DrainResponseBody(WSKResponse* response);
 extern NSData* GZipCompress(NSData* input);
@@ -35,6 +36,17 @@ extern NSString* gAbortRequestPeer;
 extern BOOL gAbortRequestSawVirtualHEAD;
 
 @interface AbortProbeConnection : WSKConnection
+@end
+
+// Observes the documented -open/-close subclassing pair, plus every -abortRequest: status. Both
+// hooks are declared once-per-CONNECTION ("called when the connection is opened", and -open may
+// return NO to reject it), so a host app that allocates in one and releases in the other is
+// following the header. Connection reuse has to leave that pairing intact, and it must not
+// manufacture a response when a persistent connection simply ends — the events are recorded in
+// order so a test can assert on the whole sequence rather than a count.
+extern NSMutableArray<NSString*>* gConnectionEvents;
+
+@interface LifecycleProbeConnection : WSKConnection
 @end
 
 // Two delegates for the weak-delegate swap test. What matters is that BOTH conform and BOTH are

--- a/Framework/TestsSupport.m
+++ b/Framework/TestsSupport.m
@@ -47,6 +47,37 @@ int ConnectToLocalhostPort(NSUInteger port) {
     return fd;
 }
 
+// Drains to EOF at a deliberate pace: read a chunk, pause, repeat. Counting the bytes is all the
+// caller wants, so nothing is accumulated.
+//
+// The pacing is the whole point and a plain sleep will not do. A client that simply stops reading
+// stalls the server's pending write, and the ordinary response-phase idle rule reclaims it after
+// two tickless — correctly. Pacing keeps bytes moving on every tick, so that rule can never fire,
+// while the transfer still spans several ticks. Anything that cuts the response short under those
+// conditions is a deadline being applied where it does not belong.
+NSUInteger DrainToEOFAtPace(int fd, NSUInteger chunkSize, useconds_t pauseMicroseconds) {
+    void* const buffer = malloc(chunkSize);
+    NSUInteger total = 0;
+
+    if (buffer == NULL) {
+        return 0;
+    }
+
+    while (1) {
+        ssize_t const got = recv(fd, buffer, chunkSize, 0);
+
+        if (got <= 0) {
+            break;  // 0 is EOF; negative is the reset a reclaimed connection produces, or the timeout
+        }
+
+        total += (NSUInteger)got;
+        usleep(pauseMicroseconds);
+    }
+
+    free(buffer);
+    return total;
+}
+
 // Reads until the peer closes the connection (EOF) or the receive timeout fires.
 // Returns the accumulated bytes; *sawEOF reports whether EOF was actually seen.
 NSData* ReadToEOF(int fd, BOOL* sawEOF) {
@@ -379,6 +410,37 @@ BOOL gAbortRequestSawVirtualHEAD = NO;
     gAbortRequestPeer = request.remoteAddressString;
     gAbortRequestSawVirtualHEAD = request.isVirtualHEAD;
     [super abortRequest:request withStatusCode:statusCode];
+}
+
+@end
+
+
+NSMutableArray<NSString*>* gConnectionEvents = nil;
+
+@implementation LifecycleProbeConnection
+
+// Appended to from the connection queue, read from the test thread only after the server has
+// stopped, which is a full barrier over every connection queue.
+- (BOOL)open {
+    BOOL const opened = [super open];
+    @synchronized(gConnectionEvents) {
+        [gConnectionEvents addObject:@"open"];
+    }
+    return opened;
+}
+
+- (void)abortRequest:(WSKRequest*)request withStatusCode:(NSInteger)statusCode {
+    @synchronized(gConnectionEvents) {
+        [gConnectionEvents addObject:[NSString stringWithFormat:@"abort %i", (int)statusCode]];
+    }
+    [super abortRequest:request withStatusCode:statusCode];
+}
+
+- (void)close {
+    @synchronized(gConnectionEvents) {
+        [gConnectionEvents addObject:@"close"];
+    }
+    [super close];
 }
 
 @end

--- a/Framework/WSKConnectionTests.m
+++ b/Framework/WSKConnectionTests.m
@@ -724,6 +724,154 @@
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// The reaper that reclaims an IDLE reused connection must not fire on one that is busy. A request
+// arriving in the previous request's final read is served without a single further byte being read,
+// and the "has the next request started arriving?" test was a read-count comparison — which such a
+// request can never satisfy, because its bytes were counted against the request before it. So the
+// connection was still marked idle while its response was streaming, and the keep-alive deadline
+// cut the body off mid-transfer under a Content-Length it then never reached.
+//
+// That is the worst shape a bug can take here: a complete, well-formed, WRONG response. The
+// deployment this library is aimed at pulls multi-hundred-megabyte builds, so a body that stops
+// early and claims not to have is an IPA that installs and crashes.
+- (void)testPipelinedRequestIsNotReclaimedWhileItsResponseIsStillStreaming {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    NSUInteger const bigLength = 8 * 1024 * 1024;
+    XCTAssertTrue([@"ALPHA" writeToFile:[dir stringByAppendingPathComponent:@"a.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    XCTAssertTrue([[NSMutableData dataWithLength:bigLength] writeToFile:[dir stringByAppendingPathComponent:@"big.bin"] atomically:YES]);
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addGETHandlerForBasePath:@"/f/" directoryPath:dir indexFilename:nil cacheAge:0 allowRangeRequests:YES];
+    // A short keep-alive and a matching tick, so the reaper's deadline lands about one second in —
+    // comfortably inside the paced transfer below, which takes roughly 2.5 s.
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_ConnectionKeepAliveTimeout : @0.5, WSKOption_ConnectionIdleTimeout : @0.5};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* const first = @"GET /f/a.txt HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    NSString* const second = @"GET /f/big.bin HTTP/1.1\r\nHost: localhost\r\n\r\n";
+
+    // PIPELINED: both requests in one write, so the second is served entirely from carried-over
+    // bytes and the connection performs no read at all while answering it.
+    int fd = ConnectToLocalhostPort(server.port);
+    XCTAssertTrue(fd >= 0);
+    NSString* const both = [first stringByAppendingString:second];
+    XCTAssertEqual(send(fd, both.UTF8String, strlen(both.UTF8String), 0), (ssize_t)strlen(both.UTF8String));
+    NSUInteger const pipelinedBytes = DrainToEOFAtPace(fd, 32 * 1024, 10000);
+    close(fd);
+
+    // SEQUENTIAL CONTROL: the same two requests, but the second written after the first reply is
+    // read, so its bytes DO arrive as a socket read. This exercises everything the pipelined case
+    // does except the carried-over path, and it must pass whether or not the bug is present — if it
+    // fails too, the test is measuring the ordinary response-phase idle rule and proves nothing.
+    fd = ConnectToLocalhostPort(server.port);
+    XCTAssertTrue(fd >= 0);
+    XCTAssertEqual(send(fd, first.UTF8String, strlen(first.UTF8String), 0), (ssize_t)strlen(first.UTF8String));
+    char reply[4096];
+    XCTAssertTrue(recv(fd, reply, sizeof(reply), 0) > 0, @"the first reply must arrive before the second request is sent");
+    XCTAssertEqual(send(fd, second.UTF8String, strlen(second.UTF8String), 0), (ssize_t)strlen(second.UTF8String));
+    NSUInteger const sequentialBytes = DrainToEOFAtPace(fd, 32 * 1024, 10000);
+    close(fd);
+
+    XCTAssertGreaterThan(sequentialBytes, bigLength, @"CONTROL FAILED: a sequential reused connection lost bytes too, so this test is measuring the ordinary idle rule rather than the keep-alive reaper");
+    XCTAssertGreaterThan(pipelinedBytes, bigLength, @"a pipelined response was cut short at %lu of %lu bytes: the connection was treated as idle while it was streaming", (unsigned long)pipelinedBytes, (unsigned long)bigLength);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
+// Everything past the header block was required to fit inside Content-Length, and anything more was
+// answered 400. TCP makes no such promise: a client that writes a body-bearing request and whatever
+// follows it in one segment lands both in one read. Refusing that is honouring a guess about
+// segmentation, and it made the verdict depend on how the client happened to split its writes —
+// the same split-dependence class this project already has an oracle for.
+//
+// The trailing bytes are still never INTERPRETED: a request carrying body framing is not eligible
+// for reuse, so the connection closes after it and the remainder is dropped exactly as before.
+// Nothing here widens what may be framed on a reused connection.
+- (void)testRequestWithBytesTrailingItsBodyIsServedRatherThanRefused {
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addHandlerForMethod:@"POST"
+                           path:@"/echo"
+                   requestClass:[WSKDataRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithData:[(WSKDataRequest*)request data] contentType:@"text/plain"];
+                   }];
+    [server addHandlerForMethod:@"GET"
+                           path:@"/ok"
+                   requestClass:[WSKRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"OK"];
+                   }];
+
+    // DEFAULT configuration — no keep-alive. This is not a reuse defect: the check predates
+    // connection reuse entirely, and a single write is all it takes to reach it.
+    NSDictionary* defaultOptions = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};  // Hoisted: the commas would split the macro's arguments
+    XCTAssertTrue([server startWithOptions:defaultOptions error:NULL]);
+    NSString* const trailing = @"POST /echo HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\nBODYGET /ok HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    NSString* reply = SendRawRequest(server.port, trailing);
+    XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 200"], @"a request whose body is followed by more bytes in the same read must still be served: %@", [reply substringToIndex:MIN((NSUInteger)40, reply.length)]);
+    XCTAssertTrue([reply containsString:@"BODY"], @"the body must be exactly Content-Length bytes, with the trailing bytes excluded: %@", reply);
+    [server stop];
+
+    // And with reuse enabled, where a pipelining client produces the same shape deliberately.
+    NSDictionary* keepAliveOptions = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_ConnectionKeepAliveTimeout : @5.0};
+    XCTAssertTrue([server startWithOptions:keepAliveOptions error:NULL]);
+    NSArray<NSString*>* replies = SendRawRequestsOnOneConnection(server.port, @[ [@"GET /ok HTTP/1.1\r\nHost: localhost\r\n\r\n" stringByAppendingString:trailing], @"" ]);
+    XCTAssertTrue(replies.count >= 1);
+    XCTAssertTrue([replies.firstObject hasPrefix:@"HTTP/1.1 200"], @"first: %@", replies.firstObject);
+    XCTAssertFalse([replies.firstObject containsString:@"400"], @"a pipelined body-bearing request must not be refused: %@", replies.firstObject);
+    [server stop];
+}
+
+// -open and -close are the documented connection-lifecycle pair: -open is "called when the
+// connection is opened" and may return NO to REJECT it, which is only meaningful once per
+// connection. A host app pairing them — allocate in one, release in the other — is following the
+// header. Reuse called -close once per REQUEST, so two requests on one connection produced one
+// open and two closes, and the second release had nothing left to release.
+//
+// The same sequence pins the other half: a persistent connection ending because the client went
+// away is the designed end of one, not a failure, and must not manufacture a response for a
+// request that does not exist.
+- (void)testReusedConnectionOpensAndClosesOnceAndInventsNoResponseAtTheEnd {
+    gConnectionEvents = [NSMutableArray array];
+
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addHandlerForMethod:@"GET"
+                           path:@"/ok"
+                   requestClass:[WSKRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"OK"];
+                   }];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES, WSKOption_ConnectionKeepAliveTimeout : @5.0, WSKOption_ConnectionClass : [LifecycleProbeConnection class]};
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSArray<NSString*>* replies = SendRawRequestsOnOneConnection(server.port, @[ @"GET /ok HTTP/1.1\r\nHost: localhost\r\n\r\nGET /ok HTTP/1.1\r\nHost: localhost\r\n\r\n", @"" ]);
+    XCTAssertEqual(replies.count, (NSUInteger)2, @"both requests must be answered before the pairing is judged");
+
+    [server stop];  // A full barrier over every connection queue, so the events are complete and stable.
+
+    NSArray<NSString*>* events = [gConnectionEvents copy];
+    XCTAssertEqual([events componentsJoinedByString:@" "].length > 0, YES);
+    NSUInteger opens = 0, closes = 0, aborts = 0;
+
+    for (NSString* event in events) {
+        if ([event isEqualToString:@"open"]) {
+            opens += 1;
+        } else if ([event isEqualToString:@"close"]) {
+            closes += 1;
+        } else if ([event hasPrefix:@"abort"]) {
+            aborts += 1;
+        }
+    }
+
+    XCTAssertEqual(opens, (NSUInteger)1, @"one connection, so one -open: %@", events);
+    XCTAssertEqual(closes, opens, @"-close must pair with -open, not run once per request: %@", events);
+    XCTAssertEqual(aborts, (NSUInteger)0, @"a client closing a persistent connection is its designed end, not a request to refuse: %@", events);
+
+    gConnectionEvents = nil;
+}
+
 - (void)testAbortedRequestCarriesItsAddressesAndHEADFlag {
     gAbortRequestPeer = nil;
     gAbortRequestSawVirtualHEAD = NO;

--- a/Sources/WebServerKit/Core/WSKConnection.m
+++ b/Sources/WebServerKit/Core/WSKConnection.m
@@ -74,6 +74,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readNextBodyChunk:(NSMutableData *)chunkData completionBlock:(ReadBodyCompletionBlock)block;
 @end
 
+@interface WSKConnection (Logging)
+- (void)_flushRequestRecordAndLog;
+@end
+
 @interface WSKConnection (Write)
 - (void)writeData:(NSData *)data withCompletionBlock:(WriteDataCompletionBlock)block;
 - (void)writeHeadersWithCompletionBlock:(WriteHeadersCompletionBlock)block;
@@ -134,6 +138,7 @@ NS_ASSUME_NONNULL_END
     NSUInteger _requestsServed;         // Bounds how long one client can hold a connection slot
     NSUInteger _readBytesWhenIdleBegan;  // Read count when the last response finished; the next request can only arrive as reads
     NSMutableData *_carryOverData;      // Bytes of the NEXT request that arrived in this request's last read
+    BOOL _requestLogged;                // This request's access line and recording are already flushed
     WSKMemoryReservation *_chunkReservation;  // This connection's chunked framing buffer
 
 #ifdef __WEBSERVERKIT_ENABLE_TESTING__
@@ -538,6 +543,11 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
     _bodyFailureStatus = kWSKHTTPStatusCode_InternalServerError;
     _chunkReservation = nil;  // Named in the reuse ivar block, so it is cleared here like the rest
     _headerPhaseTicks = 0;  // Or the second request inherits the first's deadline and is killed early.
+    // _requestLogged is deliberately NOT cleared here, and this note exists so the omission reads
+    // as a decision rather than the leak this method exists to prevent. It is cleared where the
+    // next request's header block actually ARRIVES: this reset runs whether or not another request
+    // ever comes, so clearing it here would leave the connection believing it still owed a log line
+    // for the request it just finished, and -close would write a second, emptied-out one.
 
 #ifdef __WEBSERVERKIT_ENABLE_TESTING__
     _requestPath = nil;
@@ -554,8 +564,12 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
         return;
     }
 
-    [self close];  // Flush this request's log line and any recording while its state is still live.
-    _opened = NO;  // -dealloc must not close it a second time.
+    // Flush this request's log line and any recording while its state is still live. NOT -close:
+    // that is the connection-level subclassing hook, documented as the partner of -open ("called
+    // when the connection is opened", and able to REJECT it by returning NO), so it is meaningful
+    // only once per connection. Calling it per request gave a host app pairing the two — allocate
+    // in one, release in the other — one open and N closes.
+    [self _flushRequestRecordAndLog];
     _requestsServed += 1;
     [self _resetForNextRequest];
     // Snapshot the READ count, not read+written. The response that just went out moved bytes, so
@@ -904,10 +918,24 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
     if (_carryOverData.length > 0) {
         [headersData appendData:_carryOverData];
         _carryOverData = nil;
+        // The next request is already in hand, so this connection is NOT idle and the keep-alive
+        // reaper below must not judge it. Nothing else can clear the flag on this path: the idle
+        // check clears it by noticing _totalBytesRead RISE, and a request served entirely from
+        // carried-over bytes issues no read at all, because those bytes were counted against the
+        // request before it. Left set, the reaper ran against a response that was still streaming
+        // and cut the body off mid-transfer — under a Content-Length it then never reached.
+        _awaitingNextRequest = NO;
+        _headerPhaseTicks = 0;  // A fresh header-phase budget, exactly as the idle check hands out
     }
     [self readHeaders:headersData
         withCompletionBlock:^(NSData *extraData) {
             if (extraData) {
+                // A header block arrived, so there is a new request to account for. Cleared HERE
+                // rather than in -_resetForNextRequest because the reset runs whether or not
+                // another request ever comes: a persistent connection whose client simply goes
+                // away must leave the last real request marked as flushed, or -close logs a second
+                // line for a request it has already reset away.
+                self->_requestLogged = NO;
                 // An HTTP/1.0 client cannot parse a chunked body or an interim 1xx response,
                 // so remember which dialect it speaks before framing anything back at it.
                 NSString *const requestVersion = CFBridgingRelease(CFHTTPMessageCopyVersion(self->_requestMessage));
@@ -984,35 +1012,48 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
                                 return;
                             }
 
-                            if (self->_request.usesChunkedTransferEncoding || (extraData.length <= self->_request.contentLength)) {
-                                NSString *const expectHeader = requestHeaders[@"Expect"];
+                            // Everything past the header block, trimmed to the body this request
+                            // declared. More than that is not an error: a client may write its
+                            // body and whatever follows it in one segment, and TCP is free to
+                            // deliver the two in a single read regardless. Refusing it with 400
+                            // made the verdict depend on how the client happened to split its
+                            // writes — the split-dependence class this project has an oracle for
+                            // — and it refused ordinary pipelining outright.
+                            //
+                            // The remainder is DROPPED, never interpreted. A request carrying body
+                            // framing is not eligible for reuse, so this connection closes after
+                            // it; that is what keeps "nothing can be framed by a length the next
+                            // request disagrees about" structurally true rather than parsed-for.
+                            NSData *bodyData = extraData;
 
-                                if (expectHeader && !self->_clientIsHTTP10) {
-                                    if ([expectHeader caseInsensitiveCompare:@"100-continue"] == NSOrderedSame) {  // TODO: Actually validate request before continuing
-                                        [self writeData:_continueData
-                                            withCompletionBlock:^(BOOL success) {
-                                                if (success) {
-                                                    [self _readRequestBodyWithInitialData:extraData];
-                                                } else {
-                                                    // Without this the request is left neither answered nor
-                                                    // aborted, and the connection just unwinds silently.
-                                                    [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
-                                                }
-                                            }];
-                                    } else {
-                                        WSK_LOG_ERROR(@"Unsupported 'Expect' / 'Content-Length' header combination on socket %i", self->_socket);
-                                        [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_ExpectationFailed];
-                                    }
+                            if (!self->_request.usesChunkedTransferEncoding && (extraData.length > self->_request.contentLength)) {
+                                bodyData = [extraData subdataWithRange:NSMakeRange(0, self->_request.contentLength)];
+                            }
+
+                            NSString *const expectHeader = requestHeaders[@"Expect"];
+
+                            if (expectHeader && !self->_clientIsHTTP10) {
+                                if ([expectHeader caseInsensitiveCompare:@"100-continue"] == NSOrderedSame) {  // TODO: Actually validate request before continuing
+                                    [self writeData:_continueData
+                                        withCompletionBlock:^(BOOL success) {
+                                            if (success) {
+                                                [self _readRequestBodyWithInitialData:bodyData];
+                                            } else {
+                                                // Without this the request is left neither answered nor
+                                                // aborted, and the connection just unwinds silently.
+                                                [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_InternalServerError];
+                                            }
+                                        }];
                                 } else {
-                                    // An HTTP/1.0 client has no concept of an interim response: it would
-                                    // read "100 Continue" as the final one and then mis-parse the real
-                                    // response as the body. It is not waiting for one either, so ignore
-                                    // any Expect it sent and just read the body.
-                                    [self _readRequestBodyWithInitialData:extraData];
+                                    WSK_LOG_ERROR(@"Unsupported 'Expect' / 'Content-Length' header combination on socket %i", self->_socket);
+                                    [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_ExpectationFailed];
                                 }
                             } else {
-                                WSK_LOG_ERROR(@"Unexpected 'Content-Length' header value on socket %i", self->_socket);
-                                [self abortRequest:self->_request withStatusCode:kWSKHTTPStatusCode_BadRequest];
+                                // An HTTP/1.0 client has no concept of an interim response: it would
+                                // read "100 Continue" as the final one and then mis-parse the real
+                                // response as the body. It is not waiting for one either, so ignore
+                                // any Expect it sent and just read the body.
+                                [self _readRequestBodyWithInitialData:bodyData];
                             }
                         } else {
                             // No body to read, so anything past the header block belongs to the
@@ -1078,6 +1119,14 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
                     WSK_LOG_ERROR(@"Failed decoding request target on socket %i", self->_socket);
                     [self abortRequest:nil withStatusCode:kWSKHTTPStatusCode_BadRequest];
                 }
+            } else if (self->_awaitingNextRequest && (self->_totalBytesRead == self->_readBytesWhenIdleBegan)) {
+                // A persistent connection whose client went away without beginning another
+                // request. That is how one is SUPPOSED to end — there is no request to refuse,
+                // and nobody left to read an answer — so it unwinds silently. It used to take
+                // the branch below and write a 500 into a socket that was already gone, which
+                // put a fabricated server error in the access log for every well-behaved
+                // keep-alive client.
+                WSK_LOG_DEBUG(@"Client closed idle keep-alive connection on socket %i", self->_socket);
             } else {
                 // A header block we could not read is the client's problem far more often
                 // than ours — it is malformed, or it is larger than kHeadersMaxLength.
@@ -1207,7 +1256,12 @@ static BOOL _HeadersCarryNoBodyFraming(NSDictionary *headers) {
                     [self didReadBytes:((char *)data.bytes + originalLength) length:(data.length - originalLength)];
                     block(YES);
                 } else {
-                    if (self->_totalBytesRead > 0) {
+                    if (self->_awaitingNextRequest) {
+                        // The designed end of a persistent connection, not a failure: the client
+                        // finished with it and closed. Logging that at ERROR made every correct
+                        // keep-alive client look like a fault.
+                        WSK_LOG_DEBUG(@"Client closed idle keep-alive connection on socket %i", self->_socket);
+                    } else if (self->_totalBytesRead > 0) {
                         WSK_LOG_ERROR(@"No more data available on socket %i", self->_socket);
                     } else {
                         WSK_LOG_WARNING(@"No data received from socket %i", self->_socket);
@@ -2095,7 +2149,11 @@ static inline BOOL _CompareResources(NSString *responseETag, NSString *requestET
     WSK_LOG_DEBUG(@"Connection aborted with status code %i on socket %i", (int)statusCode, _socket);
 }
 
-- (void)close {
+// One request's worth of bookkeeping: move its recording into place and write its access-log line.
+// Split out of -close, which is a once-per-CONNECTION hook, because a reused connection owes one of
+// these per REQUEST — and the last request on such a connection reaches only -close.
+- (void)_flushRequestRecordAndLog {
+    _requestLogged = YES;  // Cleared when the next request's header block arrives, so -close cannot double-log
 #ifdef __WEBSERVERKIT_ENABLE_TESTING__
 
     if (_requestPath) {
@@ -2140,6 +2198,15 @@ static inline BOOL _CompareResources(NSString *responseETag, NSString *requestET
         WSK_LOG_VERBOSE(@"[%@] %@ %i \"%@ %@\" (%lu | %lu)", self.localAddressString, self.remoteAddressString, (int)_statusCode, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead, (unsigned long)_totalBytesWritten);
     } else {
         WSK_LOG_VERBOSE(@"[%@] %@ %i \"(invalid request)\" (%lu | %lu)", self.localAddressString, self.remoteAddressString, (int)_statusCode, (unsigned long)_totalBytesRead, (unsigned long)_totalBytesWritten);
+    }
+}
+
+- (void)close {
+    // The connection is ending. Only the request still un-flushed is owed anything here: on a
+    // reused connection every earlier one was flushed as its response completed, and flushing again
+    // would log a second, emptied-out line for a request that has already been reset away.
+    if (!_requestLogged) {
+        [self _flushRequestRecordAndLog];
     }
 }
 


### PR DESCRIPTION
A narrow audit of #72's 1,024 new lines. Two lenses and the split-invariance oracle converged on the same area independently, which is the strongest agreement signal this project has produced.

## The truncation

`_awaitingNextRequest` was cleared only when the read count rose — which a request served entirely from `_carryOverData` can never do, because its bytes were counted against the request *before* it. So the connection stayed marked idle while its response streamed, and the keep-alive reaper shut the socket down mid-body:

```
keepAlive 5 / idle 30 (default):  15,867,384 of 16,777,216 bytes   TRUNCATED
control (two separate writes):    16,777,216                       complete
keepAlive 60 / idle 1:            16,777,216                       complete
```

A truncated 200 OK under a `Content-Length` it never reaches, on the large-build path this library exists to serve.

## The spurious 400 — not a reuse defect

`extraData.length <= contentLength` assumed nothing can follow a body in one read. TCP makes no such promise. It is reachable **in the default configuration** with a single write, and `git log -L` puts it in upstream GCDWebServer, predating connection reuse entirely. Trailing bytes are now trimmed to `Content-Length`; the remainder is **dropped, never interpreted**, so a body-bearing request is still ineligible for reuse and nothing can be framed by a length the next request disagrees about.

## The `-open`/`-close` contract

`-open` is documented as the connection-level hook that may *reject* a connection by returning `NO`. Reuse made its partner fire per request — one open, N closes. Per-request work moved to `-_flushRequestRecordAndLog`; `-close` flushes only what has not been flushed.

## Plus

A client closing a persistent connection is its designed end: no `ERROR` line, no 500 written into a socket that is already gone.

## Verification

Each new test was run against the unfixed tree first and fails there on its intended assertion (`3,622,183 of 8,388,608`; `HTTP/1.1 400`; `closes=2, opens=1`). The truncation test carries a **sequential control that must pass on both trees** — without it, it cannot be distinguished from the ordinary response-phase idle rule.

Split-invariance, same oracle against both trees: **14 status disagreements before, 4 and 6 in two runs after**. Read the baselines, not the counts — the counts are RST timing and moved in both directions between runs. The baselines changed exactly where they should (`200,400,close` → `200,200,close`), while a genuinely bad chunk still baselines at `400`.

162 tests, all eight trace suites (including WebDAV-Finder, which exercises the per-request trace recording that `-close` was restructured around), iOS and tvOS Debug clean.

## Left open, deliberately

No lingering close, so a client can lose the last response to a RST when the server closes with unread bytes buffered (RFC 9112 §9.6). Pre-existing and unchanged here — 48 differing segmentations before, 47 after. The remedy holds a connection slot open longer on a 128-slot server, so it wants its own bounded design rather than being tacked onto this.

`CLAUDE.md` also corrects five "still open" items that #74 and #75 had already closed, and records that the 6-hour keep-alive soak never pipelined — so a pipelining soak is still owed before release.