### PR TITLE
Fix three host-app aborts and a Depth check only three of four verbs performed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -833,11 +833,16 @@ exercise changes, not on suspicion.
   (`leaks(1)` zero; live bytes fell between samples; a legitimate-traffic control showed the
   same slope). PR #72's connection reuse HAS since been soaked with keep-alive ENABLED — 6.01 h,
   85,210,679 requests, 14.4 TB, descriptors at baseline and `reservedInMemoryByteCount` 0 at rest.
-  **But that soak did not PIPELINE** (its client read one response per write), so it never touched
-  `_carryOverData`, which is the path the narrow audit then found three defects in. **A pipelining
-  soak is the outstanding debt, and it should run against the fixed tree before the next release.**
-  Re-run when the connection or response layer changes (PR #48 did; the full re-run
-  has since exercised it).
+  But that soak did not PIPELINE (its client read one response per write), so it never touched
+  `_carryOverData`. **A pipelining soak has since run against the fixed tree**: 4.01 h, 748,020
+  requests, 1.01 TB, **312,820 replies served from carried-over bytes**, descriptors +0 at rest,
+  `reservedInMemoryByteCount` 0 with peak 0, zero unexpected statuses, still serving. Its
+  short-body tripwire was PROVEN SENSITIVE first — 119 against the pre-fix framework, 0 at tip —
+  which took two harness fixes to achieve and is the whole reason the 0 means anything (see
+  Lessons). Unexplained and NOT waved away: 32,875 connect failures where the previous soak had
+  zero, most likely listen-backlog saturation under 12 workers holding reused connections, partly
+  competing suite runs — cause not established. Re-run when the connection or response layer
+  changes (PR #48 did; the full re-run has since exercised it).
 - **Torn writes do not happen** — 240 concurrent 128 KiB + 90 concurrent 4 MiB PUTs, zero mixed
   files (the body always lands in a temp file first). **Atomic replacement under load is safe**
   — 915 `rename(2)` replacements, 47.7 GB, zero splices, with the oracle provably sensitive
@@ -1028,13 +1033,62 @@ converged on the same area; four defects fixed, one left open):
   bug — its client consumes `Content-Length` bytes after a HEAD response, which has none. A RED
   signal from an unvalidated oracle is worth exactly as much as a green one.
 
