### PR TITLE
Fix a failing test related to closing an active connection down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1223,6 +1223,17 @@ alongside the two that must change — the first change made deliberately under 
   fail-on-CI otherwise).
 - **Substring assertions**: `retry: 30000` has `retry: 3000` as a PREFIX — the fourth such
   misfire in two passes. Match the longer marker first or include its terminator.
+- **`-stop` is NOT a barrier for connection teardown** — it waits on `_sourceGroup`, which covers
+  the LISTENING sources' cancel handlers, and never on `_activeConnections`. A test that asserts on
+  anything a connection does as it unwinds (`-close`, the access-log line, a recording being moved)
+  must WAIT for the event, not read state straight after `-stop`. This was learned by writing a
+  test whose comment claimed `-stop` was "a full barrier over every connection queue": it passed
+  6/6 in isolation locally and 3/3 under saturating CPU load, and failed on CI with `closes=0`.
+  Local load does not reproduce it — the race is won or lost on machine, not on load — so the only
+  safe form is a bounded poll for the event. When adding one, check it still discriminates: the
+  defect here made `-close` run once per REQUEST, so the wrong value is already present before
+  `-stop` and a poll returns immediately with it (verified by restoring the old call and watching
+  the test fail 2 != 1).
 - **Two timing tests flake under load** (`testConnectionIdleTimeoutSparesSlowHandler`,
   `testConnectionClosesSlowlorisHeaderDribble` — observed failing at load average 169, 3/3 in
   isolation). Never read a `Run-Tests.sh` verdict while a fleet is building; re-run a failure

--- a/Framework/WSKConnectionTests.m
+++ b/Framework/WSKConnectionTests.m
@@ -849,10 +849,37 @@
     NSArray<NSString*>* replies = SendRawRequestsOnOneConnection(server.port, @[ @"GET /ok HTTP/1.1\r\nHost: localhost\r\n\r\nGET /ok HTTP/1.1\r\nHost: localhost\r\n\r\n", @"" ]);
     XCTAssertEqual(replies.count, (NSUInteger)2, @"both requests must be answered before the pairing is judged");
 
-    [server stop];  // A full barrier over every connection queue, so the events are complete and stable.
+    [server stop];
 
-    NSArray<NSString*>* events = [gConnectionEvents copy];
-    XCTAssertEqual([events componentsJoinedByString:@" "].length > 0, YES);
+    // -stop is NOT a barrier for connection teardown: it waits on _sourceGroup, which covers the
+    // LISTENING sources' cancel handlers, and never on _activeConnections. -close now runs from
+    // -dealloc for the last request on a connection, so its timing is tied to when the last block
+    // holding the connection unwinds, not to -stop. Asserting straight after it passed on this
+    // machine 6/6 in isolation and under CPU load, and failed on CI with closes=0 — the race, won
+    // locally and lost there. Wait for the event instead of assuming the ordering.
+    //
+    // This cannot mask the defect it is guarding: the unfixed code calls -close once per REQUEST,
+    // so `closes` reaches 2 before -stop is even called and the poll returns immediately with the
+    // wrong value still in hand.
+    NSDate* const deadline = [NSDate dateWithTimeIntervalSinceNow:10.0];
+
+    while ([deadline timeIntervalSinceNow] > 0) {
+        @synchronized(gConnectionEvents) {
+            if ([gConnectionEvents containsObject:@"close"]) {
+                break;
+            }
+        }
+
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+
+    NSArray<NSString*>* events = nil;
+
+    @synchronized(gConnectionEvents) {
+        events = [gConnectionEvents copy];
+    }
+
+    XCTAssertTrue([events containsObject:@"close"], @"the connection never closed within 10 s: %@", events);
     NSUInteger opens = 0, closes = 0, aborts = 0;
 
     for (NSString* event in events) {


### PR DESCRIPTION
`[server stop]` is not a hard stop since it needs to wait for ongoing connections to unwind.

This PR adds a basic timer to the test that was assuming that, so it can test once the connections have finished up.