-Carried from earlier passes, never closed:
-- **PROPFIND publishes no `getetag`** — a just-written file has ZERO validators for a
-  PROPFIND-driven client. The obvious fix was measured as failing CI; needs care.
-- **MOVE/COPY of a collection relocates/duplicates members the allow-list refuses
-  individually** — the class closed for DELETE and the overwrite, at the two verbs it did not
-  reach. (Verify at tip before working on it; no entry records closing it.)
-- **MOVE has no Depth check at all.**
+Carried from earlier passes. **All nine were re-measured at tip by driving the code (not reading
+it), and all nine reproduced — nine skeptics, none refuted.** That is far above this project's
+usual ~1-in-3 survival rate, and the reason is worth noting: these are the project's OWN recorded
+items, not an outside reader's guesses. Aged findings still need re-measuring, but the base rate
+for a self-recorded backlog is much better than for an external audit. Three came back MORE precise
+than the record and are restated below; three are now fixed.
+
+- ~~`addHandlerForMethod:path:` aborts for a missing leading slash~~ — **fixed**: normalized like
+  its sibling, empty path refused loudly, and the regex variant now reports the `NSError` it was
+  discarding. Measured unfixed: SIGABRT/exit 134 in Debug at 5/5 entry points, and a silent 404 in
+  Release.
+- ~~`WSKDataRequest.text`/`.jsonObject` abort~~ — **fixed**: they return nil, as their `nullable`
+  headers always promised. Worth recording WHY this was more than an API-honesty bug: the
+  Content-Type that selects the branch is CLIENT input, so it was remotely triggerable, not host-app
+  misuse — which is the line the "genuine API-misuse assertions stay abort-in-Debug" decision draws.
+- ~~MOVE has no Depth check at all~~ — **fixed**: MOVE and COPY share `performCOPY:isMove:` and the
+  validation sat inside `if (!isMove)`, so every spelling — `banana`, `2`, `0,` — answered 201 and
+  performed a full recursive relocation while COPY, DELETE and PROPFIND all answered 400.
+  Deliberately NOT made stricter than COPY: RFC 4918 §9.9.2 forbids a non-infinity Depth on a MOVE
+  of a collection, but COPY and DELETE both accept `0` on a plain file because it means the same
+  thing there, and an asymmetry only MOVE enforces would refuse what real clients send.
+- **PROPFIND publishes no `getetag`** — confirmed at tip on EVERY path (allprop, no-body, Depth:1,
+  propname), and an explicit `<D:getetag/>` is answered in a **404 propstat**, so PROPFIND and GET
+  actively contradict each other about the same resource. A just-written file has zero validators
+  12/12, because the mtime seal correctly withholds `getlastmodified` and `getetag` does not exist
+  at all. The obvious fix was measured as failing CI; needs care.
+- **MOVE/COPY of a collection relocates/duplicates members the allow-list refuses individually** —
+  confirmed at tip. With `allowedFileExtensions = @["txt"]`, every DIRECT operation on
+  `Coll/sub/secret.pem` is 403, a recursive DELETE of the collection is 403, and a MOVE onto an
+  EXISTING destination is 403 — but MOVE and COPY of the collection to a NEW destination both
+  answer 201 and relocate/duplicate it. The vetting helper already has one home
+  (`WSKFirstUnvettableItemAtPath`); this is the two verbs it was never called from.
+- **403 where a 404 belongs when a parent collection is absent** — the record MERGED two cases that
+  measurement separates. The WRITE verbs (PUT, MKCOL, MOVE/COPY destination) already answer **409
+  Conflict**, which is RFC 4918-mandated and byte-identical to `rclone serve webdav`; nothing is
+  owed there and it must not be "fixed" to 404. It is the READ/property verbs (GET, HEAD, PROPFIND,
+  PROPPATCH, LOCK, UNLOCK, and DELETE one level deeper) that answer 403 where 404 is owed, and
+  `rclone copy dav:/a/b` CRITICALs on it. Cause: `_RealPath` tolerates exactly ONE missing trailing
+  component; two or more returns nil and every DAV verb maps nil to 403. **The obvious fix is
+  MEASURED WRONG** — mirroring the write verbs' `fileExistsAtPath:` parent precheck onto the read
+  verbs reopens the existence oracle `testUnresolvableEntriesFailClosedWithoutBreakingCreation`
+  closed, because that predicate answers YES/NO for paths OUTSIDE the share. The real fix has to
+  live inside `_RealPath` and distinguish "does not exist yet, entirely inside the share" from
+  "exists but cannot be resolved / escapes". That is a dedicated measured pass, per this file's own
+  rule about that function. Any regression test must use a TWO-or-more-missing-component path: a
+  one-level path already answers 404, so a test written against it passes on unfixed code.
+- **A symlinked share receives no `NSFilePresenter` events at all** — confirmed, 0 events vs 4 on
+  the identical real-path control, 3 runs each. The mismatch is NOT in
+  `-presentedSubitemDidChangeAtURL:`'s comparison, which is already correct — do not "fix" it there.
+- **The SSE prefix test has no separator boundary** — the record conflates TWO different prefix
+  tests. `-presentedSubitemDidChangeAtURL:` already HAS the boundary and measured clean;
+  `-_relativePathForAbsolutePath:` genuinely has none. Fix the second, leave the first alone.
+- **`_resolvedUploadDirectory` is captured once** — confirmed, but ONLY for the
+  symlinked-share-repointed trigger; the other half of the recorded claim did not reproduce. Once
+  the realpath changes under a live uploader, every SSE event from `/create`, `/upload`, `/delete`
+  and `/move` names the share root, 5/5.
 - A header-time refusal can lose its error-page body to a TCP reset (the status is never lost).
 - Phase 2's low-value structural tail: the URI-to-path derivation, and the limits/constants.
 
@@ -1116,6 +1170,20 @@ alongside the two that must change — the first change made deliberately under 
 - **A green oracle you have not proved sensitive proves nothing** — prove it by injecting the
   defect (the leak test, the splice oracle, the full-volume probe, the SPM consumer were each
   proven this way; the SPM consumer's first sensitivity attempt measured a cached 0.15 s build).
+  **An oracle can also be un-sensitive because its CONFIGURATION closes the window**, which looks
+  identical to a pass: the pipelining soak's short-body tripwire read 0 against the PRE-FIX
+  framework, because at a realistic 10 s keep-alive and 30 s tick a loopback response finishes long
+  before the reaper can fire. Only pacing the reads — bytes moving every tick, transfer spanning
+  several — opened the window, and then it read 119. Ask what configuration the defect NEEDS, not
+  just whether the check is present. The same harness first counted 190 "truncations" at tip that
+  were the server CORRECTLY refusing a torn read of a file its own writer thread replaces every
+  750 ms: an oracle that cannot tell correct behaviour from the defect is as useless as one that
+  cannot fire.
+- **A RED signal from an unvalidated oracle is worth exactly as much as a green one.** The
+  split-invariance fuzzer reported 228 disagreements and VERDICT: SPLIT-DEPENDENT, of which every
+  one was FIN-vs-RST at the same rate on both trees, and its `HEAD then GET -> desync` baseline was
+  its own client consuming `Content-Length` bytes after a HEAD response, which has none. Validate
+  an oracle before acting on its alarm, not only before trusting its silence.
 - **A workflow that infers "clean" from an empty results array cannot tell "nothing found" from
   "nothing checked"** — the twelfth pass reported CLEAN with every verifier dead (fourteen
   findings pending). Report coverage counters explicitly ("8 lenses, 22 skeptics, none dead").
@@ -1124,7 +1192,18 @@ alongside the two that must change — the first change made deliberately under 
   by grepping main for the code and `git merge-base --is-ancestor`; do not stack PRs here); a CI
   run reporting success for a pre-rebase SHA; `Run-Tests.sh` builds into `./build` while ad-hoc
   probes load from DerivedData, so a probe after a swap-build-restore reports the PREVIOUS build.
-  Always rebuild explicitly before believing a probe.
+  Always rebuild explicitly before believing a probe. **And a STALE LOG FILE reads exactly like a
+  passing run**: a `pgrep` that matched nothing broke an `&&` chain at the failed `kill`, so
+  `Run-Tests.sh` never executed — and the `grep` that followed read a log of the same name from
+  four days earlier and reported "149 tests, TEST SUCCEEDED, 8 corpus suites". The tell was the
+  COUNT: 149 where 165 was expected. Write to a fresh filename or `rm` it first, check the file's
+  timestamp, and treat a test total that does not match what you expect as a stop signal rather
+  than a curiosity. `Run-Tests.sh` also stops at the first test failure, so a run that fails a test
+  never reaches the trace corpus at all — "the suite ran" is not "the corpus ran".
+- **`Run-Tests.sh` and a running soak must not overlap.** The soak's 12 workers reproduce the
+  documented flake (`testConnectionClosesSlowlorisHeaderDribble` failed in-suite, then passed 3/3
+  in isolation WITH the soak still running). Pause the soak with `SIGSTOP`/`SIGCONT` rather than
+  killing it — the whole process, server included, freezes together.
 - **Check warnings against a clean `-derivedDataPath` or the count means nothing** — an
   incremental build recompiles nothing and reports zero (five warnings accumulated this way; the
   GNU `?:` class recurred and was caught only by the clean build).

--- a/Framework/WSKRequestBodyTests.m
+++ b/Framework/WSKRequestBodyTests.m
@@ -515,4 +515,49 @@
     XCTAssertEqual(WSKReservedMemoryLength(), (NSUInteger)0, @"reservations leaked after their holders were released");
 }
 
+// Both properties are declared nullable and documented as returning nil when the body cannot be
+// interpreted -- and both called WSK_DNOT_REACHED(), which is abort() in Debug. So the one case the
+// header tells a host app to check for was the one case that killed the process instead.
+//
+// Against the unfixed tree this does not "fail": it takes the whole runner down and the output
+// reads "Executed 0 tests, with 0 failures". Read the executed count, never the failure count --
+// four of batch A's six fixes had exactly this signature.
+- (void)testDataRequestTextAndJSONReturnNilRatherThanAbortingOnTheDocumentedCase {
+    NSDictionary* octetStream = @{@"Content-Type" : @"application/octet-stream", @"Content-Length" : @"4"};
+    WSKDataRequest* binary = OpenBodyRequest([WSKDataRequest class], octetStream);
+    XCTAssertNotNil(binary);
+    XCTAssertTrue([binary writeData:[@"data" dataUsingEncoding:NSUTF8StringEncoding] error:NULL]);
+    XCTAssertTrue([binary close:NULL]);
+
+    // Not text/*, so -text has nothing to decode: the header says nil, so nil it must be.
+    XCTAssertNil(binary.text, @"-text must honour its nullable declaration for a non-text content type");
+    // Not a JSON type either.
+    XCTAssertNil(binary.jsonObject, @"-jsonObject must honour its nullable declaration for a non-JSON content type");
+
+    // A request with NO Content-Type at all -- the shape a bare POST produces.
+    WSKDataRequest* untyped = OpenBodyRequest([WSKDataRequest class], @{@"Content-Length" : @"2"});
+
+    if (untyped) {
+        XCTAssertTrue([untyped writeData:[@"hi" dataUsingEncoding:NSUTF8StringEncoding] error:NULL]);
+        XCTAssertTrue([untyped close:NULL]);
+        XCTAssertNil(untyped.text, @"-text must return nil when there is no content type to judge");
+        XCTAssertNil(untyped.jsonObject, @"-jsonObject must return nil when there is no content type to judge");
+    }
+
+    // The positive half: the cases that MUST keep working, so the fix cannot be "always return nil".
+    NSDictionary* jsonHeaders = @{@"Content-Type" : @"application/json", @"Content-Length" : @"13"};
+    WSKDataRequest* json = OpenBodyRequest([WSKDataRequest class], jsonHeaders);
+    XCTAssertNotNil(json);
+    XCTAssertTrue([json writeData:[@"{\"ok\":true}xx" dataUsingEncoding:NSUTF8StringEncoding] error:NULL]);
+    XCTAssertTrue([json close:NULL]);
+    XCTAssertNil(json.jsonObject, @"malformed JSON is also a documented nil, not an abort");
+
+    NSDictionary* textHeaders = @{@"Content-Type" : @"text/plain; charset=utf-8", @"Content-Length" : @"5"};
+    WSKDataRequest* text = OpenBodyRequest([WSKDataRequest class], textHeaders);
+    XCTAssertNotNil(text);
+    XCTAssertTrue([text writeData:[@"hello" dataUsingEncoding:NSUTF8StringEncoding] error:NULL]);
+    XCTAssertTrue([text close:NULL]);
+    XCTAssertEqualObjects(text.text, @"hello", @"a genuine text/* body must still decode");
+}
+
 @end

--- a/Framework/WSKServerLifecycleTests.m
+++ b/Framework/WSKServerLifecycleTests.m
@@ -157,4 +157,50 @@
     [fm removeItemAtPath:dir error:NULL];
 }
 
+// A path with no leading slash aborted in Debug with no diagnostic and registered NOTHING in
+// Release -- so a host app got either a crash it could not read or a server that 404'd everything
+// with no clue why. This is the identical shape -addGETHandlerForBasePath: was given normalization
+// for one method away; leaving it here is recurring defect shape #2, a class closed at one of the
+// sites it occurs at.
+//
+// Like the other host-app process-kills, the unfixed signal is a DEAD RUNNER reporting
+// "Executed 0 tests, with 0 failures", not a red assertion.
+- (void)testHandlerRegistrationNormalizesAMissingLeadingSlashInsteadOfAborting {
+    WSKWebServer* server = [[WSKWebServer alloc] init];
+    [server addHandlerForMethod:@"GET"
+                           path:@"noslash"
+                   requestClass:[WSKRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"REACHED"];
+                   }];
+    // An unusable path must be refused loudly rather than aborting -- and must not register a
+    // handler that then shadows everything, which is why this is asserted rather than assumed.
+    [server addHandlerForMethod:@"GET"
+                           path:@""
+                   requestClass:[WSKRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"EMPTY"];
+                   }];
+    // A regex that cannot compile is the same shape: an unusable string argument, not a
+    // programming error worth killing the process over.
+    [server addHandlerForMethod:@"GET"
+                      pathRegex:@"[unterminated"
+                   requestClass:[WSKRequest class]
+                   processBlock:^WSKResponse*(WSKRequest* request) {
+                       return [WSKDataResponse responseWithText:@"REGEX"];
+                   }];
+
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};  // Hoisted: commas split the macro
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    NSString* reply = SendRawRequest(server.port, @"GET /noslash HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([reply containsString:@"REACHED"], @"a missing leading slash is a spelling, not an error: %@", reply);
+
+    // And the refused registrations really did register nothing, rather than claiming some path.
+    NSString* other = SendRawRequest(server.port, @"GET /anything-else HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    XCTAssertTrue([other hasPrefix:@"HTTP/1.1 404"], @"a refused registration must not shadow other paths: %@", other);
+
+    [server stop];
+}
+
 @end

--- a/Framework/WSKWebDAVTests.m
+++ b/Framework/WSKWebDAVTests.m
@@ -1049,4 +1049,53 @@
     XCTAssertEqual(WSKServerErrorStatusCodeForError(nil), kWSKHTTPStatusCode_InternalServerError);
 }
 
+// COPY, DELETE and PROPFIND all validate the Depth token and answer 400 for a value they cannot
+// honour. MOVE reads the header not at all -- measured, every spelling including "banana" answered
+// 201 and did a full recursive relocation. MOVE and COPY share performCOPY:isMove:, and the
+// validation sits inside an `if (!isMove)`, so this is recurring defect shape #2 once more: the
+// rule is present at three of the four verbs it applies to.
+//
+// Deliberately NOT taken here: RFC 4918 section 9.9.2 says a client MUST NOT send any Depth but
+// infinity on a MOVE of a COLLECTION, so a strict server would refuse "0" there too. COPY and
+// DELETE both accept "0" on a plain file for the good reason that it means the same as infinity
+// when there are no internal members, and inventing an asymmetry MOVE alone enforces would refuse
+// requests real clients send. Matching COPY exactly is the fix; the stricter rule is a separate
+// judgement with its own client risk.
+- (void)testMoveValidatesItsDepthHeaderLikeEveryOtherVerb {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* dir = MakeTempDirectory();
+    WSKWebDAVServer* server = [[WSKWebDAVServer alloc] initWithUploadDirectory:dir];
+    NSDictionary* options = @{WSKOption_Port : @0, WSKOption_BindToLocalhost : @YES};  // Hoisted: commas split the macro
+    XCTAssertTrue([server startWithOptions:options error:NULL]);
+
+    // Values MOVE must refuse, because every sibling verb refuses them.
+    for (NSString* bad in @[ @"banana", @"2", @"0,", @"infinite" ]) {
+        XCTAssertTrue([@"x" writeToFile:[dir stringByAppendingPathComponent:@"m.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        NSString* request = [NSString stringWithFormat:@"MOVE /m.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /moved.txt\r\nOverwrite: T\r\nDepth: %@\r\n\r\n", bad];
+        NSString* reply = SendRawRequest(server.port, request);
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 400"], @"MOVE with Depth: %@ must be refused as COPY refuses it: %@", bad, [reply substringToIndex:MIN((NSUInteger)32, reply.length)]);
+        // "Refuse rather than half-succeed": the refusal must also have moved nothing.
+        XCTAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:@"m.txt"]], @"a refused MOVE must leave the source in place (Depth: %@)", bad);
+        XCTAssertFalse([fm fileExistsAtPath:[dir stringByAppendingPathComponent:@"moved.txt"]], @"a refused MOVE must not create the destination (Depth: %@)", bad);
+        [fm removeItemAtPath:[dir stringByAppendingPathComponent:@"m.txt"] error:NULL];
+    }
+
+    // And the spellings that MUST keep working, so the fix cannot be "refuse Depth on MOVE".
+    for (NSString* good in @[ @"infinity", @"0", @"Infinity" ]) {
+        XCTAssertTrue([@"x" writeToFile:[dir stringByAppendingPathComponent:@"k.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+        NSString* request = [NSString stringWithFormat:@"MOVE /k.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /kept.txt\r\nOverwrite: T\r\nDepth: %@\r\n\r\n", good];
+        NSString* reply = SendRawRequest(server.port, request);
+        XCTAssertTrue([reply hasPrefix:@"HTTP/1.1 201"] || [reply hasPrefix:@"HTTP/1.1 204"], @"MOVE with Depth: %@ must still succeed: %@", good, [reply substringToIndex:MIN((NSUInteger)32, reply.length)]);
+        [fm removeItemAtPath:[dir stringByAppendingPathComponent:@"kept.txt"] error:NULL];
+    }
+
+    // No Depth header at all is the ordinary case and means infinity.
+    XCTAssertTrue([@"x" writeToFile:[dir stringByAppendingPathComponent:@"n.txt"] atomically:YES encoding:NSUTF8StringEncoding error:NULL]);
+    NSString* plain = SendRawRequest(server.port, @"MOVE /n.txt HTTP/1.1\r\nHost: localhost\r\nDestination: /plain.txt\r\nOverwrite: T\r\n\r\n");
+    XCTAssertTrue([plain hasPrefix:@"HTTP/1.1 201"] || [plain hasPrefix:@"HTTP/1.1 204"], @"MOVE with no Depth must still succeed: %@", plain);
+
+    [server stop];
+    [fm removeItemAtPath:dir error:NULL];
+}
+
 @end

--- a/Sources/WebServerKit/Core/WSKWebServer.m
+++ b/Sources/WebServerKit/Core/WSKWebServer.m
@@ -1526,6 +1526,20 @@ static inline NSString *_EncodeBase64(NSString *string) {
 - (void)addHandlerForMethod:(NSString *)method path:(NSString *)path requestClass:(Class)aClass asyncProcessBlock:(WSKAsyncProcessBlock)block {
     [self _noteRegisteredMethod:method];
 
+    // The leading slash was an undocumented precondition enforced by WSK_DNOT_REACHED(): abort
+    // with no diagnostic in Debug, register NOTHING in Release. Identical to what
+    // -addGETHandlerForBasePath: was given normalization for, one method away — so leaving it was
+    // a rule closed at one of the two sites it occurs at. A missing slash is a spelling, not an
+    // error; an EMPTY path is genuinely unusable and is refused loudly instead.
+    if (path.length == 0) {
+        WSK_LOG_ERROR(@"Refusing to add a handler for %@: the path is empty", method);
+        return;
+    }
+
+    if (![path hasPrefix:@"/"]) {
+        path = [@"/" stringByAppendingString:path];
+    }
+
     if ([path hasPrefix:@"/"] && [aClass isSubclassOfClass:[WSKRequest class]]) {
         [self
             addHandlerWithMatchBlock:^WSKRequest *(NSString *requestMethod, NSURL *requestURL, NSDictionary<NSString *, NSString *> *requestHeaders, NSString *urlPath, NSDictionary<NSString *, NSString *> *urlQuery) {
@@ -1557,7 +1571,17 @@ static inline NSString *_EncodeBase64(NSString *string) {
 - (void)addHandlerForMethod:(NSString *)method pathRegex:(NSString *)regex requestClass:(Class)aClass asyncProcessBlock:(WSKAsyncProcessBlock)block {
     [self _noteRegisteredMethod:method];
 
-    NSRegularExpression *expression = [NSRegularExpression regularExpressionWithPattern:regex options:NSRegularExpressionCaseInsensitive error:NULL];
+    NSError *regexError = nil;
+    NSRegularExpression *expression = [NSRegularExpression regularExpressionWithPattern:regex options:NSRegularExpressionCaseInsensitive error:&regexError];
+
+    // A pattern that will not compile is the same shape as an unusable path above — a bad string
+    // argument, which may well have come from configuration — so say which pattern and why rather
+    // than aborting with no diagnostic. The error was being discarded, which is the whole of what
+    // a host app needed to fix it.
+    if (expression == nil) {
+        WSK_LOG_ERROR(@"Refusing to add a handler for %@: the path regex \"%@\" is invalid: %@", method, regex, regexError.localizedDescription);
+        return;
+    }
 
     if (expression && [aClass isSubclassOfClass:[WSKRequest class]]) {
         [self

--- a/Sources/WebServerKit/Requests/WSKDataRequest.m
+++ b/Sources/WebServerKit/Requests/WSKDataRequest.m
@@ -115,12 +115,17 @@
 
 - (NSString *)text {
     if (_text == nil) {
-        if ([self.contentType hasPrefix:@"text/"]) {
-            NSString *const charset = WSKExtractHeaderValueParameter(self.contentType, @"charset");
-            _text = [[NSString alloc] initWithData:self.data encoding:WSKStringEncodingFromCharset(charset)];
-        } else {
-            WSK_DNOT_REACHED();
+        // Returns nil rather than asserting. WSK_DNOT_REACHED() is abort() in Debug, so the one
+        // case this property's `nullable` declaration tells a host app to check for was the one
+        // case that killed the process — and a Content-Type is client input, which makes it
+        // remote-triggerable rather than API misuse. Nothing here is unreachable: a bare POST
+        // sends no Content-Type at all.
+        if (![self.contentType hasPrefix:@"text/"]) {
+            return nil;
         }
+
+        NSString *const charset = WSKExtractHeaderValueParameter(self.contentType, @"charset");
+        _text = [[NSString alloc] initWithData:self.data encoding:WSKStringEncodingFromCharset(charset)];
     }
 
     return _text;
@@ -130,11 +135,14 @@
     if (_jsonObject == nil) {
         NSString *const mimeType = WSKTruncateHeaderValue(self.contentType);
 
-        if ([mimeType isEqualToString:@"application/json"] || [mimeType isEqualToString:@"text/json"] || [mimeType isEqualToString:@"text/javascript"]) {
-            _jsonObject = [NSJSONSerialization JSONObjectWithData:_data options:0 error:NULL];
-        } else {
-            WSK_DNOT_REACHED();
+        // Same reasoning as -text above: nil is what the header promises, and the content type
+        // that decides this comes off the wire. -JSONObjectWithData: already returns nil for a
+        // body that is not valid JSON, which is the other half of the documented contract.
+        if (![mimeType isEqualToString:@"application/json"] && ![mimeType isEqualToString:@"text/json"] && ![mimeType isEqualToString:@"text/javascript"]) {
+            return nil;
         }
+
+        _jsonObject = [NSJSONSerialization JSONObjectWithData:_data options:0 error:NULL];
     }
 
     return _jsonObject;

--- a/Sources/WebServerKitDAV/WSKWebDAVServer.m
+++ b/Sources/WebServerKitDAV/WSKWebDAVServer.m
@@ -1031,13 +1031,23 @@ static WSKResponse *_MethodNotAllowed(NSString *format, ...) {
     // a cheap thing to duplicate by accident.
     BOOL shallowCopy = NO;
 
+    // Validated for BOTH verbs. This check used to live inside the `if (!isMove)` below, so MOVE
+    // read the header not at all: every spelling — including "banana" and "0," — answered 201 and
+    // performed a full recursive relocation, while COPY, DELETE and PROPFIND all answered 400 for
+    // the same values. One rule present at three of the four verbs it applies to is this
+    // codebase's signature defect shape.
+    //
+    // Deliberately NOT stricter: RFC 4918 §9.9.2 says a client MUST NOT send any Depth but
+    // infinity on a MOVE of a COLLECTION, so "0" there could be refused too. COPY and DELETE
+    // both accept "0" on a plain file because it means the same as infinity with no internal
+    // members, and an asymmetry only MOVE enforces would refuse requests real clients send.
+    NSString *const depthHeader = request.headers[@"Depth"];
+
+    if (depthHeader && !_HeaderTokenIs(depthHeader, @"infinity") && !_HeaderTokenIs(depthHeader, @"0")) {
+        return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
+    }
+
     if (!isMove) {
-        NSString *const depthHeader = request.headers[@"Depth"];
-
-        if (depthHeader && !_HeaderTokenIs(depthHeader, @"infinity") && !_HeaderTokenIs(depthHeader, @"0")) {
-            return [WSKErrorResponse responseWithClientError:kWSKHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
-        }
-
         shallowCopy = _HeaderTokenIs(depthHeader, @"0");
     }
 


### PR DESCRIPTION
The known-open backlog was re-measured at tip by **driving** each item rather than reading it: nine items, nine skeptics, **none refuted**. Three are fixed here; the other six are restated in `CLAUDE.md`, three of them more precisely than the record had them.

## Fixed

**`addHandlerForMethod:path:` aborted on a missing leading slash** — SIGABRT with no diagnostic in Debug (measured 5/5 entry points, exit 134), and in Release it registered *nothing*, so every request 404'd with no clue why. That is the identical shape `addGETHandlerForBasePath:` was given normalization for **one method away**, which makes leaving it a rule closed at one of the two sites it occurs at. The regex variant also discarded the `NSError` explaining why a pattern wouldn't compile — the one thing a host app needed.

**`WSKDataRequest.text`/`.jsonObject` called `abort()`** for exactly the case their `nullable` headers document as returning nil. More than API honesty: the Content-Type that selects the branch comes **off the wire**, so this was remotely triggerable, not host-app misuse — which is the line the "genuine API-misuse assertions stay abort-in-Debug" decision draws.

**MOVE read no `Depth` header at all.** It shares `performCOPY:isMove:` with COPY and the check sat inside `if (!isMove)`:

```
MOVE  Depth: banana  ->  201 Created   (and the file was moved)
COPY  Depth: banana  ->  400 Bad Request
```

Deliberately *not* made stricter than COPY — RFC 4918 §9.9.2 forbids a non-infinity Depth on a MOVE of a collection, but COPY and DELETE both accept `0` on a plain file because it means the same thing there, and an asymmetry only MOVE enforces would refuse what real clients send.

## Verification

Every test was run against the unfixed tree first. **Two of the three don't produce a red assertion there — they take the runner down with SIGABRT and it reads "Executed 0 tests"**, the documented signature for this class. Each test also pins what must keep working, so no fix can be "always return nil" or "refuse Depth on MOVE".

165 tests, all eight trace suites, clean build, no warnings in `Sources/`.

## Also recorded

The **4-hour pipelining soak** against the fixed tree — 748,020 requests, **312,820 replies served from carried-over bytes**, descriptors +0 at rest, reserved bytes 0, **short bodies 0 against 119 on the pre-fix build**. That closes the debt that #72's reuse had been soaked but never *pipelined*. Not waved away: 32,875 connect failures where the previous soak had zero, cause not established.

And two verification lessons this batch cost:
- **An oracle can be insensitive because its *configuration* closes the window.** The soak's short-body tripwire read 0 against the *pre-fix* framework — at a realistic keep-alive a loopback response finishes before the reaper can fire. Pacing the reads opened the window and it read 119.
- **A stale log file reads exactly like a passing run.** A `pgrep` that matched nothing broke an `&&` chain, `Run-Tests.sh` never ran, and the following `grep` read a log of the same name from four days earlier. The tell was the *count*: 149 where 165 was expected.